### PR TITLE
Fixed issues with English pages

### DIFF
--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -4,28 +4,21 @@ export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:43450';
 
 export async function fetchUmbracoContent(path: string) {
     // Uses Umbraco Content Delivery API pattern
-    const cleanPath = path.startsWith('/') ? path.slice(1) : path;
-    const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content/item/${cleanPath}`;
-    const headers: HeadersInit = {
-        'Accept-Language': 'nb', // Default to Norwegian
-    };
+    const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content/item/${path}`;
 
-  const response = await fetch(url, { headers });
+    const response = await fetch(url);
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch from Umbraco: ${response.statusText} ${url}`);
-  }
+    if (!response.ok) {
+      throw new Error(`Failed to fetch from Umbraco: ${response.statusText} ${url}`);
+    }
 
-  return await response.json();
+    return await response.json();
 }
 
-export async function fetchUmbracoChildren(id: string) {
-  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?fetch=children:${id}`;
-  const headers: HeadersInit = {
-    'Accept-Language': 'nb',
-  };
+export async function fetchUmbracoChildren(path: string) {
+  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?fetch=children:${path}`;
 
-  const response = await fetch(url, { headers });
+  const response = await fetch(url);
 
   if (!response.ok) {
     throw new Error(`Failed to fetch children from Umbraco: ${response.statusText} ${url}`);
@@ -35,8 +28,8 @@ export async function fetchUmbracoChildren(id: string) {
   return data.items ?? [];
 }
 
-export async function fetchUmbracoAncestors(id: string) {
-  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?fetch=ancestors:${id}`;
+export async function fetchUmbracoAncestors(path: string) {
+  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?fetch=ancestors:${path}`;
 
   const response = await fetch(url);
 

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -6,6 +6,7 @@ import { JSONTransformer } from '@transformers/JSONTransformer';
 
 const path = Astro.url.pathname;
 
+
 // Ignore internal Vite/framework paths
 if (
   path.startsWith('/@vite/') ||

--- a/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
+++ b/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
@@ -4,7 +4,7 @@ import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 
 export class HeroArticlePageBaseTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any): Promise<any> {
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.id);    
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);    
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);  
 
     return {

--- a/astro-infoportal/src/transformers/NewsArchivePageTransformer.ts
+++ b/astro-infoportal/src/transformers/NewsArchivePageTransformer.ts
@@ -6,7 +6,7 @@ export class NewsArchivePageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any): Promise<any> {
     const children = await fetchUmbracoChildren(cmsPageData.id);
  
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.id);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const newsArticles = 

--- a/astro-infoportal/src/transformers/ThemePageTransformer.ts
+++ b/astro-infoportal/src/transformers/ThemePageTransformer.ts
@@ -14,17 +14,17 @@ export class ThemePageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any): Promise<any> {
     const props = cmsPageData.properties ?? {};
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.id);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
-    const allChildren = await fetchUmbracoChildren(cmsPageData.id);
+    const allChildren = await fetchUmbracoChildren(cmsPageData.route.path);
     const children = allChildren.filter(
       (c: any) => c.properties?.showInNavigation !== false,
     );
 
     const themeGroups = await Promise.all(
       children.map(async (child: any) => {
-        const allChildPages = await fetchUmbracoChildren(child.id);
+        const allChildPages = await fetchUmbracoChildren(child.route.path);
         const childPages = allChildPages.filter(
           (c: any) => c.properties?.showInNavigation !== false,
         );


### PR DESCRIPTION
English pages was not showing when accessed with direct url.

Removed [local].astro as this one was picking the first part of the URL as locale. This is not correct for Bokmål pages. This value was not used for anything.

The topic page in English showed Bokmål sub-pages. This is fixed by using path instead of document id to look up subpages. The same change has been done for breadcrumbs.