### PR TITLE
fix: update header menu with search and language items, add mock global data

### DIFF
--- a/astro-infoportal/src/Components/Layout/Header/builders/menuBuilder.ts
+++ b/astro-infoportal/src/Components/Layout/Header/builders/menuBuilder.ts
@@ -7,8 +7,10 @@ import { formatDisplayName } from "@altinn/altinn-components";
 import {
   Buildings2Icon,
   ChatExclamationmarkIcon,
+  GlobeIcon,
   InboxFillIcon,
   InformationSquareIcon,
+  MagnifyingGlassIcon,
   MenuGridIcon,
   PadlockLockedFillIcon,
   PersonCircleIcon,
@@ -82,6 +84,18 @@ export const buildMenuItems = (pages: MenuPages, isLoggedIn: boolean, currentPat
     });
   }
 
+  if (pages.searchPageUrl && pages.searchTextPlaceholder) {
+    items.push({
+      id: "altinn-search",
+      groupId: "apps",
+      title: pages.searchTextPlaceholder,
+      href: pages.searchPageUrl,
+      icon: MagnifyingGlassIcon,
+      size: "lg" as const,
+      selected: isCurrentPage(currentPath, pages.searchPageUrl),
+    });
+  }
+
   if (pages.aboutNewAltinnPage?.url && pages.aboutNewAltinnPage?.text) {
     items.push({
       id: "about-new-altinn",
@@ -115,6 +129,27 @@ export const buildMenuItems = (pages: MenuPages, isLoggedIn: boolean, currentPat
       icon: ChatExclamationmarkIcon,
       size: "sm" as const,
       selected: isCurrentPage(currentPath, pages.helpPage.url),
+    });
+  }
+
+  if (pages.chooseLanguageText && pages.menuLanguageList && pages.menuLanguageList.length > 0) {
+    const currentLang = pages.menuLanguageList.find((l) => l.selected);
+    items.push({
+      id: "language",
+      groupId: "shortcuts",
+      title: pages.chooseLanguageText,
+      icon: GlobeIcon,
+      size: "sm" as const,
+      description: currentLang?.languageName,
+      items: pages.menuLanguageList.map((lang) => ({
+        id: lang.languageName,
+        groupId: "language",
+        title: lang.languageName,
+        selected: lang.selected,
+        onClick: () => {
+          window.location.assign(lang.pageUrl);
+        },
+      })),
     });
   }
 

--- a/astro-infoportal/src/Components/Layout/Header/types/headerTypes.ts
+++ b/astro-infoportal/src/Components/Layout/Header/types/headerTypes.ts
@@ -16,6 +16,10 @@ export interface MenuPages {
   schemaOverviewPage?: LinkItemViewModel;
   profilePage?: LinkItemViewModel;
   aboutNewAltinnPage?: LinkItemViewModel;
+  searchPageUrl?: string;
+  searchTextPlaceholder?: string;
+  chooseLanguageText?: string;
+  menuLanguageList?: { languageName: string; pageUrl: string; selected: boolean }[];
 }
 
 /**

--- a/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
+++ b/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
@@ -1,14 +1,13 @@
-import type { GlobalHeaderProps } from "@altinn/altinn-components";
+import type {
+  AuthorizedParty as LibAuthorizedParty,
+  GlobalHeaderProps,
+} from "@altinn/altinn-components";
 import { useAccountSelector } from "@altinn/altinn-components";
 import type { HeaderViewModel } from "/Models/Generated/HeaderViewModel";
 import "@altinn/altinn-components/dist/global.css";
 import { useEffect, useMemo, useState } from "react";
 // import { useSearchSuggestions } from "./hooks/useSearchSuggestions";
 import { buildDesktopMenu } from "./builders/menuBuilder";
-import {
-  buildLanguageProps,
-  createLocaleSelectHandler,
-} from "./handlers/headerHandlers";
 import { useFavorites } from "./hooks/useFavorites";
 import type { MenuPages } from "./types/headerTypes";
 import { isBrowser } from "./utils/browserUtils";
@@ -45,22 +44,6 @@ interface AuthorizedPartyData {
   subunits?: AuthorizedPartyData[];
 }
 
-// Transformed party type for account selector
-interface TransformedParty {
-  partyUuid: string;
-  name: string;
-  organizationNumber?: string;
-  dateOfBirth?: string;
-  partyId: string; // Changed to match partyUuid
-  type: "Person" | "Organization";
-  unitType?: string;
-  isDeleted: boolean;
-  onlyHierarchyElementWithNoAccess: boolean;
-  authorizedResources: string[];
-  authorizedRoles: string[];
-  subunits: TransformedParty[];
-}
-
 const useHeaderConfig = (
   {
     startAndRunCompany,
@@ -71,6 +54,7 @@ const useHeaderConfig = (
     schemaOverviewPage,
     menuText,
     searchPageUrl,
+    searchTextPlaceholder,
     menuLanguageList,
     chooseLanguageText,
     hostBaseUrl,
@@ -90,14 +74,18 @@ const useHeaderConfig = (
   const [authorizedParties, setAuthorizedParties] = useState<AuthorizedPartyData[]>([]);
   const [currentPath, setCurrentPath] = useState<string>("");
   const [shouldShowDeletedUnits, setShouldShowDeletedUnits] = useState<boolean | undefined>(undefined);
+  const [isDataLoading, setIsDataLoading] = useState(isBrowser);
 
   // Custom hooks
-  const { favorites, addFavorite, removeFavorite } = useFavorites();
+  const { favorites, isLoading: isFavoritesLoading, addFavorite, removeFavorite } = useFavorites();
 
   // Fetch user data and authorized parties on mount
   useEffect(() => {
     // Only run in browser
-    if (!isBrowser) return;
+    if (!isBrowser) {
+      setIsDataLoading(false);
+      return;
+    }
 
     setCurrentPath(window.location.pathname);
 
@@ -130,8 +118,10 @@ const useHeaderConfig = (
             setShouldShowDeletedUnits(userData.showDeletedEntities);
           }
         }
-      } catch (_error) {
+      } catch {
         // Silent fail - user is not logged in or API unavailable
+      } finally {
+        setIsDataLoading(false);
       }
     };
 
@@ -150,7 +140,11 @@ const useHeaderConfig = (
     inboxPage,
     schemaOverviewPage,
     profilePage,
-    aboutNewAltinnPage
+    aboutNewAltinnPage,
+    searchPageUrl,
+    searchTextPlaceholder,
+    chooseLanguageText,
+    menuLanguageList,
   };
 
   // Find the main user and build menu - memoized to avoid recalculation
@@ -182,15 +176,21 @@ const useHeaderConfig = (
     [pages, isLoggedIn, loggedInAsText, currentUser?.name, userType, currentPath]
   );
 
-  const transformParty = (party: AuthorizedPartyData): TransformedParty => {
+  const transformParty = (party: AuthorizedPartyData): LibAuthorizedParty => {
     const isPerson = party.type === 1 || party.type === "Person";
 
     return {
-      ...party,
+      partyUuid: party.partyUuid,
+      name: party.name,
       partyId: party.partyUuid,
       type: isPerson ? "Person" : "Organization",
-      dateOfBirth: isPerson ? party.dateOfBirth : undefined,
-      organizationNumber: !isPerson ? party.organizationNumber : undefined,
+      isDeleted: party.isDeleted,
+      onlyHierarchyElementWithNoAccess: party.onlyHierarchyElementWithNoAccess,
+      authorizedResources: party.authorizedResources,
+      authorizedRoles: party.authorizedRoles,
+      ...(party.dateOfBirth && isPerson ? { dateOfBirth: party.dateOfBirth } : {}),
+      ...(party.organizationNumber && !isPerson ? { organizationNumber: party.organizationNumber } : {}),
+      ...(party.unitType ? { unitType: party.unitType } : {}),
       subunits: party.subunits?.map(transformParty) || [],
     };
   };
@@ -210,19 +210,19 @@ const useHeaderConfig = (
         const data = await response.json();
         setShouldShowDeletedUnits(data.shouldShowDeletedEntities);
       }
-    } catch (error) {
-      console.error("Error updating show deleted preference:", error);
+    } catch {
+      // Silent fail — preference update is non-critical
     }
   };
 
   const accountSelectorData = useAccountSelector({
     languageCode: languageCode,
-    partyListDTO: partyListDTO as any,
+    partyListDTO: partyListDTO,
     favoriteAccountUuids: favorites,
     currentAccountUuid: currentAccountUuid,
     selfAccountUuid: selfAccountUuid,
-    isVirtualized: authorizedParties.length > 20,
-    isLoading: false,
+    virtualized: authorizedParties.length > 20,
+    isLoading: isDataLoading || isFavoritesLoading,
     showDeletedUnits: shouldShowDeletedUnits,
     onShowDeletedUnitsChange: onShowDeletedUnitsChange,
     onToggleFavorite: (accountId: string) => {
@@ -243,9 +243,6 @@ const useHeaderConfig = (
       (window as Window).open(changeUrl.toString(), "_self");
     },
   });
-
-  const languageProps = buildLanguageProps(menuLanguageList);
-  const handleLocaleSelect = createLocaleSelectHandler(menuLanguageList);
 
   const globalHeaderProps: GlobalHeaderProps = {
     globalMenu: {
@@ -269,30 +266,6 @@ const useHeaderConfig = (
       logo: { href: startPage.url },
     }),
     desktopMenu,
-    globalSearch: {
-      // value: searchValue,
-      // onChange: setSearchValue,
-      // onFocus: () => setIsSearchFocused(true),
-      // onBlur: () => setIsSearchFocused(false),
-      // suggestions: suggestions,
-      onSearch: (query: string) => {
-        if (!isBrowser || !searchPageUrl) return;
-
-        const url = new URL(searchPageUrl, location.origin);
-        if (query) url.searchParams.set("q", query);
-        location.assign(url.toString());
-      },
-    },
-    locale: {
-      title: chooseLanguageText,
-      options: languageProps.map((l) => ({
-        value: l.value,
-        label: l.label,
-        checked: l.checked,
-        onClick: () => handleLocaleSelect(l.value),
-      })),
-      onSelect: handleLocaleSelect,
-    },
     accountSelector: {
       ...accountSelectorData,
       forceOpenFullScreen: false,

--- a/astro-infoportal/src/Components/Shared/ContentArea/ContentArea.tsx
+++ b/astro-infoportal/src/Components/Shared/ContentArea/ContentArea.tsx
@@ -2,7 +2,7 @@ import { Card } from "@digdir/designsystemet-react";
 import type { ContentAreaProps } from "/Models/Generated/ContentAreaProps";
 import * as Components from "../../../App.Components";
 import "./ContentArea.scss";
-import { IReactComponentProps } from "/Models/Generated/IReactComponentProps";
+import type { IReactComponentProps } from "/Models/Generated/IReactComponentProps";
 
 interface IReactComponentPropsType {
   type: string;

--- a/astro-infoportal/src/pages/[local]/[...slug].astro
+++ b/astro-infoportal/src/pages/[local]/[...slug].astro
@@ -6,14 +6,13 @@ import { JSONTransformer } from '@transformers/JSONTransformer';
 
 const path = Astro.url.pathname;
 
-// Specifically ignore internal/vite, api, and file asset requests
+// Ignore internal Vite/framework paths
 if (
-  path.startsWith('/@vite/') || 
-  path.startsWith('/@react-refresh') || 
-  path.startsWith('/@id/') || 
+  path.startsWith('/@vite/') ||
+  path.startsWith('/@react-refresh') ||
+  path.startsWith('/@id/') ||
   path.startsWith('/@fs/')
 ) {
-  // Let Vite handle these natively during development
   return new Response(null, { status: 404 });
 }
 
@@ -22,7 +21,70 @@ if (path.startsWith('/api/') || path.match(/\.[a-zA-Z0-9]+$/)) {
 }
 
 let umbracoPageData: any = null;
-let globalData: any = null;
+
+// TODO: Replace with real Umbraco global data when backend supports it
+let globalData: any = {
+  headerViewModel: {
+    banner: {
+      message: {
+        items: [
+          {
+            html: "\u003cp\u003eVi fornyer Altinn.\u0026nbsp;\u003ca href=\u0022/nyheter/om-nye-altinn/\u0022 class=\u0022ds-link\u0022\u003eLes mer om hva som er nytt.\u003c/a\u003e\u003c/p\u003e",
+            componentName: "RichText",
+          },
+        ],
+        componentName: "RichTextArea",
+      },
+      isActive: true,
+      badgeText: "Beta",
+      colorTheme: "accent",
+      closeButtonText: "Lukk",
+      contentHash: "88628bb068b41760",
+      localStoragePrefix: "infoportal-banner-dismissed",
+      componentName: "BannerBlock",
+    },
+    startAndRunCompany: { text: "Starte og drive bedrift", url: "/starte-og-drive/" },
+    helpPage: { text: "Trenger du hjelp?", url: "/hjelp/" },
+    loginPage: { text: "Logg inn", url: "https://af.at23.altinn.cloud/" },
+    schemaOverviewPage: { text: "Alle skjema og tjenester", url: "/skjemaoversikt/" },
+    inboxPage: { text: "Innboks", url: "https://af.at23.altinn.cloud/" },
+    accessManagementPage: { text: "Tilgangsstyring", url: "https://am.ui.at23.altinn.cloud/accessmanagement/ui" },
+    profilePage: { text: "Din profil", url: "https://af.at23.altinn.cloud/profile" },
+    logOutPage: { text: "Logg ut", url: "https://platform.at23.altinn.cloud/authentication/api/v1/logout" },
+    aboutNewAltinnPage: { text: "Om nye altinn", url: "/nyheter/om-nye-altinn/" },
+    startPage: { text: "", url: "/" },
+    loggedInAsText: "Logget inn som",
+    backButtonText: "Tilbake",
+    chooseLanguageText: "Velg språk",
+    menuLanguageList: [
+      { pageUrl: "/starte-og-drive/", languageTeaser: "Alt innhold er tilgjengelig på bokmål.", languageImage: "/Static/img/no.svg", languageName: "Bokmål", selected: true },
+      { pageUrl: "/nn/starte-og-drive/", languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.", languageImage: "/Static/img/no.svg", languageName: "Nynorsk", selected: false },
+      { pageUrl: "/en/start-and-run-business/", languageTeaser: "Some content is available in English.", languageImage: "/Static/img/gb.svg", languageName: "English", selected: false },
+    ],
+    shortcutText: "Snarveier",
+    menuText: "Meny",
+    searchTextPlaceholder: "Søk i innhold",
+    searchPageUrl: "/sok/",
+    suggestionsTitle: "Utvalgte hurtiglenker",
+    useSearchSuggestions: false,
+    dateOfBirthText: "Fødslesnummer",
+    orgNrText: "Org. nr",
+    hostBaseUrl: "https://at23.altinn.cloud/",
+  },
+  footerViewModel: {
+    startAndRunCompany: { text: "Starte og drive bedrift", url: "/starte-og-drive/" },
+    helpPage: { text: "Hjelp og kontakt", url: "/hjelp/" },
+    address1: "Digitaliseringsdirektoratet,",
+    address2: "Postboks 1382 Vika, 0114 Oslo. Org.nr. 991 825 827",
+    aboutAltinnReference: { text: "Om Altinn", url: "/om-altinn/" },
+    operationalMessagesReference: { text: "Driftsmeldinger", url: "/om-altinn/driftsmeldinger/" },
+    privacyReference: { text: "Personvern", url: "/om-altinn/personvern/" },
+    accessibilityLocation: { text: "Tilgjengelighet", url: "/om-altinn/tilgjengelighet/" },
+    searchPageUrl: "/sok/",
+    searchUrlBody: "/sok/",
+  },
+  skipLinkText: "Hopp til hovedinnhold",
+};
 
 const [pageResult] = await Promise.allSettled([
   fetchUmbracoContent(path),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactored the header menu to move search and language selector from dedicated GlobalHeader props into the menu builder. Added mock global data (header + footer view models).

## Changes
- **menuBuilder.ts** — Added search menu item (MagnifyingGlassIcon) and language selector (GlobeIcon) to the menu   
- **headerTypes.ts** — Extended `MenuPages` interface with `searchPageUrl`, `searchTextPlaceholder`, `chooseLanguageText`, `menuLanguageList`
- **useHeaderConfig.ts** — Replaced custom `TransformedParty` with library's `LibAuthorizedParty`, removed unused `headerHandlers` imports, removed `globalSearch` and `locale` props (now handled by menu builder), added proper loading states
- **ContentArea.tsx** — Changed `import` to `import type` for `IReactComponentProps`
- **[...slug].astro** — Added inline mock `globalData` with header and footer view models

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
