### PR TITLE
feat: add sql db fqdn and client id used by workload identity

### DIFF
--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: umbraco
+        azure.workload.identity/use: "true"
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         linkerd.io/inject: enabled
@@ -27,6 +28,9 @@ spec:
             requests:
               cpu: "1"
               memory: 2Gi
+          env:
+            - name: AZURE_SQL_FQDN
+              value: ${UMBRACO_SQL_CONN_FQDN}
           ports:
             - name: http
               containerPort: 8080

--- a/syncroot/base/umbraco/serviceaccount.yaml
+++ b/syncroot/base/umbraco/serviceaccount.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: umbraco
+  annotations:
+    azure.workload.identity/client-id: ${UMBRACO_CLIENT_ID}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
You need to give me or update this PR so that the azureSQL FQDN is added to a environment variable that umbraco uses. Currently it will be injected into the env var AZURE_SQL_FQDN. The auth against the database leverages azure workload identity to remove the need for passwords

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
