### PR TITLE
Feat/al/page templates forms

### DIFF
--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
 
-export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:43450';
+export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:36990';
 
 export async function fetchUmbracoContent(path: string) {
     // Uses Umbraco Content Delivery API pattern

--- a/astro-infoportal/src/transformers/ProviderPageTransformer.ts
+++ b/astro-infoportal/src/transformers/ProviderPageTransformer.ts
@@ -1,0 +1,79 @@
+import type { IJSONTransformer } from "../IJSONTransformer";
+import { fetchUmbracoAncestors } from "../../../api/umbraco/client";
+import { BreadcrumbsTransformer } from "../../BreadcrumbsTransformer";
+
+export class ProviderPageTransformer implements IJSONTransformer {
+    public async Transform(cmsPageData:any): Promise<any> {
+        /* C# logic (TS-ish++):
+        const culture: CultureInfo.CurrentCulture.NormalizeCulture();
+                    const contentid: currentPage.ContentLink.ID;
+                    const showalleSchemasText: `{localizationService.GetStringByCulture(`/schema/showallschemas", culture)} {currentPage.PageName}";
+        
+                    const organization: ResolveOrganization(currentPage.ProviderAcronym, currentPage.ProviderOrgNr, currentPage.PageName, culture.Name);
+        
+                    const allproviders: schemaRelationsService.GetProviders(culture.Name);
+                    const currentproviderData: allProviders.FirstOrDefault(p: > p.id: = currentPage.ContentLink.ID);
+                    const schemas: currentProviderData?.List ?? [];
+        
+                    const operationalmessages: relationsDataProvider.GetMessages(currentPage, true);
+        
+                    return {
+                        pageName: currentPage.PageName,
+                        showAllSchemesLinKText: showAlleSchemasText,
+                        breadcrumb: breadcrumbViewModelBuilder.Build({ currentPage: currentPage }),
+                        mainIntro: richTextAreaPropsBuilder.Build({
+                            richTextArea: currentPage.MainIntro,
+                            propertyName: "currentPage.MainIntro"
+                        }),
+                        operationalMessages: operationalMessages.map(x: > operationalMessageViewModelBuilder.Build({ operationalMessageViewModel: x })),
+                        schemas: schemas.map(x: > {
+                            id: x.Id,
+                            title: x.Title,
+                            url: x.Url,
+                            providers: x.Providers.map(p: >
+                            {
+                                const org: ResolveOrganization(p.Acronym, p.OrgNr, p.Name, culture.Name);
+                                return {
+                                    name: p.Name,
+                                    imageUrl: org?.GetImageUrl(),
+                                    url: p.Url
+                                };
+                            })
+                        }),
+                        url: urlResolver.GetUrl(currentPage.ContentLink, culture.Name, { contextMode: ContextMode.Default }),
+                        providerIcon: {
+                            name: currentPage.PageName,
+                            imageUrl: organization?.GetImageUrl(),
+                            url: currentPage.LinkURL
+                        },
+                        contactInfo: BuildContactInfo(currentPage),
+                    }
+        */
+        const props = cmsPageData?.properties ?? {};
+        const ancestors = await fetchUmbracoAncestors(cmsPageData.id);
+        const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+        let bodyData = {
+            componentName: "ProviderPage",
+            pageName: cmsPageData?.name ?? null,
+            showAllSchemesLinKText: props?.showAllSchemesLinKText ?? null,
+            breadcrumb: breadcrumb,
+            mainIntro: props?.mainIntro ?? null,
+            operationalMessages: props?.operationalMessages ?? null,
+            schemas: props?.schemas ?? null,
+            url: props?.url ?? null,
+            providerIcon: props?.providerIcon ?? null,
+            contactInfo: props?.contactInfo ?? null,
+        };
+
+        return bodyData;
+    }
+}
+
+
+
+
+
+
+
+
+

--- a/astro-infoportal/src/transformers/SchemaOverviewPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaOverviewPageTransformer.ts
@@ -1,23 +1,47 @@
 import type { IJSONTransformer } from "./IJSONTransformer";
 import type { SchemaOverviewPageProps } from "@components/Pages/SchemaOverviewPage/SchemaOverviewPage.types";
+import { fetchUmbracoAncestors, fetchUmbracoChildren } from "../api/umbraco/client";
+import { BlockTransformer } from "./BlockTransformer";
+import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 
 export class SchemaOverviewPageTransformer implements IJSONTransformer {
-  public async Transform(cmsPageData: any): Promise<SchemaOverviewPageProps> {
+  public async Transform(cmsPageData: any): Promise<any> {
+    const props = cmsPageData.properties ?? {};    
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+
+    const providers = await fetchUmbracoChildren(cmsPageData.route.path);
+
+    const providerCollections = providers.map((item: any) => ({
+      // Fill in missing mapping here
+        }));
+
+    const categories = await fetchUmbracoChildren("7be52f06-4b7f-43e3-be3e-7871e56c27fc");
+
+    const schemaCategories = categories.map((item: any) => ({
+      // Fill in missing mapping here
+        }));    
+
+    const recommendedSchemas = props.recommendedSchemas.map((item: any) => ({
+          pageName: item.name,
+          url: item.route?.path,
+          componentName: "RecommendedSchema"
+        }));
+    
     return {
       componentName: "SchemaOverviewPage",
-      renderAlternateHeader: cmsPageData.properties.renderAlternateHeader || false,
-      title: cmsPageData.properties.title || undefined,
-      suggestions: cmsPageData.properties.suggestions || undefined,
-      breadcrumb: cmsPageData.properties.breadcrumb || undefined,
-      schemaCategories: cmsPageData.properties.schemaCategories || [],
-      providerCollections: cmsPageData.properties.providerCollections || [],
-      agencyText: cmsPageData.properties.agencyText || undefined,
-      servicesText: cmsPageData.properties.servicesText || undefined,
-      providersText: cmsPageData.properties.providersText || undefined,
-      recommendedSchemasHeaderText: cmsPageData.properties.recommendedSchemasHeaderText || undefined,
-      recommendedSchemas: cmsPageData.properties.recommendedSchemas || [],
-      initialTab: cmsPageData.properties.initialTab || undefined,
-      ...cmsPageData.properties,
+      renderAlternateHeader: props.renderAlternateHeader || false,
+      title: props.title || undefined,
+      suggestions: props.suggestions || undefined,
+      breadcrumb: breadcrumb,
+      schemaCategories: schemaCategories,
+      providerCollections: providerCollections,
+      agencyText: "Etater",
+      servicesText: "Alle tjenester",
+      providersText: "Alle etater",
+      recommendedSchemasHeaderText: "Aktuelle skjemaer og tjenester",
+      recommendedSchemas: recommendedSchemas,
+      initialTab: cmsPageData.properties.initialTab || undefined
     };
   }
 }

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -3,22 +3,41 @@ import type { SchemaPageProps } from "@components/Pages/SchemaPage/SchemaPage.ty
 
 export class SchemaPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any): Promise<SchemaPageProps> {
+    const props = cmsPageData.properties ?? {};    
+
+    const accordianList = {};
+    accordianList["items"]  = props.accordianList.map((item: any) => ({
+          translatedHeading: item.name,
+          description: item.description,
+          componentName: "SchemaAccordianBlock"
+        }));
+
+    const mainBody = {};    
+    
+    mainBody["items"]  = props.mainIntro.items.map((item: any) => ({
+          translatedHeading: item.name,
+          html: item.html,
+          componentName: "RichText"
+        }));
+
     return {
       componentName: "SchemaPage",
-      schemaCategory: cmsPageData.properties.schemaCategory || undefined,
-      schemaPageNameText: cmsPageData.properties.schemaPageNameText || undefined,
-      schemaCode: cmsPageData.properties.schemaCode || undefined,
-      attachmentText: cmsPageData.properties.attachmentText || undefined,
-      attachments: cmsPageData.properties.attachments || [],
-      schemaFromProviderText: cmsPageData.properties.schemaFromProviderText || undefined,
+      //schemaCategory: cmsPageData.properties.schemaCategory || undefined,
+      schemaPageNameText: cmsPageData.name,
+      schemaCode: props.schemaCode,
+      //attachmentText: cmsPageData.properties.attachmentText || undefined,
+      //attachments: cmsPageData.properties.attachments || [],
+      //schemaFromProviderText: cmsPageData.properties.schemaFromProviderText || undefined,
+      orangeMessage: props.orangeMessage,
       providerPages: cmsPageData.properties.providerPages || [],
       promoArea: cmsPageData.properties.promoArea || undefined,
       areThereMunicipalities: cmsPageData.properties.areThereMunicipalities || false,
       areThereCounties: cmsPageData.properties.areThereCounties || false,
-      subHeading: cmsPageData.properties.subHeading || undefined,
+      accordianList: accordianList,
+      mainBody: mainBody,
+      //subHeading: cmsPageData.properties.subHeading || undefined,
       deadline: cmsPageData.properties.deadline || undefined,
-      deadlineText: cmsPageData.properties.deadlineText || undefined,
-      ...cmsPageData.properties,
+      deadlineText: cmsPageData.properties.deadlineText || undefined
     };
   }
 }

--- a/umbraco-infoportal/ContentPickerConverter.cs
+++ b/umbraco-infoportal/ContentPickerConverter.cs
@@ -1,0 +1,92 @@
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Serialization;
+using uSync.Core.Extensions;
+
+
+// Injecting the IPublishedContentCache for fetching content from the Umbraco cache
+public class ContentPickerPropertyConverter : IPropertyValueConverter
+{
+    private readonly IJsonSerializer _json;
+    private readonly ILogger<ContentPickerPropertyConverter> _logger;
+
+    private readonly IPublishedContentCache _publishedContentCache;
+
+    public ContentPickerPropertyConverter(IJsonSerializer json, ILogger<ContentPickerPropertyConverter> logger, IPublishedContentCache publishedContentCache)
+    {
+        _json = json;
+        _logger = logger;
+        _publishedContentCache = publishedContentCache;
+    }
+
+    // Make sure the Property Value Converter only applies to the Content Picker property editor
+    public bool IsConverter(IPublishedPropertyType propertyType)
+        => propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.MultiNodeTreePicker) 
+        && "accordianList".Equals(propertyType.Alias);
+
+
+    public bool? IsValue(object? value, PropertyValueLevel level)
+    {
+        return level switch
+        {
+            PropertyValueLevel.Source => null,
+            PropertyValueLevel.Inter => null,
+            PropertyValueLevel.Object => value is JsonArray,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, $"Invalid level: {level}.")
+        };
+    }
+
+    public Type GetPropertyValueType(IPublishedPropertyType propertyType)
+        => typeof(JsonArray);
+
+    public PropertyCacheLevel GetPropertyCacheLevel(IPublishedPropertyType propertyType)
+        => PropertyCacheLevel.Elements;
+
+    public object? ConvertSourceToIntermediate(IPublishedElement owner, IPublishedPropertyType propertyType, 
+        object? source, bool preview)
+    {
+        return source;
+    }
+
+    public object? ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType,
+        PropertyCacheLevel referenceCacheLevel, object? inter, bool preview)
+    {
+        if (inter != null)
+        {
+            string[] uriStrings = inter.ToString().Split(",");
+            JsonArray items = [];
+
+
+            foreach (string uriString in uriStrings)
+            {
+                IPublishedContent content = _publishedContentCache.GetById(new GuidUdi(new Uri(uriString)).Guid);
+                if (content != null)
+                {
+                    JsonObject item = new JsonObject()
+                    {
+                        { "contentType", content.ContentType.Alias},
+                        { "name", content.Name }
+                    }; 
+
+                    foreach (IPublishedProperty property in content.Properties)
+                    {
+                        object value = property.GetDeliveryApiValue(true);
+                        item.Add(property.Alias, value.ConvertToJsonNode());
+                    }
+                    items.Add(item);
+                }
+            }
+
+            //return new JsonObject{{"items", items}};
+            return items;
+        }
+        else
+        {
+            return null;
+        }
+    }
+}
+

--- a/umbraco-infoportal/RichTextPropertyConverter.cs
+++ b/umbraco-infoportal/RichTextPropertyConverter.cs
@@ -23,7 +23,7 @@ public class RichTextPropertyConverter : IPropertyValueConverter
         _publishedContentCache = publishedContentCache;
     }
 
-    // Make sure the Property Value Converter only applies to the Content Picker property editor
+    // Make sure the Property Value Converter only applies to the RichText property editor
     public bool IsConverter(IPublishedPropertyType propertyType)
         => propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.RichText);
 
@@ -129,14 +129,17 @@ public class RichTextPropertyConverter : IPropertyValueConverter
 
                 IPublishedContent content = _publishedContentCache.GetById(new GuidUdi(uri).Guid);
                 
-                foreach (IPublishedProperty property in content.Properties)
+                if (content != null)
                 {
-                    object value = property.GetDeliveryApiValue(true);
+                    foreach (IPublishedProperty property in content.Properties)
+                    {
+                        object value = property.GetDeliveryApiValue(true);
 
-                    if (value is Boolean) {
-                        item.Add(property.Alias, (Boolean) value);    
-                    } else {
-                        item.Add(property.Alias, value.ConvertToJsonNode());    
+                        if (value is bool v) {
+                            item.Add(property.Alias, v);    
+                        } else {
+                            item.Add(property.Alias, value.ConvertToJsonNode());    
+                        }
                     }
                 }
                 return item;


### PR DESCRIPTION
I started the work on page templates, but it is far from complete.

After latest import, each page of type "schemaPage" in Umbraco do have a subfolder called "Sideblokker" with blocks.

I added a property converter in Umbraco to be able to render the rich text property from each of the blocks directly on the schemaPage content and adjusted the page template to demonstrate how to fetch this rich text.

I've also added some suggestion in schemaOverviewPage on how to retrieve categories to display on the page.