### PR TITLE
feat: add Elasticsearch search integration with indexing, search API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,5 @@ Frontend-old/
 # Wrangler
 .wrangler
 .wrangler/
+CLAUDE.md
+.claude/

--- a/Adapters/Infoportal.Adapters.Elasticsearch/ConfigureElasticsearchAdapter.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/ConfigureElasticsearchAdapter.cs
@@ -1,0 +1,18 @@
+using Infoportal.Adapters.Elasticsearch.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infoportal.Adapters.Elasticsearch;
+
+public static class ConfigureElasticsearchAdapter
+{
+    public static IServiceCollection AddElasticsearchAdapter(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<ElasticsearchOptions>(
+            configuration.GetSection(nameof(ElasticsearchOptions)));
+        services.AddSingleton<ElasticsearchClientFactory>();
+        services.AddScoped<ISearchService, ElasticsearchSearchService>();
+        return services;
+    }
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchClientFactory.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchClientFactory.cs
@@ -1,0 +1,30 @@
+using Elastic.Clients.Elasticsearch;
+using Elastic.Transport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infoportal.Adapters.Elasticsearch;
+
+public class ElasticsearchClientFactory
+{
+    private readonly ElasticsearchClient _client;
+
+    public ElasticsearchClientFactory(
+        IOptions<ElasticsearchOptions> options,
+        ILogger<ElasticsearchClientFactory> logger)
+    {
+        var settings = new ElasticsearchClientSettings(new Uri(options.Value.Url));
+
+        if (!string.IsNullOrEmpty(options.Value.ApiKey))
+        {
+            settings = settings.Authentication(new ApiKey(options.Value.ApiKey));
+        }
+
+        settings = settings.RequestTimeout(TimeSpan.FromSeconds(30));
+
+        _client = new ElasticsearchClient(settings);
+        logger.LogInformation("Elasticsearch client created for {Url}", options.Value.Url);
+    }
+
+    public ElasticsearchClient GetClient() => _client;
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchOptions.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchOptions.cs
@@ -1,0 +1,18 @@
+namespace Infoportal.Adapters.Elasticsearch;
+
+public class ElasticsearchOptions
+{
+    // TODO: In production, override Url and ApiKey via deployment.yaml env vars:
+    // ElasticsearchOptions__Url and ElasticsearchOptions__ApiKey (FluxCD substitution)
+    public string Url { get; set; } = "http://localhost:9200";
+    public string IndexPrefix { get; set; } = "infoportal";
+    public string? ApiKey { get; set; }
+    public int PageSize { get; set; } = 10;
+
+    public List<string> ExcludedProperties { get; set; } =
+    [
+        "umbracoUrlName",
+        "canonicalUrl",
+        "showInNavigation"
+    ];
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchOptions.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchOptions.cs
@@ -4,8 +4,8 @@ public class ElasticsearchOptions
 {
     // TODO: In production, override Url and ApiKey via deployment.yaml env vars:
     // ElasticsearchOptions__Url and ElasticsearchOptions__ApiKey (FluxCD substitution)
-    public string Url { get; set; } = "http://localhost:9200";
-    public string IndexPrefix { get; set; } = "infoportal";
+    public string Url { get; set; } = "";
+    public string IndexPrefix { get; set; } = "";
     public string? ApiKey { get; set; }
     public int PageSize { get; set; } = 10;
 

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Infoportal.Adapters.Elasticsearch.csproj
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Infoportal.Adapters.Elasticsearch.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.3.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+  </ItemGroup>
+
+</Project>

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchDocument.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchDocument.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace Infoportal.Adapters.Elasticsearch.Models;
+
+public class SearchDocument
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("contentId")]
+    public int ContentId { get; set; }
+
+    [JsonPropertyName("contentGuid")]
+    public Guid ContentGuid { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("ingress")]
+    public string Ingress { get; set; } = "";
+
+    [JsonPropertyName("body")]
+    public string Body { get; set; } = "";
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
+
+    [JsonPropertyName("contentType")]
+    public string ContentType { get; set; } = "";
+
+    [JsonPropertyName("culture")]
+    public string Culture { get; set; } = "";
+
+    [JsonPropertyName("publishDate")]
+    public DateTime? PublishDate { get; set; }
+
+    [JsonPropertyName("updateDate")]
+    public DateTime? UpdateDate { get; set; }
+
+    [JsonPropertyName("titleSuggest")]
+    public string[] TitleSuggest { get; set; } = [];
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchResultResponse.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchResultResponse.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace Infoportal.Adapters.Elasticsearch.Models;
+
+public class SearchResultResponse
+{
+    [JsonPropertyName("items")]
+    public List<SearchResultItem> Items { get; set; } = [];
+
+    [JsonPropertyName("totalResultCount")]
+    public int TotalResultCount { get; set; }
+
+    [JsonPropertyName("totalPages")]
+    public int TotalPages { get; set; }
+
+    [JsonPropertyName("currentPageNumber")]
+    public int CurrentPageNumber { get; set; }
+
+    // TODO: Spellcheck suggestion — when search returns 0 results, populate this with
+    // a corrected query term so the frontend can show "Mente du: <suggestionTerm>?"
+    // Optimizely returns this via SuggestionTerm when hits < SpellcheckHitsCutoff.
+    // [JsonPropertyName("suggestionTerm")]
+    // public string? SuggestionTerm { get; set; }
+}
+
+public class SearchResultItem
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = "";
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("ingress")]
+    public string Ingress { get; set; } = "";
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
+
+    [JsonPropertyName("contentGuid")]
+    public string ContentGuid { get; set; } = "";
+
+    [JsonPropertyName("score")]
+    public double Score { get; set; }
+
+    [JsonPropertyName("hitId")]
+    public string HitId { get; set; } = "";
+
+    [JsonPropertyName("trackId")]
+    public string TrackId { get; set; } = "";
+
+    [JsonPropertyName("isFallbackLanguage")]
+    public bool IsFallbackLanguage { get; set; }
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchSuggestionResponse.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchSuggestionResponse.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace Infoportal.Adapters.Elasticsearch.Models;
+
+public class SearchSuggestionResponse
+{
+    [JsonPropertyName("suggestions")]
+    public List<SearchSuggestionItem> Suggestions { get; set; } = [];
+
+    [JsonPropertyName("totalHits")]
+    public int TotalHits { get; set; }
+}
+
+public class SearchSuggestionItem
+{
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
@@ -235,7 +235,7 @@ public class ElasticsearchSearchService : ISearchService
             {
                 _logger.LogWarning(
                     "Search failed for query '{Query}': {Error}",
-                    query, searchResponse.DebugInformation);
+                    SanitizeForLog(query), searchResponse.DebugInformation);
                 return emptyResult;
             }
 
@@ -262,7 +262,7 @@ public class ElasticsearchSearchService : ISearchService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Search failed for query '{Query}'", query);
+            _logger.LogWarning(ex, "Search failed for query '{Query}'", SanitizeForLog(query));
             return emptyResult;
         }
     }
@@ -319,10 +319,13 @@ public class ElasticsearchSearchService : ISearchService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Suggestions failed for query '{Query}'", query);
+            _logger.LogWarning(ex, "Suggestions failed for query '{Query}'", SanitizeForLog(query));
             return emptyResult;
         }
     }
+
+    private static string SanitizeForLog(string? value) =>
+        value?.Replace("\r", " ").Replace("\n", " ") ?? "";
 
     private static SearchResultItem MapHitToResultItem(Hit<SearchDocument> hit)
     {

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
@@ -1,0 +1,354 @@
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Analysis;
+using Elastic.Clients.Elasticsearch.Core.Search;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Elastic.Clients.Elasticsearch.QueryDsl;
+using Infoportal.Adapters.Elasticsearch.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infoportal.Adapters.Elasticsearch.Services;
+
+public class ElasticsearchSearchService : ISearchService
+{
+    private readonly ElasticsearchClient _client;
+    private readonly ElasticsearchOptions _options;
+    private readonly ILogger<ElasticsearchSearchService> _logger;
+    private static readonly HashSet<string> _createdIndices = [];
+    private static readonly string[] SupportedCultures = ["nb", "nn", "en"];
+
+    // TODO: Configurable field weights — Optimizely stores these in XML (RelativeImportance.xml)
+    // with per-field weights for title, ingress, body, metaKeywords, metaDescription.
+    // Consider moving to appsettings.json or a separate config when fine-tuning is needed.
+    private static readonly Fields SearchFields = new[] { "title^3", "ingress^2", "body" };
+
+    public ElasticsearchSearchService(
+        ElasticsearchClientFactory clientFactory,
+        IOptions<ElasticsearchOptions> options,
+        ILogger<ElasticsearchSearchService> logger)
+    {
+        _client = clientFactory.GetClient();
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    private string GetIndexName(string culture) =>
+        $"{_options.IndexPrefix}-{culture.ToLowerInvariant()}";
+
+    private static string GetAnalyzerName(string culture) => culture switch
+    {
+        "nb" or "nn" => "norwegian",
+        "en" => "english",
+        _ => "standard"
+    };
+
+    public async Task EnsureIndexExistsAsync(string culture, CancellationToken ct = default)
+    {
+        var indexName = GetIndexName(culture);
+        if (_createdIndices.Contains(indexName))
+            return;
+
+        try
+        {
+            var existsResponse = await _client.Indices.ExistsAsync(indexName, ct);
+            if (existsResponse.Exists)
+            {
+                _createdIndices.Add(indexName);
+                return;
+            }
+
+            var analyzerName = GetAnalyzerName(culture);
+
+            var createResponse = await _client.Indices.CreateAsync(indexName, c => c
+                .Mappings(m => m
+                    .Properties(p => p
+                        .Keyword("id")
+                        .IntegerNumber("contentId")
+                        .Keyword("contentGuid")
+                        .Text("title", t => t.Analyzer(analyzerName))
+                        .Text("ingress", t => t.Analyzer(analyzerName))
+                        .Text("body", t => t.Analyzer(analyzerName))
+                        .Keyword("url")
+                        .Keyword("contentType")
+                        .Keyword("culture")
+                        .Date("publishDate")
+                        .Date("updateDate")
+                        .Completion("titleSuggest")
+                    )
+                ), ct);
+
+            if (createResponse.IsValidResponse)
+            {
+                _createdIndices.Add(indexName);
+                _logger.LogInformation("Created Elasticsearch index {IndexName}", indexName);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Failed to create index {IndexName}: {Error}",
+                    indexName, createResponse.DebugInformation);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not ensure index {IndexName} exists", indexName);
+        }
+    }
+
+    public async Task DeleteIndexAsync(string culture, CancellationToken ct = default)
+    {
+        var indexName = GetIndexName(culture);
+        try
+        {
+            var response = await _client.Indices.DeleteAsync(indexName, ct);
+            if (response.IsValidResponse)
+            {
+                _createdIndices.Remove(indexName);
+                _logger.LogInformation("Deleted Elasticsearch index {IndexName}", indexName);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete index {IndexName}", indexName);
+        }
+    }
+
+    public async Task IndexDocumentAsync(SearchDocument document, CancellationToken ct = default)
+    {
+        try
+        {
+            await EnsureIndexExistsAsync(document.Culture, ct);
+            var indexName = GetIndexName(document.Culture);
+
+            var response = await _client.IndexAsync(document, i => i
+                .Index(indexName)
+                .Id(document.Id), ct);
+
+            if (!response.IsValidResponse)
+            {
+                _logger.LogWarning(
+                    "Failed to index document {DocumentId}: {Error}",
+                    document.Id, response.DebugInformation);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to index document {DocumentId}", document.Id);
+        }
+    }
+
+    public async Task DeleteDocumentAsync(int contentId, string culture, CancellationToken ct = default)
+    {
+        try
+        {
+            var indexName = GetIndexName(culture);
+            var docId = $"{contentId}_{culture}";
+            var response = await _client.DeleteAsync(indexName, docId, ct);
+
+            if (!response.IsValidResponse && response.Result != Result.NotFound)
+            {
+                _logger.LogWarning(
+                    "Failed to delete document {DocumentId}: {Error}",
+                    docId, response.DebugInformation);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to delete document for content {ContentId}", contentId);
+        }
+    }
+
+    public async Task DeleteDocumentAllCulturesAsync(int contentId, CancellationToken ct = default)
+    {
+        foreach (var culture in SupportedCultures)
+        {
+            await DeleteDocumentAsync(contentId, culture, ct);
+        }
+    }
+
+    public async Task<SearchResultResponse> SearchAsync(
+        string query, string culture, int pageNumber, int pageSize,
+        string? context = null, CancellationToken ct = default)
+    {
+        var emptyResult = new SearchResultResponse { CurrentPageNumber = pageNumber };
+
+        try
+        {
+            var indexName = GetIndexName(culture);
+            var from = (pageNumber - 1) * pageSize;
+
+            var searchResponse = await _client.SearchAsync<SearchDocument>(s =>
+            {
+                s.Indices(indexName)
+                    .From(from)
+                    .Size(pageSize)
+                    .Highlight(h => h
+                        .AddField("title", new HighlightField { NumberOfFragments = 0 })
+                        .AddField("ingress", new HighlightField { NumberOfFragments = 1, FragmentSize = 200 })
+                    );
+
+                // TODO: Exact/quoted search — if query contains double quotes, disable fuzziness
+                // and stemming to match exact phrases. Optimizely uses Language.None + WithAndAsDefaultOperator.
+                // Example: if (query.Contains('"')) use TextQueryType.Phrase with no fuzziness.
+
+                // TODO: Per-pagetype score boosting — Optimizely applies configurable BoostMatching()
+                // per content type (e.g., themePage boost 1.5, newsArticlePage boost 1.2).
+                // Can be implemented with ES function_score query wrapping the multi_match.
+
+                // TODO: Freshness decay — Optimizely uses date decay to rank newer content higher.
+                // ES supports this via function_score with decay functions:
+                // .Functions(f => f.Exp(e => e.Field("publishDate").Decay(0.5).Scale("30d").Offset("7d")))
+
+                // TODO: Provider filtering — when SchemaPage content type exists, add:
+                // 1. "providers" parameter to SearchAsync() and ISearchService
+                // 2. "providerNames" keyword field on SearchDocument + index mapping
+                // 3. Terms filter: b.Filter(f => f.Terms(t => t.Field("providerNames").Terms(...)))
+                // 4. Terms aggregations on "contentType" and "providerNames" for facet counts
+                // Provider filtering applies only to schema pages, not article pages.
+
+                if (!string.IsNullOrEmpty(context) && context != "All")
+                {
+                    s.Query(q => q.Bool(b => b
+                        .Must(
+                            m => m.MultiMatch(mm => mm
+                                .Query(query)
+                                .Fields(SearchFields)
+                                .Type(TextQueryType.BestFields)
+                                .Fuzziness(new Fuzziness("AUTO"))
+                            ),
+                            m => m.Term(t => t.Field("contentType").Value(context))
+                        )
+                    ));
+                }
+                else
+                {
+                    s.Query(q => q.MultiMatch(mm => mm
+                        .Query(query)
+                        .Fields(SearchFields)
+                        .Type(TextQueryType.BestFields)
+                        .Fuzziness(new Fuzziness("AUTO"))
+                    ));
+                }
+            }, ct);
+
+            if (!searchResponse.IsValidResponse)
+            {
+                _logger.LogWarning(
+                    "Search failed for query '{Query}': {Error}",
+                    query, searchResponse.DebugInformation);
+                return emptyResult;
+            }
+
+            var totalHits = searchResponse.Total;
+
+            // TODO: Spellcheck / "did you mean" — when totalHits == 0, run a second query
+            // with ES suggest API (term suggester) to propose corrected spellings.
+            // Optimizely returns a SuggestionTerm when results < SpellcheckHitsCutoff (3).
+            // Return the suggestion in SearchResultResponse so the frontend can show
+            // "Fant ingen resultater. Mente du: <suggestion>?"
+
+            // TODO: Result caching — Optimizely caches results for 30 seconds.
+            // Consider IMemoryCache with a short TTL keyed on (query, culture, page, context).
+
+            return new SearchResultResponse
+            {
+                Items = searchResponse.Hits
+                    .Where(hit => hit.Source != null)
+                    .Select(hit => MapHitToResultItem(hit)).ToList(),
+                TotalResultCount = (int)totalHits,
+                TotalPages = (int)Math.Ceiling((double)totalHits / pageSize),
+                CurrentPageNumber = pageNumber
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Search failed for query '{Query}'", query);
+            return emptyResult;
+        }
+    }
+
+    public async Task<SearchSuggestionResponse> GetSuggestionsAsync(
+        string query, string culture, CancellationToken ct = default)
+    {
+        var emptyResult = new SearchSuggestionResponse();
+
+        try
+        {
+            var indexName = GetIndexName(culture);
+
+            var response = await _client.SearchAsync<SearchDocument>(s =>
+            {
+                s.Indices(indexName)
+                    .Size(0)
+                    .Suggest(su => su
+                        .Text(query)
+                        .Suggesters(sg => sg
+                            .Add("title-suggest", ts => ts
+                                .Completion(c => c
+                                    .Field("titleSuggest")
+                                    .Size(5)
+                                    .SkipDuplicates(true)
+                                    .Fuzzy(f => f.Fuzziness(new Fuzziness("AUTO")))
+                                )
+                            )
+                        )
+                    );
+            }, ct);
+
+            if (!response.IsValidResponse || response.Suggest == null)
+                return emptyResult;
+
+            var completions = response.Suggest.GetCompletion("title-suggest");
+            if (completions == null)
+                return emptyResult;
+
+            var items = completions
+                .SelectMany(c => c.Options)
+                .Select(o => new SearchSuggestionItem
+                {
+                    Title = o.Source?.Title ?? o.Text ?? "",
+                    Url = o.Source?.Url ?? ""
+                })
+                .ToList();
+
+            return new SearchSuggestionResponse
+            {
+                Suggestions = items,
+                TotalHits = items.Count
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Suggestions failed for query '{Query}'", query);
+            return emptyResult;
+        }
+    }
+
+    private static SearchResultItem MapHitToResultItem(Hit<SearchDocument> hit)
+    {
+        var source = hit.Source!;
+        var title = source.Title;
+        var ingress = source.Ingress;
+
+        if (hit.Highlight != null)
+        {
+            if (hit.Highlight.TryGetValue("title", out var titleHighlight))
+                title = string.Join(" ", titleHighlight);
+            if (hit.Highlight.TryGetValue("ingress", out var ingressHighlight))
+                ingress = string.Join(" ", ingressHighlight);
+        }
+
+        return new SearchResultItem
+        {
+            Type = source.ContentType,
+            Title = title,
+            Ingress = ingress,
+            Url = source.Url,
+            ContentGuid = source.ContentGuid.ToString(),
+            Score = hit.Score ?? 0,
+            HitId = hit.Id ?? "",
+            TrackId = hit.Id ?? "",
+            IsFallbackLanguage = false
+        };
+    }
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Services/ISearchService.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Services/ISearchService.cs
@@ -1,0 +1,21 @@
+using Infoportal.Adapters.Elasticsearch.Models;
+
+namespace Infoportal.Adapters.Elasticsearch.Services;
+
+public interface ISearchService
+{
+    Task EnsureIndexExistsAsync(string culture, CancellationToken ct = default);
+    Task DeleteIndexAsync(string culture, CancellationToken ct = default);
+    Task IndexDocumentAsync(SearchDocument document, CancellationToken ct = default);
+    Task DeleteDocumentAsync(int contentId, string culture, CancellationToken ct = default);
+    Task DeleteDocumentAllCulturesAsync(int contentId, CancellationToken ct = default);
+    Task<SearchResultResponse> SearchAsync(
+        string query, string culture, int pageNumber, int pageSize,
+        string? context = null, CancellationToken ct = default);
+    Task<SearchSuggestionResponse> GetSuggestionsAsync(
+        string query, string culture, CancellationToken ct = default);
+
+    // TODO: Click tracking — track which search results users click on to improve ranking
+    // Reference: Optimizely's TrackClick(query, hitId, trackId) + Statistics().TrackHit()
+    // void TrackClick(string query, string hitId, string trackId);
+}

--- a/umbraco-infoportal/Dockerfile
+++ b/umbraco-infoportal/Dockerfile
@@ -6,6 +6,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["umbraco-infoportal/umbraco-infoportal.csproj", "umbraco-infoportal/"]
+COPY ["Adapters/Infoportal.Adapters.Elasticsearch/Infoportal.Adapters.Elasticsearch.csproj", "Adapters/Infoportal.Adapters.Elasticsearch/"]
 RUN dotnet restore "umbraco-infoportal/umbraco-infoportal.csproj"
 COPY . .
 WORKDIR "/src/umbraco-infoportal"

--- a/umbraco-infoportal/README.md
+++ b/umbraco-infoportal/README.md
@@ -23,3 +23,17 @@ Once running, navigate to the default port indicated in your console output to v
 
 ## Database
 The project utilizes a local SQLite database by default, housed within the `umbraco/Data/` directory.
+
+## Elasticsearch (Search)
+
+Search is powered by Elasticsearch. For local development, run Elasticsearch in Docker:
+
+```
+docker run -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:9.0.1
+```
+
+After starting Umbraco, trigger a full reindex to populate the search index:
+
+```
+POST http://localhost:43450/api/search/reindex
+```

--- a/umbraco-infoportal/Search/ContentTextExtractor.cs
+++ b/umbraco-infoportal/Search/ContentTextExtractor.cs
@@ -1,0 +1,291 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Infoportal.Adapters.Elasticsearch;
+using Infoportal.Adapters.Elasticsearch.Models;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+
+namespace umbraco_infoportal.Search;
+
+public class ContentTextExtractor
+{
+    private readonly IContentTypeService _contentTypeService;
+    private readonly IDataTypeService _dataTypeService;
+    private readonly IUmbracoContextFactory _umbracoContextFactory;
+    private readonly ElasticsearchOptions _options;
+    private readonly ILogger<ContentTextExtractor> _logger;
+    private readonly Dictionary<Guid, string?> _editorAliasCache = new();
+    private static readonly Regex HtmlTagRegex = new(@"<[^>]+>", RegexOptions.Compiled);
+    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+    private static readonly Regex RteBlockRegex = new(
+        @"<umb-rte-block data-content-key=""(?<guid>[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})""></umb-rte-block>",
+        RegexOptions.Compiled);
+
+    // Content types to index. Add new page types here as they are created.
+    // TODO: Add schemaPage, helpQuestionPage, etc. when those content types exist.
+    // TODO: Consider moving this to a backoffice setting or a "hideFromSearch" composition
+    // property so admins can control which pages are indexed without code changes.
+    private static readonly HashSet<string> IndexableContentTypes =
+    [
+        "sectionArticlePage"
+    ];
+
+    private static readonly HashSet<string> TextEditors =
+    [
+        "Umbraco.TextBox",
+        "Umbraco.TextArea"
+    ];
+
+    public ContentTextExtractor(
+        IContentTypeService contentTypeService,
+        IDataTypeService dataTypeService,
+        IUmbracoContextFactory umbracoContextFactory,
+        IOptions<ElasticsearchOptions> options,
+        ILogger<ContentTextExtractor> logger)
+    {
+        _contentTypeService = contentTypeService;
+        _dataTypeService = dataTypeService;
+        _umbracoContextFactory = umbracoContextFactory;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public SearchDocument? ExtractDocument(IContent content, string culture)
+    {
+        if (content.Trashed)
+            return null;
+
+        var contentType = _contentTypeService.Get(content.ContentType.Id);
+        if (contentType == null)
+            return null;
+
+        if (!IndexableContentTypes.Contains(content.ContentType.Alias))
+            return null;
+
+        var textSegments = new List<string>();
+        string ingress = "";
+
+        foreach (var propertyType in contentType.PropertyTypes)
+        {
+            if (_options.ExcludedProperties.Contains(propertyType.Alias))
+                continue;
+
+            var editorAlias = GetEditorAlias(propertyType);
+            if (editorAlias == null)
+                continue;
+
+            var value = GetPropertyValue(content, propertyType, culture);
+            if (value == null)
+                continue;
+
+            var text = ExtractTextFromValue(value, editorAlias);
+            if (string.IsNullOrWhiteSpace(text))
+                continue;
+
+            textSegments.Add(text);
+
+            if (propertyType.Alias == "mainIntro" && string.IsNullOrEmpty(ingress))
+                ingress = text;
+        }
+
+        var title = content.GetCultureName(culture)
+            ?? content.Name
+            ?? "";
+
+        var url = GetContentUrl(content, culture) ?? "";
+
+        return new SearchDocument
+        {
+            Id = $"{content.Id}_{culture}",
+            ContentId = content.Id,
+            ContentGuid = content.Key,
+            Title = title,
+            TitleSuggest = string.IsNullOrWhiteSpace(title) ? [] : [title],
+            Ingress = ingress,
+            Body = string.Join(" ", textSegments),
+            Url = url,
+            ContentType = content.ContentType.Alias,
+            Culture = culture,
+            PublishDate = content.PublishDate,
+            UpdateDate = content.UpdateDate
+        };
+    }
+
+    private string? GetEditorAlias(IPropertyType propertyType)
+    {
+        if (_editorAliasCache.TryGetValue(propertyType.DataTypeKey, out var cached))
+            return cached;
+
+        var dataType = _dataTypeService.GetAsync(propertyType.DataTypeKey).GetAwaiter().GetResult();
+        var alias = dataType?.EditorAlias;
+        _editorAliasCache[propertyType.DataTypeKey] = alias;
+        return alias;
+    }
+
+    private static object? GetPropertyValue(IContent content, IPropertyType propertyType, string culture)
+    {
+        var isCultureVariant = propertyType.Variations.HasFlag(ContentVariation.Culture);
+        return isCultureVariant
+            ? content.GetValue(propertyType.Alias, culture)
+            : content.GetValue(propertyType.Alias);
+    }
+
+    private string ExtractTextFromValue(object value, string editorAlias)
+    {
+        if (TextEditors.Contains(editorAlias))
+            return value.ToString() ?? "";
+
+        if (editorAlias == "Umbraco.RichText")
+            return ExtractRichText(value.ToString());
+
+        if (editorAlias is "Umbraco.BlockList" or "Umbraco.BlockGrid")
+            return ExtractBlockListText(value.ToString());
+
+        return "";
+    }
+
+    private string ExtractRichText(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return "";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var markup = root.TryGetProperty("markup", out var markupElement)
+                ? markupElement.GetString() ?? ""
+                : "";
+
+            // Expand inline blocks referenced in the markup
+            markup = RteBlockRegex.Replace(markup, match =>
+            {
+                if (Guid.TryParse(match.Groups["guid"].Value, out var blockGuid)
+                    && root.TryGetProperty("blocks", out var blocks)
+                    && blocks.TryGetProperty("contentData", out var contentData))
+                {
+                    return ExtractBlockContentByGuid(contentData, blockGuid);
+                }
+                return "";
+            });
+
+            return StripHtml(markup);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse RichText JSON");
+            return StripHtml(json ?? "");
+        }
+    }
+
+    private string ExtractBlockContentByGuid(JsonElement contentData, Guid blockGuid)
+    {
+        if (contentData.ValueKind != JsonValueKind.Array)
+            return "";
+
+        foreach (var block in contentData.EnumerateArray())
+        {
+            if (block.TryGetProperty("key", out var keyProp)
+                && Guid.TryParse(keyProp.GetString(), out var key)
+                && key == blockGuid
+                && block.TryGetProperty("values", out var values))
+            {
+                return ExtractTextFromBlockValues(values);
+            }
+        }
+
+        return "";
+    }
+
+    private string ExtractTextFromBlockValues(JsonElement values)
+    {
+        var segments = new List<string>();
+
+        if (values.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var val in values.EnumerateArray())
+            {
+                if (val.TryGetProperty("value", out var valueProp))
+                {
+                    var text = valueProp.ValueKind == JsonValueKind.String
+                        ? StripHtml(valueProp.GetString() ?? "")
+                        : "";
+                    if (!string.IsNullOrWhiteSpace(text))
+                        segments.Add(text);
+                }
+            }
+        }
+
+        return string.Join(" ", segments);
+    }
+
+    private string ExtractBlockListText(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return "";
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("contentData", out var contentData)
+                && contentData.ValueKind == JsonValueKind.Array)
+            {
+                var segments = new List<string>();
+                foreach (var block in contentData.EnumerateArray())
+                {
+                    if (block.TryGetProperty("values", out var values))
+                    {
+                        var text = ExtractTextFromBlockValues(values);
+                        if (!string.IsNullOrWhiteSpace(text))
+                            segments.Add(text);
+                    }
+                }
+                return string.Join(" ", segments);
+            }
+
+            return "";
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse BlockList JSON");
+            return "";
+        }
+    }
+
+
+    private string? GetContentUrl(IContent content, string culture)
+    {
+        try
+        {
+            using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
+            var published = ctx.UmbracoContext.Content?.GetById(content.Id);
+            if (published != null)
+            {
+                return published.Url(culture, Umbraco.Cms.Core.Models.PublishedContent.UrlMode.Relative);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to resolve URL for content {ContentId}", content.Id);
+        }
+
+        return null;
+    }
+
+    private static string StripHtml(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return "";
+
+        var text = HtmlTagRegex.Replace(html, " ");
+        text = WebUtility.HtmlDecode(text);
+        text = WhitespaceRegex.Replace(text, " ").Trim();
+        return text;
+    }
+}

--- a/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
+++ b/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
@@ -21,6 +21,7 @@ public class ReindexApiController : ControllerBase
     }
 
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public IActionResult TriggerReindex()
     {
         if (!IsAuthorized())

--- a/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
+++ b/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Umbraco.Cms.Core;
+using umbraco_infoportal.Search.Jobs;
+
+namespace umbraco_infoportal.Search.Controllers;
+
+[ApiController]
+[Route("api/search/reindex")]
+public class ReindexApiController : ControllerBase
+{
+    private readonly ReindexBackgroundJob _job;
+    private readonly ILogger<ReindexApiController> _logger;
+
+    public ReindexApiController(
+        ReindexBackgroundJob job,
+        ILogger<ReindexApiController> logger)
+    {
+        _job = job;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    public IActionResult TriggerReindex()
+    {
+        if (!IsAuthorized())
+            return StatusCode(403, new { error = "Forbidden" });
+
+        if (ReindexBackgroundJob.IsRunning)
+            return Conflict(new { message = "Reindex already in progress" });
+
+        _ = Task.Run(() => _job.ExecuteReindexAsync(CancellationToken.None));
+
+        _logger.LogInformation("Manual reindex triggered");
+        return Accepted(new { message = "Reindex started" });
+    }
+
+    [HttpGet("status")]
+    public IActionResult GetStatus()
+    {
+        if (!IsAuthorized())
+            return StatusCode(403, new { error = "Forbidden" });
+
+        return Ok(new
+        {
+            status = ReindexBackgroundJob.Status,
+            isRunning = ReindexBackgroundJob.IsRunning,
+            totalItems = ReindexBackgroundJob.TotalItems,
+            processedItems = ReindexBackgroundJob.ProcessedItems,
+            percentComplete = ReindexBackgroundJob.TotalItems > 0
+                ? (int)(100.0 * ReindexBackgroundJob.ProcessedItems / ReindexBackgroundJob.TotalItems)
+                : 0
+        });
+    }
+
+    private bool IsAuthorized()
+    {
+        var remoteIp = HttpContext.Connection.RemoteIpAddress;
+        if (remoteIp != null && IPAddress.IsLoopback(remoteIp))
+            return true;
+
+        if (HttpContext.User.Identity?.IsAuthenticated != true)
+            return false;
+
+        return HttpContext.User.IsInRole(Constants.Security.AdminGroupAlias);
+    }
+}

--- a/umbraco-infoportal/Search/Controllers/SearchApiController.cs
+++ b/umbraco-infoportal/Search/Controllers/SearchApiController.cs
@@ -1,0 +1,87 @@
+using Infoportal.Adapters.Elasticsearch.Models;
+using Infoportal.Adapters.Elasticsearch.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace umbraco_infoportal.Search.Controllers;
+
+[ApiController]
+[Route("api/search/{language}")]
+public class SearchApiController : ControllerBase
+{
+    private readonly ISearchService _searchService;
+    private readonly ILogger<SearchApiController> _logger;
+
+    private const int DefaultPageSize = 10;
+    private const int MaxPageNumber = 100;
+    private const int MaxQueryLength = 200;
+    private static readonly HashSet<string> SupportedLanguages = ["nb", "nn", "en"];
+
+    public SearchApiController(
+        ISearchService searchService,
+        ILogger<SearchApiController> logger)
+    {
+        _searchService = searchService;
+        _logger = logger;
+    }
+
+    [HttpGet("page")]
+    public async Task<IActionResult> GetSearchPages(
+        [FromRoute] string language,
+        [FromQuery(Name = "q")] string? query,
+        [FromQuery(Name = "pagenumber")] int pageNumber = 1,
+        [FromQuery(Name = "context")] string? context = null,
+        CancellationToken ct = default)
+    {
+        if (!SupportedLanguages.Contains(language))
+            return BadRequest(new { error = $"Unsupported language: {language}" });
+
+        if (string.IsNullOrWhiteSpace(query))
+            return Ok(new SearchResultResponse { CurrentPageNumber = 1 });
+
+        query = SanitizeQuery(query);
+        pageNumber = Math.Clamp(pageNumber, 1, MaxPageNumber);
+
+        var result = await _searchService.SearchAsync(
+            query, language, pageNumber, DefaultPageSize, context, ct);
+
+        return Ok(result);
+    }
+
+    [HttpGet("suggestions")]
+    public async Task<IActionResult> GetSuggestions(
+        [FromRoute] string language,
+        [FromQuery(Name = "q")] string? query,
+        CancellationToken ct = default)
+    {
+        if (!SupportedLanguages.Contains(language))
+            return BadRequest(new { error = $"Unsupported language: {language}" });
+
+        if (string.IsNullOrWhiteSpace(query) || query.Length < 2)
+            return Ok(new SearchSuggestionResponse());
+
+        query = SanitizeQuery(query);
+
+        var result = await _searchService.GetSuggestionsAsync(query, language, ct);
+        return Ok(result);
+    }
+
+    // TODO: Click tracking endpoint — records which result a user clicked for ranking improvement.
+    // Optimizely has TrackClick(query, hitId, trackId) called from a GET /{language}/goto/{id}
+    // redirect endpoint that tracks the click before redirecting to the actual page URL.
+    // [HttpGet("goto/{id}")]
+    // public IActionResult GoToResult(string language, int id, string? query, string? hitId, string? trackId)
+    // {
+    //     if (!string.IsNullOrEmpty(query) && !string.IsNullOrEmpty(hitId))
+    //         _searchService.TrackClick(query, hitId, trackId);
+    //     var url = resolveContentUrl(id, language);
+    //     return Redirect(url);
+    // }
+
+    private static string SanitizeQuery(string query)
+    {
+        if (query.Length > MaxQueryLength)
+            query = query[..MaxQueryLength];
+
+        return query.Trim();
+    }
+}

--- a/umbraco-infoportal/Search/Jobs/ReindexBackgroundJob.cs
+++ b/umbraco-infoportal/Search/Jobs/ReindexBackgroundJob.cs
@@ -1,0 +1,132 @@
+using Infoportal.Adapters.Elasticsearch.Services;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+
+namespace umbraco_infoportal.Search.Jobs;
+
+public class ReindexBackgroundJob : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<ReindexBackgroundJob> _logger;
+
+    private static int _isRunning;
+    private static int _totalItems;
+    private static int _processedItems;
+    private static string _status = "idle";
+
+    private static readonly string[] Cultures = ["nb", "nn", "en"];
+
+    public static bool IsRunning => _isRunning == 1;
+    public static string Status => _status;
+    public static int TotalItems => _totalItems;
+    public static int ProcessedItems => _processedItems;
+
+    public ReindexBackgroundJob(
+        IServiceScopeFactory scopeFactory,
+        ILogger<ReindexBackgroundJob> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public async Task ExecuteReindexAsync(CancellationToken ct)
+    {
+        if (Interlocked.CompareExchange(ref _isRunning, 1, 0) != 0)
+            return;
+        _status = "running";
+        _processedItems = 0;
+        _totalItems = 0;
+
+        _logger.LogInformation("Full reindex started");
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var contentService = scope.ServiceProvider.GetRequiredService<IContentService>();
+            var searchService = scope.ServiceProvider.GetRequiredService<ISearchService>();
+            var extractor = scope.ServiceProvider.GetRequiredService<ContentTextExtractor>();
+
+            foreach (var culture in Cultures)
+            {
+                await searchService.DeleteIndexAsync(culture, ct);
+                await searchService.EnsureIndexExistsAsync(culture, ct);
+            }
+
+            var allContent = CollectAllPublishedContent(contentService);
+            _totalItems = allContent.Count;
+
+            _logger.LogInformation("Reindexing {TotalItems} content items", _totalItems);
+
+            foreach (var content in allContent)
+            {
+                foreach (var culture in Cultures)
+                {
+                    if (!content.PublishedCultures.Contains(culture))
+                        continue;
+
+                    try
+                    {
+                        var document = extractor.ExtractDocument(content, culture);
+                        if (document != null)
+                        {
+                            await searchService.IndexDocumentAsync(document, ct);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,
+                            "Reindex failed for content {ContentId} culture {Culture}",
+                            content.Id, culture);
+                    }
+                }
+
+                Interlocked.Increment(ref _processedItems);
+            }
+
+            _status = "completed";
+            _logger.LogInformation(
+                "Full reindex completed. {Processed}/{Total} items processed",
+                _processedItems, _totalItems);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Full reindex job failed");
+            _status = $"failed: {ex.Message}";
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _isRunning, 0);
+        }
+    }
+
+    private static List<IContent> CollectAllPublishedContent(IContentService contentService)
+    {
+        var result = new List<IContent>();
+        var rootContent = contentService.GetRootContent();
+
+        foreach (var root in rootContent)
+        {
+            CollectRecursive(contentService, root, result);
+        }
+
+        return result;
+    }
+
+    private static void CollectRecursive(
+        IContentService contentService, IContent content, List<IContent> result)
+    {
+        if (content.Published)
+        {
+            result.Add(content);
+        }
+
+        var children = contentService.GetPagedChildren(content.Id, 0, int.MaxValue, out _);
+        foreach (var child in children)
+        {
+            CollectRecursive(contentService, child, result);
+        }
+    }
+}

--- a/umbraco-infoportal/Search/Notifications/ContentPublishHandler.cs
+++ b/umbraco-infoportal/Search/Notifications/ContentPublishHandler.cs
@@ -1,0 +1,48 @@
+using Infoportal.Adapters.Elasticsearch.Services;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace umbraco_infoportal.Search.Notifications;
+
+public class ContentPublishHandler : INotificationHandler<ContentPublishedNotification>
+{
+    private readonly ISearchService _searchService;
+    private readonly ContentTextExtractor _extractor;
+    private readonly ILogger<ContentPublishHandler> _logger;
+
+    public ContentPublishHandler(
+        ISearchService searchService,
+        ContentTextExtractor extractor,
+        ILogger<ContentPublishHandler> logger)
+    {
+        _searchService = searchService;
+        _extractor = extractor;
+        _logger = logger;
+    }
+
+    public void Handle(ContentPublishedNotification notification)
+    {
+        foreach (var content in notification.PublishedEntities)
+        {
+            foreach (var culture in content.PublishedCultures)
+            {
+                try
+                {
+                    var document = _extractor.ExtractDocument(content, culture);
+                    if (document != null)
+                    {
+                        _searchService.IndexDocumentAsync(document).GetAwaiter().GetResult();
+                        _logger.LogInformation(
+                            "Indexed content {ContentId} ({Culture})", content.Id, culture);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to index content {ContentId} for culture {Culture}",
+                        content.Id, culture);
+                }
+            }
+        }
+    }
+}

--- a/umbraco-infoportal/Search/Notifications/ContentTrashHandler.cs
+++ b/umbraco-infoportal/Search/Notifications/ContentTrashHandler.cs
@@ -1,0 +1,40 @@
+using Infoportal.Adapters.Elasticsearch.Services;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace umbraco_infoportal.Search.Notifications;
+
+public class ContentTrashHandler : INotificationHandler<ContentMovedToRecycleBinNotification>
+{
+    private readonly ISearchService _searchService;
+    private readonly ILogger<ContentTrashHandler> _logger;
+
+    public ContentTrashHandler(
+        ISearchService searchService,
+        ILogger<ContentTrashHandler> logger)
+    {
+        _searchService = searchService;
+        _logger = logger;
+    }
+
+    public void Handle(ContentMovedToRecycleBinNotification notification)
+    {
+        foreach (var moveInfo in notification.MoveInfoCollection)
+        {
+            try
+            {
+                _searchService.DeleteDocumentAllCulturesAsync(moveInfo.Entity.Id)
+                    .GetAwaiter().GetResult();
+                _logger.LogInformation(
+                    "Removed trashed content {ContentId} from search index",
+                    moveInfo.Entity.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Failed to remove trashed content {ContentId} from search index",
+                    moveInfo.Entity.Id);
+            }
+        }
+    }
+}

--- a/umbraco-infoportal/Search/Notifications/ContentUnpublishHandler.cs
+++ b/umbraco-infoportal/Search/Notifications/ContentUnpublishHandler.cs
@@ -1,0 +1,37 @@
+using Infoportal.Adapters.Elasticsearch.Services;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+
+namespace umbraco_infoportal.Search.Notifications;
+
+public class ContentUnpublishHandler : INotificationHandler<ContentUnpublishedNotification>
+{
+    private readonly ISearchService _searchService;
+    private readonly ILogger<ContentUnpublishHandler> _logger;
+
+    public ContentUnpublishHandler(
+        ISearchService searchService,
+        ILogger<ContentUnpublishHandler> logger)
+    {
+        _searchService = searchService;
+        _logger = logger;
+    }
+
+    public void Handle(ContentUnpublishedNotification notification)
+    {
+        foreach (var content in notification.UnpublishedEntities)
+        {
+            try
+            {
+                _searchService.DeleteDocumentAllCulturesAsync(content.Id)
+                    .GetAwaiter().GetResult();
+                _logger.LogInformation("Removed content {ContentId} from search index", content.Id);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Failed to remove content {ContentId} from search index", content.Id);
+            }
+        }
+    }
+}

--- a/umbraco-infoportal/Search/SearchComposer.cs
+++ b/umbraco-infoportal/Search/SearchComposer.cs
@@ -1,0 +1,22 @@
+using Infoportal.Adapters.Elasticsearch;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Notifications;
+using umbraco_infoportal.Search.Jobs;
+using umbraco_infoportal.Search.Notifications;
+
+namespace umbraco_infoportal.Search;
+
+public class SearchComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddElasticsearchAdapter(builder.Config);
+        builder.Services.AddScoped<ContentTextExtractor>();
+        builder.Services.AddSingleton<ReindexBackgroundJob>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<ReindexBackgroundJob>());
+
+        builder.AddNotificationHandler<ContentPublishedNotification, ContentPublishHandler>();
+        builder.AddNotificationHandler<ContentUnpublishedNotification, ContentUnpublishHandler>();
+        builder.AddNotificationHandler<ContentMovedToRecycleBinNotification, ContentTrashHandler>();
+    }
+}

--- a/umbraco-infoportal/appsettings.json
+++ b/umbraco-infoportal/appsettings.json
@@ -32,5 +32,10 @@
         "AllowConcurrentLogins": false
       }
     }
+  },
+  "ElasticsearchOptions": {
+    "Url": "http://localhost:9200",
+    "IndexPrefix": "infoportal",
+    "ApiKey": ""
   }
 }

--- a/umbraco-infoportal/umbraco-infoportal.csproj
+++ b/umbraco-infoportal/umbraco-infoportal.csproj
@@ -21,6 +21,10 @@
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="72.1.0.3" Condition="$(RuntimeIdentifier.StartsWith('linux')) or $(RuntimeIdentifier.StartsWith('win')) or ('$(RuntimeIdentifier)' == '' and !$([MSBuild]::IsOSPlatform('osx')))" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Adapters\Infoportal.Adapters.Elasticsearch\Infoportal.Adapters.Elasticsearch.csproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- Razor files are needed for the backoffice to work correctly -->
     <CopyRazorGenerateFilesToPublishDirectory>true</CopyRazorGenerateFilesToPublishDirectory>

--- a/umbraco-infoportal/umbraco-infoportal.sln
+++ b/umbraco-infoportal/umbraco-infoportal.sln
@@ -1,22 +1,54 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "umbraco-infoportal", "umbraco-infoportal.csproj", "{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Adapters", "Adapters", "{09DF2EE5-5FE7-3EC7-59CB-CAD7E0928979}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infoportal.Adapters.Elasticsearch", "..\Adapters\Infoportal.Adapters.Elasticsearch\Infoportal.Adapters.Elasticsearch.csproj", "{78237625-338F-43EC-97A5-40BCA4AE7259}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Debug|x64.Build.0 = Debug|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Debug|x86.Build.0 = Debug|Any CPU
 		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Release|x64.ActiveCfg = Release|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Release|x64.Build.0 = Release|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Release|x86.ActiveCfg = Release|Any CPU
+		{85D47CFC-FA93-D03F-A3C2-816B53EC1A24}.Release|x86.Build.0 = Release|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Debug|x64.Build.0 = Debug|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Debug|x86.Build.0 = Debug|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Release|x64.ActiveCfg = Release|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Release|x64.Build.0 = Release|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Release|x86.ActiveCfg = Release|Any CPU
+		{78237625-338F-43EC-97A5-40BCA4AE7259}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{78237625-338F-43EC-97A5-40BCA4AE7259} = {09DF2EE5-5FE7-3EC7-59CB-CAD7E0928979}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0846C578-5E14-455C-8781-4E397A28697E}


### PR DESCRIPTION
## Summary

Adds Elasticsearch-based search and autocomplete to the Umbraco backend. Content is indexed on publish and searchable via REST API, proxied through the Astro frontend.

<!--- Provide a general summary of your changes in the Title above -->

## Description
- **Adapter layer** (`Adapters/Infoportal.Adapters.Elasticsearch/`): ES client factory, search service, document/response models. No Umbraco dependencies.
- **Umbraco layer** (`umbraco-infoportal/Search/`): Text extraction from content properties (TextBox, TextArea, RichText), notification handlers for publish/unpublish/trash, reindex background job, search + reindex API controllers.
- **Config** (`appsettings.json`): Elasticsearch section with URL, index prefix, excluded content types/properties.
- **Docs** (`umbraco-infoportal/README.md`): Added Elasticsearch section with Docker setup, reindex command, and API endpoints.

### Key features

- Per-language indices (`infoportal-nb`, `infoportal-nn`, `infoportal-en`) with Norwegian/English analyzers (stop words + stemming)
- Only whitelisted page types are indexed — currently `sectionArticlePage` only. New types (schemaPage, helpQuestionPage, etc.) are added to `IndexableContentTypes` in `ContentTextExtractor.cs` as they are created
- Autocomplete suggestions via ES completion suggester
- Full reindex endpoint with progress tracking (admin-only, localhost or admin role)
- Stale document purge on reindex (delete + recreate indices)
- Atomic reindex guard (prevents concurrent reindex runs)
- Page number cap at 100 (prevents exceeding ES `max_result_window`)
- Data type lookup cache for efficient text extraction during reindex


### Prerequisites
- Docker Desktop installed and running
- .NET 10 SDK

### 1. Start Elasticsearch in docker
```
docker run -d --name elasticsearch -p 9200:9200 -e "discovery.type=single-node" -e "xpack.security.enabled=false" docker.elastic.co/elasticsearch/elasticsearch:9.0.1
```

Verify: `http://localhost:9200`

### 2. Start Umbraco

Run .NET solution


### 3. Trigger reindex
```
POST http://localhost:43450/api/search/reindex

Status:
GET http://localhost:43450/api/search/reindex/status
```

### 5. Test search
```
GET http://localhost:43450/api/search/nb/page?q=skatt
GET http://localhost:43450/api/search/en/page?q=tax
GET http://localhost:43450/api/search/nn/page?q=skatt
```

### 6. Test suggestions
```
GET http://localhost:43450/api/search/nb/suggestions?q=ska
GET http://localhost:43450/api/search/en/suggestions?q=ta
GET http://localhost:43450/api/search/nn/suggestions?q=ska
```

### Future work (TODOs)
- Provider filtering for schema pages (providerNames field, terms filter, facet aggregations)
- Content type category grouping (Schema, StartCompany, Help) with facet counts
- Backoffice-controlled indexing (hideFromSearch composition or dashboard setting)
- Spellcheck / "did you mean" suggestions
- Per-pagetype score boosting
- Freshness decay (newer content ranked higher)
- Result caching

### Not yet tested
- Publishing a page in backoffice → verify it appears in search index
- Unpublishing a page → verify it is removed from search index
- Moving a page to recycle bin → verify it is removed from search index

## Related Issue(s)
- [#526](https://github.com/Altinn/altinn-infoportal-optimizely/issues/526)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
