### PR TITLE
feat: add initial setup of syncroot for at22 and tt02 for umbraco

### DIFF
--- a/.github/workflows/publish-syncroot-main.yaml
+++ b/.github/workflows/publish-syncroot-main.yaml
@@ -1,0 +1,37 @@
+name: Publish Syncroot artifacts
+
+on:
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+
+env:
+  SYNCROOT_ARTIFACT_NAME: infoportal/syncroot
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-flux-artifacts-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-syncroot:
+    name: Publish syncroot artifact
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Build and push syncroot artifact
+        uses: Altinn/altinn-platform/actions/flux/build-push-image@8d4e42eae11efbc3a159aa62fe15ed49954d9df9 # main
+        with:
+          image_name: ${{ env.SYNCROOT_ARTIFACT_NAME }}
+          tag: at22
+          workdir: ./syncroot
+          azure_subscription_id: ${{ secrets.DIS_SYNCROOT_AZURE_SUBSCRIPTION_ID }}
+          azure_app_id: ${{ secrets.DIS_SYNCROOT_AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.DIS_SYNCROOT_AZURE_TENANT_ID }}

--- a/syncroot/README.md
+++ b/syncroot/README.md
@@ -1,0 +1,63 @@
+# Info Portalen (Umbraco) Infrastructure
+
+This directory contains the Kubernetes manifests for the Umbraco CMS implementation of the Info Portalen project.
+
+## TODO
+There are still things that needs to be done before this can be deployed.
+In `syncroot/at22/kustomization.yaml` the team need to define the image name (container registry + repository) and a valid image tag. The current setup is just a dumme value that will not work.
+
+There are still some questions regarding storage and backup. This setup should get you going once you have a public available docker image of umbraco that can be deployed.
+
+I have disbaled the push trigger for the pipeline so it shouldn't publish an deployment before the docker image todos are done.
+
+## Folder Structure
+
+- **base/**: Contains the base Kubernetes resources for the Umbraco stack.
+  - **umbraco/**:
+    - `deployment.yaml`: Defines the Umbraco pod with single replica and `Recreate` strategy.
+    - `service.yaml`: ClusterIP service for internal routing.
+    - `httproute.yaml`: Gateway API routing for external access.
+    - `storage.yaml`: Persistent Volume Claims for data and media.
+    - `serviceaccount.yaml`: Dedicated service account for the Umbraco pod.
+    - `kustomization.yaml`: Orchestrates the resources and applies common labels.
+- **at22/**: Kustomize overlay for the AT22 environment.
+  - `kustomization.yaml`: Applies environment-specific patches (e.g., hostnames, image tags).
+- **tt02/**: Kustomize overlay for the TT02 environment.
+- **prod/**: Kustomize overlay for the Production environment.
+
+## Resources Created
+
+### Deployment
+- **Name**: `umbraco`
+- **Namespace**: `product-infoportal` (inherited from base kustomization)
+- **Replicas**: 1
+- **Strategy**: `Recreate` (required for RWO storage)
+- **Port**: 8080 (named `http`)
+
+### Storage (PVCs)
+1. **umbraco-data**: 
+   - **Size**: 10Gi
+   - **StorageClass**: `managed-csi-premium` (Azure Disk)
+   - **Mount Path**: `/app/umbraco/Data`
+   - **Access Mode**: `ReadWriteOnce`
+2. **umbraco-media**:
+   - **Size**: 50Gi
+   - **StorageClass**: `azurefile-csi-premium` (Azure Files)
+   - **Mount Path**: `/app/umbraco/wwwroot/media`
+   - **Access Mode**: `ReadWriteMany`
+3. **Logs**:
+   - **Type**: `emptyDir`
+   - **Mount Path**: `/app/umbraco/Logs`
+
+### Networking
+- **Service**: ClusterIP on port 80 (targets container port 8080).
+- **HTTPRoute**: Routes traffic via `traefik-gateway` in the `traefik` namespace.
+  - **AT22 Hostname**: `infoportal.at22.dis-core.altinn.cloud`
+
+### Identity
+- **ServiceAccount**: `umbraco` (no additional permissions assigned).
+
+## Labels
+Resources are consistently labeled using Kustomize `commonLabels`:
+- `app.kubernetes.io/name: umbraco`
+- `app.kubernetes.io/part-of: infoportal`

--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+images:
+- name: umbraco
+  newName: my-registry/umbraco
+  newTag: v0.0.1
+
+patches:
+  - target:
+      kind: HTTPRoute
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/hostnames
+        value:
+          - infoportal.at22.dis-core.altinn.cloud

--- a/syncroot/base/kustomization.yaml
+++ b/syncroot/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: product-infoportal
+resources:
+  - umbraco

--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: umbraco
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: umbraco
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: umbraco
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        linkerd.io/inject: enabled
+    spec:
+      serviceAccountName: umbraco
+      containers:
+        - name: umbraco
+          image: umbraco:1
+          resources:
+            requests:
+              cpu: "1"
+              memory: 2Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: umbraco-data
+              mountPath: /app/umbraco/Data
+            - name: umbraco-media
+              mountPath: /app/umbraco/wwwroot/media
+            - name: umbraco-logs
+              mountPath: /app/umbraco/Logs
+      volumes:
+        - name: umbraco-data
+          persistentVolumeClaim:
+            claimName: umbraco-data
+        - name: umbraco-media
+          persistentVolumeClaim:
+            claimName: umbraco-media
+        - name: umbraco-logs
+          emptyDir: {}

--- a/syncroot/base/umbraco/httproute.yaml
+++ b/syncroot/base/umbraco/httproute.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: umbraco
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: traefik
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: umbraco
+          port: 80

--- a/syncroot/base/umbraco/kustomization.yaml
+++ b/syncroot/base/umbraco/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/part-of: infoportal
+  app.kubernetes.io/name: umbraco
+
+resources:
+  - storage.yaml
+  - serviceaccount.yaml
+  - deployment.yaml
+  - service.yaml
+  - httproute.yaml

--- a/syncroot/base/umbraco/service.yaml
+++ b/syncroot/base/umbraco/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: umbraco
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: umbraco
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/syncroot/base/umbraco/serviceaccount.yaml
+++ b/syncroot/base/umbraco/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: umbraco

--- a/syncroot/base/umbraco/storage.yaml
+++ b/syncroot/base/umbraco/storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: umbraco-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: managed-csi-premium
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: umbraco-media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: azurefile-csi-premium
+  resources:
+    requests:
+      storage: 50Gi

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+images:
+- name: umbraco
+  newName: my-registry/umbraco
+  newTag: v0.0.1
+
+patches:
+  - target:
+      kind: HTTPRoute
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/hostnames
+        value:
+          - infoportal.tt02.dis-core.altinn.cloud


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is just a suggestion from me to get you going in at22.
Please read the README.md to get a basic overview og the setup

## TODO
There are still things that needs to be done before this can be deployed.
In `syncroot/at22/kustomization.yaml` the team need to define the image name (container registry + repository) and a valid image tag. The current setup is just a dumme value that will not work.

There are still some questions regarding storage and backup. This setup should get you going once you have a public available docker image of umbraco that can be deployed.

I have disbaled the push trigger for the pipeline so it shouldn't publish an deployment before the docker image todos are done.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
