### PR TITLE
chore: suggestion of a syncroot workflow that replaces the at22 image tag

### DIFF
--- a/.github/workflows/publish-syncroot-main.yaml
+++ b/.github/workflows/publish-syncroot-main.yaml
@@ -1,7 +1,12 @@
 name: Publish Syncroot artifacts
+run-name: Deploy ${{ inputs.image-tag }}
 
 on:
   workflow_dispatch:
+    inputs:
+      image-tag:
+        description: 'Umbraco image tag to deploy'
+        required: true
   # push:
   #   branches:
   #     - main
@@ -25,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Update image tag
+        run: yq -i '(.images[] | select(.name == "umbraco")).newTag = "${{ inputs.image-tag }}"' ./syncroot/at22/kustomization.yaml
 
       - name: Build and push syncroot artifact
         uses: Altinn/altinn-platform/actions/flux/build-push-image@8d4e42eae11efbc3a159aa62fe15ed49954d9df9 # main


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This will not persist the deployed version in any way, just replace the value before building and pushing the OCI image.

<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
