### PR TITLE
Feat/al/add tar in container

### DIFF
--- a/umbraco-infoportal/Dockerfile
+++ b/umbraco-infoportal/Dockerfile
@@ -20,6 +20,5 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 
 RUN apt-get update && apt-get install -y tar && apt-get clean && rm -rf /var/lib/apt/lists/*
-ENV PATH="/usr/bin/tar:${PATH}"
 
 ENTRYPOINT ["dotnet", "umbraco-infoportal.dll"]

--- a/umbraco-infoportal/Dockerfile
+++ b/umbraco-infoportal/Dockerfile
@@ -20,5 +20,6 @@ WORKDIR /app
 COPY --from=publish /app/publish .
 
 RUN apt-get update && apt-get install -y tar && apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV PATH="/usr/bin/tar:${PATH}"
 
 ENTRYPOINT ["dotnet", "umbraco-infoportal.dll"]

--- a/umbraco-infoportal/Dockerfile
+++ b/umbraco-infoportal/Dockerfile
@@ -19,4 +19,6 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 
+RUN apt-get update && apt-get install -y tar && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["dotnet", "umbraco-infoportal.dll"]


### PR DESCRIPTION
Tar support is necessary for "kubectl cp" to work for copying files (f.ex. Sqlite file with updated data) to the pod.
