### PR TITLE
feat:Added uSync package and exported Settings

### DIFF
--- a/umbraco-infoportal/uSync/v17/ContentTypes/accordiancollectionblock.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/accordiancollectionblock.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="dcdb4fd8-8ec8-4e4f-a6af-e1bd2a7e66bf" Alias="accordianCollectionBlock" Level="2">
+  <Info>
+    <Name>Nedtrekkssamler</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>7e4388b2-8563-44b6-933f-823a2846c8b5</Key>
+      <Name>Nedtrekksmeny område</Name>
+      <Alias>accordianArea</Alias>
+      <Definition>8448291d-db3e-4252-83ba-2ed84876fbbe</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>84ea2e90-788d-4696-ae98-ede14b3babfc</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/accordiancollectionblockelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/accordiancollectionblockelement.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="c15dde67-b3d2-4a9d-bc14-91672e45709f" Alias="accordianCollectionBlockElement" Level="2">
+  <Info>
+    <Name>Nedtrekkssamler</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>4700310c-528c-4b82-b7ef-12231b4827cd</Key>
+      <Name>Nedtrekkssamler</Name>
+      <Alias>accordianCollectionBlockPicker</Alias>
+      <Definition>52dddfca-df5c-4bd1-b06f-cb89b44ec432</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>01100edb-5e3f-4af3-a439-1a971557b5db</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/blokk.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/blokk.config
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="fcdf53f6-dc55-4fae-b1bb-e66ca2d2bc2b" Alias="blokk" Level="1">
+  <Info>
+    <Name>Blokk</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>3b5041f2-c938-4bca-9414-b5b080919eb3</Key>
+      <Name>Innholdsblokk</Name>
+      <Alias>innholdsblokk</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>490f258e-d716-4f18-a40f-acdc630dcb30</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/contentblock.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/contentblock.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="5a3b4404-0fcc-42a0-b328-ebd32bc194f8" Alias="contentBlock" Level="2">
+  <Info>
+    <Name>Innholdsblokk</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>068c5b17-3a9b-470a-b572-4bd36ddde187</Key>
+      <Name>Innhold</Name>
+      <Alias>content</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>b705b9e5-b430-480a-8381-9914d5967670</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/contentblockelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/contentblockelement.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="3a5ac8e8-4001-4988-908c-91c91fc3beef" Alias="contentBlockElement" Level="2">
+  <Info>
+    <Name>Innholdsblokk</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>ad814ffb-5d2f-4c40-a31e-f6cd3a59dcf3</Key>
+      <Name>Innholdsblokk</Name>
+      <Alias>contentBlockPicker</Alias>
+      <Definition>a92db0f3-e77a-4fd2-9db0-81f68ad2a442</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>f8ddefed-7240-4ce6-9f6b-be24947451bf</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/enkelblokk.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/enkelblokk.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="992992d4-53b1-41d9-bc02-2113caabd278" Alias="enkelBlokk" Level="1">
+  <Info>
+    <Name>Enkel blokk</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties />
+  <Tabs />
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/innholdsmappe.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/innholdsmappe.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="80e81cc0-9025-4404-a20c-3fecc8386641" Alias="innholdsmappe" Change="Rename" />

--- a/umbraco-infoportal/uSync/v17/ContentTypes/linkblock.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/linkblock.config
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="3cba3fce-5d3e-4fe1-abb0-21f3cd107d7c" Alias="linkBlock" Level="2">
+  <Info>
+    <Name>Lenke</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>15e79798-37ce-4f2e-91a9-e9abf20a9ebe</Key>
+      <Name>Overskrift (bare synlig på halv bredde)</Name>
+      <Alias>extraTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>dfddfa7e-b57c-4d16-81ba-8b5ed921589e</Key>
+      <Name>Full bredde?</Name>
+      <Alias>fullWidth</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>00359c6e-1a5f-4a15-a121-c37b7ce81b3a</Key>
+      <Name>Lenkeikon</Name>
+      <Alias>icon</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>477eebda-23d5-48a5-a73a-d02444aa9996</Key>
+      <Name>Lenke</Name>
+      <Alias>urlBlock</Alias>
+      <Definition>7ee13de3-166d-47e5-a73f-edc2cec6510d</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>f36df765-88a2-44ad-b180-54a359f3edf3</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/linkblockelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/linkblockelement.config
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="fa44c41d-6612-443a-bcc6-8e5e73f3501d" Alias="linkBlockElement" Level="2">
+  <Info>
+    <Name>Lenke</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>c60424dc-a263-47e5-98bc-86445b6a8f74</Key>
+      <Name>Lenke</Name>
+      <Alias>linkBlockPicker</Alias>
+      <Definition>c7c9029f-f742-4203-81b3-fa03ee3e0074</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab></Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs />
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/nedtrekkselement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/nedtrekkselement.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="52c06f64-dc96-4dff-a1ca-c04985e466eb" Alias="nedtrekkselement" Change="Rename" />

--- a/umbraco-infoportal/uSync/v17/ContentTypes/newsarchive.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/newsarchive.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="150fcacd-d1e7-41c1-aa84-175adc0556a4" Alias="newsArchive" Change="Rename" />

--- a/umbraco-infoportal/uSync/v17/ContentTypes/newsarchivepage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/newsarchivepage.config
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="150fcacd-d1e7-41c1-aa84-175adc0556a4" Alias="newsArchivePage" Level="1">
+  <Info>
+    <Name>Nyhetarkiv</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate>Nyhetarkiv</DefaultTemplate>
+    <AllowedTemplates>
+      <Template Key="019d0a11-b3b6-7c6b-84be-3f71cf711b2d">Nyhetarkiv</Template>
+    </AllowedTemplates>
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>2bf3204d-944e-430b-acad-d35f820230c6</Key>
+      <Name>Blokkområde bunn</Name>
+      <Alias>bottomContentArea</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>abaa862c-5e46-478c-96fa-f16e7c403271</Key>
+      <Name>Canonical Url</Name>
+      <Alias>canonicalUrl</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8025264f-73f4-4ba6-856e-c3aa8ce15a21</Key>
+      <Name>SEO beskrivelse</Name>
+      <Alias>metaDescription</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>5eae4a43-9e2d-4f3e-815e-dd871b08435c</Key>
+      <Name>SEO nøkkelord</Name>
+      <Alias>metaKeywords</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6976035b-d623-4509-bce9-8fbb3ce227d6</Key>
+      <Name>Meta tittel</Name>
+      <Alias>metaTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>dd797f9b-c2d4-4b89-9373-fc9f05ba81f4</Key>
+      <Name>Vis i navigasjon</Name>
+      <Alias>showInNavigation</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4aac45ab-1a3a-4290-896d-b94d309d5925</Key>
+      <Name>Navn i URL-adresse</Name>
+      <Alias>umbracoUrlName</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>3d0d2e16-e44a-4571-b6c6-1daaf5c41373</Key>
+      <Caption>Navigasjon</Caption>
+      <Alias>navigasjon</Alias>
+      <Type>Tab</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>3e43ff64-fcec-4bfc-a4f4-23719f9b6401</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Tab</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>9946c848-5ff1-45f8-a752-cf674f601f3d</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/newsarticlepage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/newsarticlepage.config
@@ -1,0 +1,193 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="8d4a53fe-1b5f-4df5-94ce-06ff534de43f" Alias="newsArticlePage" Level="1">
+  <Info>
+    <Name>Nyhetsartikkelside</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate>Nyhetsartikkelside</DefaultTemplate>
+    <AllowedTemplates>
+      <Template Key="019d0a0a-abc3-7733-a24d-9a6c700e3994">Nyhetsartikkelside</Template>
+    </AllowedTemplates>
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>bfdbaf64-698e-45a5-810a-40d4c3db753c</Key>
+      <Name>Blokkområde bunn</Name>
+      <Alias>bottomContentArea</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>901883a6-b979-4cc0-9ad3-02a834b9b1de</Key>
+      <Name>Canonical Url</Name>
+      <Alias>canonicalUrl</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0f9b5d1f-fa03-4028-9d0e-c8b149dcc680</Key>
+      <Name>Brødtekst</Name>
+      <Alias>mainBody</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b6f4acce-1b83-4b8e-8bfe-5df7793bab29</Key>
+      <Name>Ingress</Name>
+      <Alias>mainIntro</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a354b04a-343a-4a4b-be7a-bf86ad1e424e</Key>
+      <Name>SEO beskrivelse</Name>
+      <Alias>metaDescription</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>25aab75f-7e43-4502-966e-dafe642abaf4</Key>
+      <Name>SEO nøkkelord</Name>
+      <Alias>metaKeywords</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3edbcf97-c8b1-42aa-8ad7-0cfea3324f8e</Key>
+      <Name>Meta tittel</Name>
+      <Alias>metaTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0c9c0bcd-bc5e-4bbf-b33d-83136a2a1599</Key>
+      <Name>Vis i navigasjon</Name>
+      <Alias>showInNavigation</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6c3f023c-691f-420b-aa81-fbc3d20ff00a</Key>
+      <Name>Navn i URL-adresse</Name>
+      <Alias>umbracoUrlName</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>189dd955-a999-47db-84db-59dc9e09968f</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>62e40dbe-3eea-469b-8a6c-3a8c42a80ae9</Key>
+      <Caption>Navigasjon</Caption>
+      <Alias>navigasjon</Alias>
+      <Type>Tab</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>634f496e-00b0-4547-ad19-0e9bd6b251b0</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Tab</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/schemaaccordianblock.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/schemaaccordianblock.config
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="e9073262-787c-4a36-9dec-17595ad9528d" Alias="schemaAccordianBlock" Level="2">
+  <Info>
+    <Name>Nedtrekkselement</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>a03cd52e-2846-428c-8ceb-3a792665f829</Key>
+      <Name>Innhold</Name>
+      <Alias>description</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>780b0300-524c-414a-b119-aca3a8a309df</Key>
+      <Name>Overskrift</Name>
+      <Alias>heading</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a8b26471-eda9-410d-ab63-e7e0df5923d7</Key>
+      <Name>TranslatedHeading</Name>
+      <Alias>translatedHeading</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>6f5e885f-b0e4-48c1-a614-1e8c4db04706</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/schemaaccordianblockelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/schemaaccordianblockelement.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="52c06f64-dc96-4dff-a1ca-c04985e466eb" Alias="schemaAccordianBlockElement" Level="2">
+  <Info>
+    <Name>Nedtrekkselement</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>2eb6d1f7-9fa7-417e-8c27-fe51d018504f</Key>
+      <Name>Nedtrekkselement</Name>
+      <Alias>schemaAccordianBlockPicker</Alias>
+      <Definition>1890c776-2cfc-42e6-b4b8-3f8a69474136</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>cd43536a-1d82-4d81-b4db-87f5b7de7ebe</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/sectionarticlepage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/sectionarticlepage.config
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="de044169-a8ca-474b-869b-65de088321e6" Alias="sectionArticlePage" Level="1">
+  <Info>
+    <Name>Starte og drive - Artikkel</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="de044169-a8ca-474b-869b-65de088321e6" SortOrder="0">sectionArticlePage</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>189d0a7b-1b3b-45a6-810d-0ccb2fe0382b</Key>
+      <Name>Brødtekst</Name>
+      <Alias>mainBody</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>08cd50f6-4c7c-4c84-bbf3-e385d464fee7</Key>
+      <Name>Ingress</Name>
+      <Alias>mainIntro</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8b2c942d-66d6-4fe6-9d37-e137b321ac2c</Key>
+      <Name>SEO beskrivelse</Name>
+      <Alias>metaDescription</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1edcb101-ed4b-40f6-8b20-a118e7360355</Key>
+      <Name>SEO nøkkelord</Name>
+      <Alias>metaKeywords</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f619573b-b26d-400d-9cc3-0163861c8599</Key>
+      <Name>Meta tittel</Name>
+      <Alias>metaTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>8e85b2fe-837f-4fe8-afcf-c08857e9b4c9</Key>
+      <Name>Vis i navigasjon</Name>
+      <Alias>showInNavigation</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>25437cb5-f578-4e4a-92bb-1d15e4def183</Key>
+      <Name>Navn i URL-adresse</Name>
+      <Alias>umbracoUrlName</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>29fa8aac-9fbf-46d0-8684-a91c3d67134b</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Tab</Type>
+      <SortOrder>3</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>57c94c28-fce7-4511-907c-f4829a54dabb</Key>
+      <Caption>Navigasjon</Caption>
+      <Alias>navigasjon</Alias>
+      <Type>Tab</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>b0764d6c-e6bf-436c-9097-c953cfdfe5f3</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/sectionpage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/sectionpage.config
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="d642858a-87d9-4844-8eb2-ebdc73563b0e" Alias="sectionPage" Level="1">
+  <Info>
+    <Name>Starte og drive - Forside</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="76a1be25-ff7c-48d1-8b77-be2415ab9744" SortOrder="0">themeContainerPage</ContentType>
+    <ContentType Key="49108713-618e-4c5f-826b-a9dfbe92f0ca" SortOrder="1">themePage</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>63adce2d-c171-42e6-a335-911df3470253</Key>
+      <Name>Link til temaside</Name>
+      <Alias>goToLinkLocation</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a0956026-d096-46fa-8d10-8355f7bef46b</Key>
+      <Name>Linktekst til temaside</Name>
+      <Alias>goToLinkText</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>9ca46ea5-4dae-4e3a-a789-7df671db7c51</Key>
+      <Name>Overskrift</Name>
+      <Alias>heading</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a4e11b47-3500-4b5f-a4ff-b1c92cb594c9</Key>
+      <Name>Vis i navigasjon</Name>
+      <Alias>showInNavigation</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>6028c81e-bcf5-436d-8816-a9a4d977a0e2</Key>
+      <Name>Fremhevede tema</Name>
+      <Alias>themePageArea</Alias>
+      <Definition>022841b2-41b0-41bf-a74f-f318ec3eb390</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>28999fba-c4f5-4a58-b4f2-c8e32e48a5da</Key>
+      <Name>Navn i URL-adresse</Name>
+      <Alias>umbracoUrlName</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>04c441fc-5914-4945-8f23-6d6c79f848ba</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>7fbda6c4-f6e4-43ed-a682-c51b0c425190</Key>
+      <Caption>Navigasjon</Caption>
+      <Alias>navigasjon</Alias>
+      <Type>Tab</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/startpage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/startpage.config
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="d4bf360e-8730-46ea-9758-5fc4a48990dd" Alias="startPage" Level="1">
+  <Info>
+    <Name>Forside</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="d642858a-87d9-4844-8eb2-ebdc73563b0e" SortOrder="0">sectionPage</ContentType>
+  </Structure>
+  <GenericProperties />
+  <Tabs />
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/syscontentassetfolder.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/syscontentassetfolder.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="140cc88a-abc7-44bc-8263-d6059eb866a0" Alias="sysContentAssetFolder" Level="1">
+  <Info>
+    <Name>Innholdsressursmappe</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties />
+  <Tabs />
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/syscontentfolder.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/syscontentfolder.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="80e81cc0-9025-4404-a20c-3fecc8386641" Alias="sysContentFolder" Level="1">
+  <Info>
+    <Name>Innholdsmappe</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties />
+  <Tabs />
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/tableblock.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/tableblock.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="6cf9203e-fdee-48de-9657-da2ee1512898" Alias="tableBlock" Level="2">
+  <Info>
+    <Name>Tabellblokk</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>961a7487-c12e-4349-91d4-23404708a158</Key>
+      <Name>Tabell</Name>
+      <Alias>table</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>3c2ad649-a1ef-42bd-a8e5-b31756f2f534</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/tableblockelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/tableblockelement.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="88a091bc-d6c2-4341-84aa-ab3c079905fb" Alias="tableBlockElement" Level="2">
+  <Info>
+    <Name>Tabellblokk</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>57ebc873-909d-4db3-bc23-d55f325f9880</Key>
+      <Name>Tabellblokk</Name>
+      <Alias>tableBlockPicker</Alias>
+      <Definition>a7ee6523-d4ef-42ca-8fc2-25227ebdfb07</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>065f754b-5924-4d2f-9b5c-f26b899faec7</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/themecontainerpage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/themecontainerpage.config
@@ -1,0 +1,136 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="76a1be25-ff7c-48d1-8b77-be2415ab9744" Alias="themeContainerPage" Level="1">
+  <Info>
+    <Name>Starte og drive - Temamappe</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>8235fec8-3912-473e-bd52-982197a84801</Key>
+      <Name>Canonical URL</Name>
+      <Alias>canonicalUrl</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1d4b9098-88af-4eeb-8849-60ab819addb0</Key>
+      <Name>SEO beskrivelse</Name>
+      <Alias>metaDescription</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c6dcdf2b-339d-425e-86d5-5a6c56058abb</Key>
+      <Name>SEO nøkkelord</Name>
+      <Alias>metaKeywords</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>da12b389-36e9-4c0e-9477-331392ff7ce1</Key>
+      <Name>Meta tittel</Name>
+      <Alias>metaTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1708cc8f-ed8c-4f15-8edf-b8bbce9feb0c</Key>
+      <Name>Vis i navigasjon</Name>
+      <Alias>showInNavigation</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>30cbccfb-ea18-4eee-8486-6676899fc278</Key>
+      <Name>Navn i URL-adresse</Name>
+      <Alias>umbracoUrlName</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>1d4be2dd-b046-4a2e-8e70-ca10369667c9</Key>
+      <Caption>Navigasjon</Caption>
+      <Alias>navigasjon</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>23b14874-8443-4cba-a248-4c3f246d0a8c</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Tab</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/themepage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/themepage.config
@@ -1,0 +1,178 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="49108713-618e-4c5f-826b-a9dfbe92f0ca" Alias="themePage" Level="1">
+  <Info>
+    <Name>Starte og drive - Temaside</Name>
+    <Icon>icon-document-html</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure>
+    <ContentType Key="de044169-a8ca-474b-869b-65de088321e6" SortOrder="0">sectionArticlePage</ContentType>
+    <ContentType Key="76a1be25-ff7c-48d1-8b77-be2415ab9744" SortOrder="1">themeContainerPage</ContentType>
+  </Structure>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>e15b5d4a-7ce5-4aa1-82f6-27d72881c9a4</Key>
+      <Name>Faglig brukerstøtte</Name>
+      <Alias>bottomContentArea</Alias>
+      <Definition>fd1e0da5-5606-4862-b679-5d0cf3a52a59</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a9c6bc92-2d83-4ef1-9bf3-2da60822bd12</Key>
+      <Name>Canonical URL</Name>
+      <Alias>canonicalUrl</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e33f10a6-5735-488c-8c65-fbd8d35217b0</Key>
+      <Name>Ingress</Name>
+      <Alias>mainIntro</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7c5cc0e0-6273-440d-a64d-1c772a05e93b</Key>
+      <Name>SEO beskrivelse</Name>
+      <Alias>metaDescription</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>62119e06-c96e-4492-a5e1-2fcf903fca70</Key>
+      <Name>SEO nøkkelord</Name>
+      <Alias>metaKeywords</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7909dff3-f904-40a8-a4a3-83d2477130e9</Key>
+      <Name>Meta tittel</Name>
+      <Alias>metaTitle</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="sEO">SEO</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>df889f0a-c27a-421c-9cfa-0de5710b6b10</Key>
+      <Name>Vis i navigasjon</Name>
+      <Alias>showInNavigation</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>5</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>7fd85ce1-c191-465a-9888-4f2940c48104</Key>
+      <Name>Navn i URL-adresse</Name>
+      <Alias>umbracoUrlName</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="navigasjon">Navigasjon</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>20369d8b-35dc-464f-8f6a-678b81d18dec</Key>
+      <Caption>SEO</Caption>
+      <Alias>sEO</Alias>
+      <Type>Tab</Type>
+      <SortOrder>2</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>7bd9d6ba-2faa-4652-99d6-4e4e44f8b919</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+    <Tab>
+      <Key>b2081ea8-bed5-4175-8772-a993495c1108</Key>
+      <Caption>Navigasjon</Caption>
+      <Alias>navigasjon</Alias>
+      <Type>Tab</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/urlblock.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/urlblock.config
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="37ff0190-0c59-42a8-a955-f63d7066c41a" Alias="urlBlock" Level="2">
+  <Info>
+    <Name>URL</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>81679024-a2f4-455c-ad5d-fdf4954e63e4</Key>
+      <Name>Lenketekst</Name>
+      <Alias>linkText</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ebfb84c5-d492-4dfd-812d-52f8d5808b37</Key>
+      <Name>Åpne i nytt vindu</Name>
+      <Alias>openInNewWindow</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>56c129b8-2f04-42ac-a0c8-a2994915c641</Key>
+      <Name>Lenke (URL)</Name>
+      <Alias>url</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>903003fa-c4db-48e2-9522-fd78af691e55</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/urlblockelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/urlblockelement.config
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="fcac3fa4-9137-437d-9039-06365a88e2f9" Alias="urlBlockElement" Level="2">
+  <Info>
+    <Name>URL</Name>
+    <Icon>icon-plugin</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>true</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Folder>Blokktyper</Folder>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>d5e75cfe-f885-4cf1-a50f-3ee6f10c2c2e</Key>
+      <Name>URL</Name>
+      <Alias>urlBlockPicker</Alias>
+      <Definition>19102e9c-c395-498c-9f2b-495d74101234</Definition>
+      <Type>Umbraco.MultiNodeTreePicker</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>8750a9fc-5dbc-483f-8f0b-6386a0138863</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Tab</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/ContentTypes/urlelement.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/urlelement.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="fcac3fa4-9137-437d-9039-06365a88e2f9" Alias="urlElement" Change="Rename" />

--- a/umbraco-infoportal/uSync/v17/DataTypes/ApprovedColor.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/ApprovedColor.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0225af17-b302-49cb-9176-b9f35cab9c17" Alias="Approved Color" Level="1">
+  <Info>
+    <Name>Approved Color</Name>
+    <EditorAlias>Umbraco.ColorPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ColorPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/CheckboxList.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/CheckboxList.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="fbaf13a8-4036-41f2-93a3-974f678c312a" Alias="Checkbox list" Level="1">
+  <Info>
+    <Name>Checkbox list</Name>
+    <EditorAlias>Umbraco.CheckBoxList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.CheckBoxList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/ContentPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/ContentPicker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="fd1e0da5-5606-4862-b679-5d0cf3a52a59" Alias="Content Picker" Level="1">
+  <Info>
+    <Name>Content Picker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "3cba3fce-5d3e-4fe1-abb0-21f3cd107d7c",
+  "maxNumber": 10,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/DatePicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/DatePicker.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="5046194e-4237-453c-a547-15db3a07c4e1" Alias="Date Picker" Level="1">
+  <Info>
+    <Name>Date Picker</Name>
+    <EditorAlias>Umbraco.DateTime</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DatePicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "format": "YYYY-MM-DD"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/DatePickerWithTime.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/DatePickerWithTime.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="e4d66c0f-b935-4200-81f0-025f7256b89a" Alias="Date Picker with time" Level="1">
+  <Info>
+    <Name>Date Picker with time</Name>
+    <EditorAlias>Umbraco.DateTime</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DatePicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "format": "YYYY-MM-DD HH:mm:ss"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/DateTimePickerWithTimeZone.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/DateTimePickerWithTimeZone.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="88e8a052-30ee-4d44-a507-59f2cdfc769c" Alias="Date Time Picker (with time zone)" Level="1">
+  <Info>
+    <Name>Date Time Picker (with time zone)</Name>
+    <EditorAlias>Umbraco.DateTimeWithTimeZone</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.DateTimeWithTimeZonePicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "timeFormat": "HH:mm",
+  "timeZones": {
+    "mode": "all"
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Dropdown.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Dropdown.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0b6a45e7-44ba-430d-9da5-4e46060b9e03" Alias="Dropdown" Level="1">
+  <Info>
+    <Name>Dropdown</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": false
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/DropdownMultiple.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/DropdownMultiple.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="f38f0ac7-1d27-439c-9f3f-089cd8825a53" Alias="Dropdown multiple" Level="1">
+  <Info>
+    <Name>Dropdown multiple</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": true
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/ImageCropper.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/ImageCropper.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1df9f033-e6d4-451f-b8d2-e0cbc50a836f" Alias="Image Cropper" Level="1">
+  <Info>
+    <Name>Image Cropper</Name>
+    <EditorAlias>Umbraco.ImageCropper</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ImageCropper</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/ImageMediaPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/ImageMediaPicker.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ad9f0cf2-bda2-45d5-9ea1-a63cfc873fd3" Alias="Image Media Picker" Level="1">
+  <Info>
+    <Name>Image Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "cc07b313-0843-4aa8-bbda-871c8da728c8",
+  "multiple": false,
+  "validationLimit": {
+    "min": 0,
+    "max": 1
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/InnholdsblokkPlukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/InnholdsblokkPlukker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="a92db0f3-e77a-4fd2-9db0-81f68ad2a442" Alias="Innholdsblokk-plukker" Level="1">
+  <Info>
+    <Name>Innholdsblokk-plukker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "5a3b4404-0fcc-42a0-b328-ebd32bc194f8",
+  "maxNumber": 1,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelBigint.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelBigint.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="930861bf-e262-4ead-a704-f99453565708" Alias="Label (bigint)" Level="1">
+  <Info>
+    <Name>Label (bigint)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "BIGINT"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelBytes.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelBytes.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f" Alias="Label (bytes)" Level="1">
+  <Info>
+    <Name>Label (bytes)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "labelTemplate": "{=value | bytes}",
+  "umbracoDataValueType": "BIGINT"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelDatetime.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelDatetime.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0e9794eb-f9b5-4f20-a788-93acd233a7e4" Alias="Label (datetime)" Level="1">
+  <Info>
+    <Name>Label (datetime)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "DATETIME"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelDecimal.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelDecimal.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8f1ef1e1-9de4-40d3-a072-6673f631ca64" Alias="Label (decimal)" Level="1">
+  <Info>
+    <Name>Label (decimal)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "DECIMAL"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelInteger.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelInteger.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8e7f995c-bd81-4627-9932-c40e568ec788" Alias="Label (integer)" Level="1">
+  <Info>
+    <Name>Label (integer)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "INT"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelPixels.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelPixels.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="5eb57825-e15e-4fc7-8e37-fca65cdafbde" Alias="Label (pixels)" Level="1">
+  <Info>
+    <Name>Label (pixels)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "labelTemplate": "{=value}px",
+  "umbracoDataValueType": "INT"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelString.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelString.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="f0bc4bfb-b499-40d6-ba86-058885a5178c" Alias="Label (string)" Level="1">
+  <Info>
+    <Name>Label (string)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "STRING"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LabelTime.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LabelTime.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="a97cec69-9b71-4c30-8b12-ec398860d7e8" Alias="Label (time)" Level="1">
+  <Info>
+    <Name>Label (time)</Name>
+    <EditorAlias>Umbraco.Label</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Label</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "umbracoDataValueType": "TIME"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/LenkePlukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/LenkePlukker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="c7c9029f-f742-4203-81b3-fa03ee3e0074" Alias="Lenke-plukker" Level="1">
+  <Info>
+    <Name>Lenke-plukker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "3cba3fce-5d3e-4fe1-abb0-21f3cd107d7c",
+  "maxNumber": 1,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Lenkeblokkplukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Lenkeblokkplukker.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="c7c9029f-f742-4203-81b3-fa03ee3e0074" Alias="Lenkeblokkplukker" Change="Rename" />

--- a/umbraco-infoportal/uSync/v17/DataTypes/ListViewContent.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/ListViewContent.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="c0808dd3-8133-4e4b-8ce8-e2bea84a96a4" Alias="List View - Content" Level="1">
+  <Info>
+    <Name>List View - Content</Name>
+    <EditorAlias>Umbraco.ListView</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Collection</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "includeProperties": [
+    {
+      "alias": "updateDate",
+      "header": "Last edited",
+      "isSystem": true
+    },
+    {
+      "alias": "creator",
+      "header": "Updated by",
+      "isSystem": true
+    }
+  ],
+  "layouts": [
+    {
+      "name": "Grid",
+      "collectionView": "Umb.CollectionView.Document.Grid",
+      "icon": "icon-thumbnails-small",
+      "isSystem": true,
+      "selected": true
+    },
+    {
+      "name": "List",
+      "collectionView": "Umb.CollectionView.Document.Table",
+      "icon": "icon-list",
+      "isSystem": true,
+      "selected": true
+    }
+  ],
+  "orderBy": "updateDate",
+  "orderDirection": "desc",
+  "pageSize": 100
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/ListViewMedia.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/ListViewMedia.config
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="3a0156c4-3b8c-4803-bdc1-6871faa83fff" Alias="List View - Media" Level="1">
+  <Info>
+    <Name>List View - Media</Name>
+    <EditorAlias>Umbraco.ListView</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Collection</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "includeProperties": [
+    {
+      "alias": "updateDate",
+      "header": "Last edited",
+      "isSystem": true
+    },
+    {
+      "alias": "creator",
+      "header": "Updated by",
+      "isSystem": true
+    }
+  ],
+  "layouts": [
+    {
+      "name": "Grid",
+      "collectionView": "Umb.CollectionView.Media.Grid",
+      "icon": "icon-thumbnails-small",
+      "isSystem": true,
+      "selected": true
+    },
+    {
+      "name": "List",
+      "collectionView": "Umb.CollectionView.Media.Table",
+      "icon": "icon-list",
+      "isSystem": true,
+      "selected": true
+    }
+  ],
+  "orderBy": "updateDate",
+  "orderDirection": "desc",
+  "pageSize": 100
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/MediaPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/MediaPicker.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="4309a3ea-0d78-4329-a06c-c80b036af19a" Alias="Media Picker" Level="1">
+  <Info>
+    <Name>Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": false,
+  "validationLimit": {
+    "min": 0,
+    "max": 1
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/MemberPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/MemberPicker.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1ea2e01f-ebd8-4ce1-8d71-6b1149e63548" Alias="Member Picker" Level="1">
+  <Info>
+    <Name>Member Picker</Name>
+    <EditorAlias>Umbraco.MemberPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MemberPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/MultiURLPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/MultiURLPicker.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="b4e3535a-1753-47e2-8568-602cf8cfee6f" Alias="Multi URL Picker" Level="1">
+  <Info>
+    <Name>Multi URL Picker</Name>
+    <EditorAlias>Umbraco.MultiUrlPicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MultiUrlPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/MultipleImageMediaPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/MultipleImageMediaPicker.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0e63d883-b62b-4799-88c3-157f82e83ecc" Alias="Multiple Image Media Picker" Level="1">
+  <Info>
+    <Name>Multiple Image Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "cc07b313-0843-4aa8-bbda-871c8da728c8",
+  "multiple": true
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/MultipleMediaPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/MultipleMediaPicker.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1b661f40-2242-4b44-b9cb-3990ee2b13c0" Alias="Multiple Media Picker" Level="1">
+  <Info>
+    <Name>Multiple Media Picker</Name>
+    <EditorAlias>Umbraco.MediaPicker3</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.MediaPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "multiple": true
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/NedtrekkselementPlukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/NedtrekkselementPlukker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="1890c776-2cfc-42e6-b4b8-3f8a69474136" Alias="Nedtrekkselement-plukker" Level="1">
+  <Info>
+    <Name>Nedtrekkselement-plukker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "e9073262-787c-4a36-9dec-17595ad9528d",
+  "maxNumber": 1,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/NedtrekkssamlerNedtrekksmenyOmraadeContentPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/NedtrekkssamlerNedtrekksmenyOmraadeContentPicker.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8448291d-db3e-4252-83ba-2ed84876fbbe" Alias="Nedtrekkssamler - Nedtrekksmeny område - Content Picker" Level="1">
+  <Info>
+    <Name>Nedtrekkssamler - Nedtrekksmeny område - Content Picker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "e9073262-787c-4a36-9dec-17595ad9528d",
+  "maxNumber": 100,
+  "minNumber": 0
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/NedtrekkssamlerPlukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/NedtrekkssamlerPlukker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="52dddfca-df5c-4bd1-b06f-cb89b44ec432" Alias="Nedtrekkssamler-plukker" Level="1">
+  <Info>
+    <Name>Nedtrekkssamler-plukker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "dcdb4fd8-8ec8-4e4f-a6af-e1bd2a7e66bf",
+  "maxNumber": 1,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Numeric.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Numeric.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="2e6d3631-066e-44b8-aec4-96f09099b2b5" Alias="Numeric" Level="1">
+  <Info>
+    <Name>Numeric</Name>
+    <EditorAlias>Umbraco.Integer</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Integer</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Radiobox.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Radiobox.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="bb5f57c9-ce2b-4bb9-b697-4caca783a805" Alias="Radiobox" Level="1">
+  <Info>
+    <Name>Radiobox</Name>
+    <EditorAlias>Umbraco.RadioButtonList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.RadioButtonList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/RichtextEditor.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/RichtextEditor.config
@@ -1,0 +1,104 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ca90c950-0aff-4e72-b976-a30b1ac57dad" Alias="Richtext editor" Level="1">
+  <Info>
+    <Name>Richtext editor</Name>
+    <EditorAlias>Umbraco.RichText</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Tiptap</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "3a5ac8e8-4001-4988-908c-91c91fc3beef"
+    },
+    {
+      "contentElementTypeKey": "fa44c41d-6612-443a-bcc6-8e5e73f3501d"
+    },
+    {
+      "contentElementTypeKey": "52c06f64-dc96-4dff-a1ca-c04985e466eb"
+    },
+    {
+      "contentElementTypeKey": "c15dde67-b3d2-4a9d-bc14-91672e45709f"
+    },
+    {
+      "contentElementTypeKey": "88a091bc-d6c2-4341-84aa-ab3c079905fb"
+    },
+    {
+      "contentElementTypeKey": "fcac3fa4-9137-437d-9039-06365a88e2f9"
+    }
+  ],
+  "extensions": [
+    "Umb.Tiptap.RichTextEssentials",
+    "Umb.Tiptap.Anchor",
+    "Umb.Tiptap.Blockquote",
+    "Umb.Tiptap.Bold",
+    "Umb.Tiptap.BulletList",
+    "Umb.Tiptap.CodeBlock",
+    "Umb.Tiptap.Embed",
+    "Umb.Tiptap.Figure",
+    "Umb.Tiptap.Heading",
+    "Umb.Tiptap.HorizontalRule",
+    "Umb.Tiptap.HtmlAttributeClass",
+    "Umb.Tiptap.HtmlAttributeDataset",
+    "Umb.Tiptap.HtmlAttributeId",
+    "Umb.Tiptap.HtmlAttributeStyle",
+    "Umb.Tiptap.HtmlTagDiv",
+    "Umb.Tiptap.HtmlTagSpan",
+    "Umb.Tiptap.Image",
+    "Umb.Tiptap.Italic",
+    "Umb.Tiptap.Link",
+    "Umb.Tiptap.MediaUpload",
+    "Umb.Tiptap.OrderedList",
+    "Umb.Tiptap.Strike",
+    "Umb.Tiptap.Subscript",
+    "Umb.Tiptap.Superscript",
+    "Umb.Tiptap.Table",
+    "Umb.Tiptap.TextAlign",
+    "Umb.Tiptap.TextDirection",
+    "Umb.Tiptap.TextIndent",
+    "Umb.Tiptap.TrailingNode",
+    "Umb.Tiptap.Underline",
+    "Umb.Tiptap.Block"
+  ],
+  "maxImageSize": 500,
+  "overlaySize": "medium",
+  "toolbar": [
+    [
+      [
+        "Umb.Tiptap.Toolbar.SourceEditor"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Bold",
+        "Umb.Tiptap.Toolbar.Italic",
+        "Umb.Tiptap.Toolbar.Underline"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.TextAlignLeft",
+        "Umb.Tiptap.Toolbar.TextAlignCenter",
+        "Umb.Tiptap.Toolbar.TextAlignRight"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.BulletList",
+        "Umb.Tiptap.Toolbar.OrderedList"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Blockquote",
+        "Umb.Tiptap.Toolbar.HorizontalRule"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Link",
+        "Umb.Tiptap.Toolbar.Unlink"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.MediaPicker",
+        "Umb.Tiptap.Toolbar.EmbeddedMedia",
+        "Umb.Tiptap.Toolbar.BlockPicker"
+      ],
+      [
+        "Umb.Tiptap.Toolbar.Heading1",
+        "Umb.Tiptap.Toolbar.Heading2",
+        "Umb.Tiptap.Toolbar.Heading3"
+      ]
+    ]
+  ]
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/StarteOgDriveArtikkelBlokklisteBlockList.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/StarteOgDriveArtikkelBlokklisteBlockList.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="475fe1d6-705d-4b8b-9d4b-554cca534ae5" Alias="Starte og drive - Artikkel - Blokkliste - Block List" Level="1">
+  <Info>
+    <Name>Starte og drive - Artikkel - Blokkliste - Block List</Name>
+    <EditorAlias>Umbraco.BlockList</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.BlockList</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "blocks": [
+    {
+      "contentElementTypeKey": "b628e2a3-7ef7-4f77-b97a-9121f6807a88",
+      "label": "Lenkeblokk"
+    }
+  ]
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/StarteOgDriveForsideFremhevedeTemaContentPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/StarteOgDriveForsideFremhevedeTemaContentPicker.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="022841b2-41b0-41bf-a74f-f318ec3eb390" Alias="Starte og drive - Forside - Fremhevede tema - Content Picker" Level="1">
+  <Info>
+    <Name>Starte og drive - Forside - Fremhevede tema - Content Picker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "76a1be25-ff7c-48d1-8b77-be2415ab9744,49108713-618e-4c5f-826b-a9dfbe92f0ca,de044169-a8ca-474b-869b-65de088321e6",
+  "maxNumber": 30,
+  "minNumber": 0
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/TabellblokkPlukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/TabellblokkPlukker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="a7ee6523-d4ef-42ca-8fc2-25227ebdfb07" Alias="Tabellblokk-plukker" Level="1">
+  <Info>
+    <Name>Tabellblokk-plukker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "6cf9203e-fdee-48de-9657-da2ee1512898",
+  "maxNumber": 1,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Tags.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Tags.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="b6b73142-b9c1-4bf8-a16d-e1c23320b549" Alias="Tags" Level="1">
+  <Info>
+    <Name>Tags</Name>
+    <EditorAlias>Umbraco.Tags</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Tags</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "group": "default",
+  "storageType": "Json"
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Textarea.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Textarea.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3" Alias="Textarea" Level="1">
+  <Info>
+    <Name>Textarea</Name>
+    <EditorAlias>Umbraco.TextArea</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.TextArea</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Textstring.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Textstring.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="0cc0eba1-9960-42c9-bf9b-60e150b429ae" Alias="Textstring" Level="1">
+  <Info>
+    <Name>Textstring</Name>
+    <EditorAlias>Umbraco.TextBox</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.TextBox</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "inputType": "text",
+  "maxChars": 512
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/Truefalse.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/Truefalse.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="92897bc6-a5f3-4ffe-ae27-f2e7e33dda49" Alias="True/false" Level="1">
+  <Info>
+    <Name>True/false</Name>
+    <EditorAlias>Umbraco.TrueFalse</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Toggle</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/URLPicker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/URLPicker.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="7ee13de3-166d-47e5-a73f-edc2cec6510d" Alias="URL picker" Level="1">
+  <Info>
+    <Name>URL picker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "37ff0190-0c59-42a8-a955-f63d7066c41a",
+  "maxNumber": 1,
+  "minNumber": 0
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/URLPlukker.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/URLPlukker.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="19102e9c-c395-498c-9f2b-495d74101234" Alias="URL-plukker" Level="1">
+  <Info>
+    <Name>URL-plukker</Name>
+    <EditorAlias>Umbraco.MultiNodeTreePicker</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.ContentPicker</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "filter": "37ff0190-0c59-42a8-a955-f63d7066c41a",
+  "maxNumber": 1,
+  "minNumber": 0,
+  "startNode": {
+    "type": "content",
+    "id": "84db27a9-cdee-4521-8872-b9967ada4c69",
+    "dynamicRoot": {
+      "originKey": "84db27a9-cdee-4521-8872-b9967ada4c69",
+      "originAlias": "ByKey"
+    }
+  }
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/UploadArticle.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/UploadArticle.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="bc1e266c-dac4-4164-bf08-8a1ec6a7143d" Alias="Upload Article" Level="1">
+  <Info>
+    <Name>Upload Article</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "pdf",
+    "docx",
+    "doc"
+  ]
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/UploadAudio.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/UploadAudio.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="8f430dd6-4e96-447e-9dc0-cb552c8cd1f3" Alias="Upload Audio" Level="1">
+  <Info>
+    <Name>Upload Audio</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "mp3",
+    "weba",
+    "oga",
+    "opus"
+  ]
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/UploadFile.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/UploadFile.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="84c6b441-31df-4ffe-b67e-67d5bc3ae65a" Alias="Upload File" Level="1">
+  <Info>
+    <Name>Upload File</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/UploadVectorGraphics.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/UploadVectorGraphics.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="215cb418-2153-4429-9aef-8c0f0041191b" Alias="Upload Vector Graphics" Level="1">
+  <Info>
+    <Name>Upload Vector Graphics</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "svg"
+  ]
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/UploadVideo.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/UploadVideo.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="70575fe7-9812-4396-bbe1-c81a76db71b5" Alias="Upload Video" Level="1">
+  <Info>
+    <Name>Upload Video</Name>
+    <EditorAlias>Umbraco.UploadField</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.UploadField</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "fileExtensions": [
+    "mp4",
+    "webm",
+    "ogv"
+  ]
+}]]></Config>
+</DataType>

--- a/umbraco-infoportal/uSync/v17/Domains/_nb.config
+++ b/umbraco-infoportal/uSync/v17/Domains/_nb.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Domain Key="cdcab783-0000-0000-0000-000000000000" Alias="/">
+  <Info>
+    <IsWildcard>false</IsWildcard>
+    <Language>nb</Language>
+    <Root Key="790aa76b-f609-472a-8c1c-a360c8d64a84">/Start</Root>
+  </Info>
+</Domain>

--- a/umbraco-infoportal/uSync/v17/Domains/en_en.config
+++ b/umbraco-infoportal/uSync/v17/Domains/en_en.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Domain Key="5f785b64-0000-0000-0000-000000000000" Alias="/en">
+  <Info>
+    <IsWildcard>false</IsWildcard>
+    <Language>en</Language>
+    <Root Key="790aa76b-f609-472a-8c1c-a360c8d64a84">/Start</Root>
+  </Info>
+</Domain>

--- a/umbraco-infoportal/uSync/v17/Domains/nn_nn.config
+++ b/umbraco-infoportal/uSync/v17/Domains/nn_nn.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Domain Key="624658bb-0000-0000-0000-000000000000" Alias="/nn">
+  <Info>
+    <IsWildcard>false</IsWildcard>
+    <Language>nn</Language>
+    <Root Key="790aa76b-f609-472a-8c1c-a360c8d64a84">/Start</Root>
+  </Info>
+</Domain>

--- a/umbraco-infoportal/uSync/v17/Languages/en-us.config
+++ b/umbraco-infoportal/uSync/v17/Languages/en-us.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Empty Key="fc6f9a20-07e0-459a-8a23-f172f9fd52ee" Alias="en-US" Change="Delete" />

--- a/umbraco-infoportal/uSync/v17/Languages/en.config
+++ b/umbraco-infoportal/uSync/v17/Languages/en.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Language Key="ad4fa7d7-0000-0000-0000-000000000000" Alias="en" Level="0">
+  <Name>English</Name>
+  <IsoCode>en</IsoCode>
+  <IsMandatory>false</IsMandatory>
+  <IsDefault>false</IsDefault>
+  <Fallback>nb</Fallback>
+</Language>

--- a/umbraco-infoportal/uSync/v17/Languages/nb.config
+++ b/umbraco-infoportal/uSync/v17/Languages/nb.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Language Key="37ed7a4e-0000-0000-0000-000000000000" Alias="nb" Level="0">
+  <Name>Norwegian Bokmål</Name>
+  <IsoCode>nb</IsoCode>
+  <IsMandatory>false</IsMandatory>
+  <IsDefault>true</IsDefault>
+</Language>

--- a/umbraco-infoportal/uSync/v17/Languages/nn.config
+++ b/umbraco-infoportal/uSync/v17/Languages/nn.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Language Key="ad4fa7e2-0000-0000-0000-000000000000" Alias="nn" Level="0">
+  <Name>Norwegian Nynorsk</Name>
+  <IsoCode>nn</IsoCode>
+  <IsMandatory>false</IsMandatory>
+  <IsDefault>false</IsDefault>
+  <Fallback>nb</Fallback>
+</Language>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/file.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/file.config
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="4c52d8ab-54e6-40cd-999c-7a5f24903e4d" Alias="File" Level="1">
+  <Info>
+    <Name>File</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>icon-document</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>f9527050-59bc-43e4-8fa8-1658d1319ff5</Key>
+      <Name>File size</Name>
+      <Alias>umbracoBytes</Alias>
+      <Definition>ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="file">File</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>3531c0a3-4e0a-4324-a621-b9d3822b071f</Key>
+      <Name>File extension</Name>
+      <Alias>umbracoExtension</Alias>
+      <Definition>f0bc4bfb-b499-40d6-ba86-058885a5178c</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="file">File</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a0fb68f3-f427-47a6-afce-536ffa5b64e9</Key>
+      <Name>File</Name>
+      <Alias>umbracoFile</Alias>
+      <Definition>84c6b441-31df-4ffe-b67e-67d5bc3ae65a</Definition>
+      <Type>Umbraco.UploadField</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="file">File</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>50899f9c-023a-4466-b623-aba9049885fe</Key>
+      <Caption>File</Caption>
+      <Alias>file</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/folder.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/folder.config
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="f38bd2d7-65d0-48e6-95dc-87ce06ec2d3d" Alias="Folder" Level="1">
+  <Info>
+    <Name>Folder</Name>
+    <Icon>icon-folder</Icon>
+    <Thumbnail>icon-folder</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>3a0156c4-3b8c-4803-bdc1-6871faa83fff</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties />
+  <Structure>
+    <MediaType Key="f38bd2d7-65d0-48e6-95dc-87ce06ec2d3d" SortOrder="0">Folder</MediaType>
+    <MediaType Key="cc07b313-0843-4aa8-bbda-871c8da728c8" SortOrder="1">Image</MediaType>
+    <MediaType Key="4c52d8ab-54e6-40cd-999c-7a5f24903e4d" SortOrder="2">File</MediaType>
+    <MediaType Key="f6c515bb-653c-4bdc-821c-987729ebe327" SortOrder="3">umbracoMediaVideo</MediaType>
+    <MediaType Key="a5ddeee0-8fd8-4cee-a658-6f1fcdb00de3" SortOrder="4">umbracoMediaAudio</MediaType>
+    <MediaType Key="a43e3414-9599-4230-a7d3-943a21b20122" SortOrder="5">umbracoMediaArticle</MediaType>
+    <MediaType Key="c4b1efcf-a9d5-41c4-9621-e9d273b52a9c" SortOrder="6">umbracoMediaVectorGraphics</MediaType>
+  </Structure>
+  <Tabs />
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/image.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/image.config
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="cc07b313-0843-4aa8-bbda-871c8da728c8" Alias="Image" Level="1">
+  <Info>
+    <Name>Image</Name>
+    <Icon>icon-picture</Icon>
+    <Thumbnail>icon-picture</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>bd4c5ace-26e3-4a8b-af1a-e8206a35fa07</Key>
+      <Name>File size</Name>
+      <Alias>umbracoBytes</Alias>
+      <Definition>ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="image">Image</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>f7786fe8-724a-4ed0-b244-72546db32a92</Key>
+      <Name>File extension</Name>
+      <Alias>umbracoExtension</Alias>
+      <Definition>f0bc4bfb-b499-40d6-ba86-058885a5178c</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>4</SortOrder>
+      <Tab Alias="image">Image</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>b646ca8f-e469-4fc2-a48a-d4dc1aa64a53</Key>
+      <Name>Image</Name>
+      <Alias>umbracoFile</Alias>
+      <Definition>1df9f033-e6d4-451f-b8d2-e0cbc50a836f</Definition>
+      <Type>Umbraco.ImageCropper</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="image">Image</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>854087f6-648b-40ed-bc98-b8a9789e80b9</Key>
+      <Name>Height</Name>
+      <Alias>umbracoHeight</Alias>
+      <Definition>5eb57825-e15e-4fc7-8e37-fca65cdafbde</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="image">Image</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>a68d453b-1f62-44f4-9f71-0b6bbd43c355</Key>
+      <Name>Width</Name>
+      <Alias>umbracoWidth</Alias>
+      <Definition>5eb57825-e15e-4fc7-8e37-fca65cdafbde</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="image">Image</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>79ed4d07-254a-42cf-8fa9-ebe1c116a596</Key>
+      <Caption>Image</Caption>
+      <Alias>image</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediaarticle.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediaarticle.config
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="a43e3414-9599-4230-a7d3-943a21b20122" Alias="umbracoMediaArticle" Level="1">
+  <Info>
+    <Name>Article</Name>
+    <Icon>icon-article</Icon>
+    <Thumbnail>icon-article</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>aab7d00c-7209-4337-be3f-a4421c8d79a0</Key>
+      <Name>File size</Name>
+      <Alias>umbracoBytes</Alias>
+      <Definition>ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="article">Article</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>ef1b4af7-36de-45eb-8c18-a2de07319227</Key>
+      <Name>File extension</Name>
+      <Alias>umbracoExtension</Alias>
+      <Definition>f0bc4bfb-b499-40d6-ba86-058885a5178c</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="article">Article</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e5c8c2d0-2d82-4f01-b53a-45a1d1cbf19c</Key>
+      <Name>Article</Name>
+      <Alias>umbracoFile</Alias>
+      <Definition>bc1e266c-dac4-4164-bf08-8a1ec6a7143d</Definition>
+      <Type>Umbraco.UploadField</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="article">Article</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>9af3bd65-f687-4453-9518-5f180d1898ec</Key>
+      <Caption>Article</Caption>
+      <Alias>article</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediaaudio.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediaaudio.config
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="a5ddeee0-8fd8-4cee-a658-6f1fcdb00de3" Alias="umbracoMediaAudio" Level="1">
+  <Info>
+    <Name>Audio</Name>
+    <Icon>icon-audio-lines</Icon>
+    <Thumbnail>icon-audio-lines</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>3cbf538a-29ab-4317-a9eb-bbcdf1a54260</Key>
+      <Name>File size</Name>
+      <Alias>umbracoBytes</Alias>
+      <Definition>ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="audio">Audio</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1bee433f-a21a-4031-8e03-af01bb8d2de9</Key>
+      <Name>File extension</Name>
+      <Alias>umbracoExtension</Alias>
+      <Definition>f0bc4bfb-b499-40d6-ba86-058885a5178c</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="audio">Audio</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>1f48d730-f174-4684-afad-a335e59d84a0</Key>
+      <Name>Audio</Name>
+      <Alias>umbracoFile</Alias>
+      <Definition>8f430dd6-4e96-447e-9dc0-cb552c8cd1f3</Definition>
+      <Type>Umbraco.UploadField</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="audio">Audio</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>335fb495-0a87-4e82-b902-30eb367b767c</Key>
+      <Caption>Audio</Caption>
+      <Alias>audio</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediavectorgraphics.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediavectorgraphics.config
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="c4b1efcf-a9d5-41c4-9621-e9d273b52a9c" Alias="umbracoMediaVectorGraphics" Level="1">
+  <Info>
+    <Name>Vector Graphics (SVG)</Name>
+    <Icon>icon-origami</Icon>
+    <Thumbnail>icon-origami</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>09a07aff-861d-4769-a2b0-c165ebd43d39</Key>
+      <Name>File size</Name>
+      <Alias>umbracoBytes</Alias>
+      <Definition>ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="vectorGraphics">Vector Graphics</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>0f25a89e-2eb7-49bc-a7b4-759a7e4c69f2</Key>
+      <Name>File extension</Name>
+      <Alias>umbracoExtension</Alias>
+      <Definition>f0bc4bfb-b499-40d6-ba86-058885a5178c</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="vectorGraphics">Vector Graphics</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>e2a2bdf2-971b-483e-95a1-4104cc06af26</Key>
+      <Name>Vector Graphics</Name>
+      <Alias>umbracoFile</Alias>
+      <Definition>215cb418-2153-4429-9aef-8c0f0041191b</Definition>
+      <Type>Umbraco.UploadField</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="vectorGraphics">Vector Graphics</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>f199b4d7-9e84-439f-8531-f87d9af37711</Key>
+      <Caption>Vector Graphics</Caption>
+      <Alias>vectorGraphics</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediavideo.config
+++ b/umbraco-infoportal/uSync/v17/MediaTypes/umbracomediavideo.config
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MediaType Key="f6c515bb-653c-4bdc-821c-987729ebe327" Alias="umbracoMediaVideo" Level="1">
+  <Info>
+    <Name>Video</Name>
+    <Icon>icon-video</Icon>
+    <Thumbnail>icon-video</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>True</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>180eeecf-1f00-409e-8234-bba967e08b0a</Key>
+      <Name>File size</Name>
+      <Alias>umbracoBytes</Alias>
+      <Definition>ba5bdbe6-ab3e-46a8-82b3-2c45f10bc47f</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="video">Video</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>edd2b3fd-1e57-4e57-935e-096defccdc9b</Key>
+      <Name>File extension</Name>
+      <Alias>umbracoExtension</Alias>
+      <Definition>f0bc4bfb-b499-40d6-ba86-058885a5178c</Definition>
+      <Type>Umbraco.Label</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="video">Video</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>bed8ab97-d85f-44d2-a8b9-aef6893f9610</Key>
+      <Name>Video</Name>
+      <Alias>umbracoFile</Alias>
+      <Definition>70575fe7-9812-4396-bbe1-c81a76db71b5</Definition>
+      <Type>Umbraco.UploadField</Type>
+      <Mandatory>true</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="video">Video</Tab>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>2f0a61b6-cf92-4ff4-b437-751ab35eb254</Key>
+      <Caption>Video</Caption>
+      <Alias>video</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MediaType>

--- a/umbraco-infoportal/uSync/v17/MemberTypes/member.config
+++ b/umbraco-infoportal/uSync/v17/MemberTypes/member.config
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<MemberType Key="d59be02f-1df9-4228-aa1e-01917d806cda" Alias="Member" Level="1">
+  <Info>
+    <Name>Member</Name>
+    <Icon>icon-user</Icon>
+    <Thumbnail>icon-user</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Nothing</Variations>
+    <IsElement>false</IsElement>
+    <Compositions />
+  </Info>
+  <GenericProperties>
+    <GenericProperty>
+      <Key>2a280588-0000-0000-0000-000000000000</Key>
+      <Name>Comments</Name>
+      <Alias>umbracoMemberComments</Alias>
+      <Definition>c6bac0dd-4ab9-45b1-8e30-e4b619ee5da3</Definition>
+      <Type>Umbraco.TextArea</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="membership">Membership</Tab>
+      <CanEdit>false</CanEdit>
+      <CanView>false</CanView>
+      <IsSensitive>false</IsSensitive>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Structure />
+  <Tabs>
+    <Tab>
+      <Key>0756729d-d665-46e3-b84a-37aceaa614f8</Key>
+      <Caption>Membership</Caption>
+      <Alias>membership</Alias>
+      <Type>Group</Type>
+      <SortOrder>1</SortOrder>
+    </Tab>
+  </Tabs>
+</MemberType>

--- a/umbraco-infoportal/uSync/v17/RelationTypes/umbMember.config
+++ b/umbraco-infoportal/uSync/v17/RelationTypes/umbMember.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RelationType Key="bf2a9ac5-b791-377e-bafb-9d06ed87864d" Alias="umbMember" Level="0">
+  <Info>
+    <Name>Related Member</Name>
+    <ParentType />
+    <ChildType />
+    <Bidirectional>false</Bidirectional>
+    <IsDependency>true</IsDependency>
+  </Info>
+</RelationType>

--- a/umbraco-infoportal/uSync/v17/Templates/forside.config
+++ b/umbraco-infoportal/uSync/v17/Templates/forside.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019c6b83-4063-7526-9b75-5c0c82fd222f" Alias="Forside" Level="1">
+  <Name>Forside</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/innholdsressursmappe.config
+++ b/umbraco-infoportal/uSync/v17/Templates/innholdsressursmappe.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019cfbe2-2392-744b-bbb7-1dbcf4deed42" Alias="Innholdsressursmappe" Level="1">
+  <Name>Innholdsressursmappe</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/nyhetarkiv.config
+++ b/umbraco-infoportal/uSync/v17/Templates/nyhetarkiv.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019d0a11-b3b6-7c6b-84be-3f71cf711b2d" Alias="Nyhetarkiv" Level="1">
+  <Name>Nyhetarkiv</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/nyhetsartikkelside.config
+++ b/umbraco-infoportal/uSync/v17/Templates/nyhetsartikkelside.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019d0a0a-abc3-7733-a24d-9a6c700e3994" Alias="Nyhetsartikkelside" Level="1">
+  <Name>Nyhetsartikkelside</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/starteogdriveartikkel.config
+++ b/umbraco-infoportal/uSync/v17/Templates/starteogdriveartikkel.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019c6b81-3fdc-71f2-ae81-0cb01d57a805" Alias="StarteOgDriveArtikkel" Level="1">
+  <Name>Starte og drive - Artikkel</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/starteogdriveforside.config
+++ b/umbraco-infoportal/uSync/v17/Templates/starteogdriveforside.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019c6b72-5df0-78f4-889a-2841172d264b" Alias="StarteOgDriveForside" Level="1">
+  <Name>Starte og drive - Forside</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/starteogdrivetemamappe.config
+++ b/umbraco-infoportal/uSync/v17/Templates/starteogdrivetemamappe.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019c6b7e-e48a-733b-b688-13528b001741" Alias="StarteOgDriveTemamappe" Level="1">
+  <Name>Starte og drive - Temamappe</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/Templates/starteogdrivetemaside.config
+++ b/umbraco-infoportal/uSync/v17/Templates/starteogdrivetemaside.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Template Key="019c6b76-c4a3-77bd-8f63-968a9724dbe5" Alias="StarteOgDriveTemaside" Level="1">
+  <Name>Starte og drive - Temaside</Name>
+  <Parent />
+</Template>

--- a/umbraco-infoportal/uSync/v17/usync.config
+++ b/umbraco-infoportal/uSync/v17/usync.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<uSync version="17.0.4.0" format="10.7.0" />

--- a/umbraco-infoportal/umbraco-infoportal.csproj
+++ b/umbraco-infoportal/umbraco-infoportal.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
     <PackageReference Include="Umbraco.Cms" Version="17.2.2" />
     <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.2.2" />
+    <PackageReference Include="uSync" Version="17.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Added the Umbraco uSync package using the command "dotnet add package usync"

This allows us to export and import Settings as XML files from Umbraco UI, especially Document Types and Data Types.

Setting up a fresh Umbraco instance and importing the master Settings makes it ready for mass import of content.

The master Settings files resides in the umbraco-infoportal/uSync folder.



