### PR TITLE
feat: add search page frontend with SSR, facets, and language support

### DIFF
--- a/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchResultResponse.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchResultResponse.cs
@@ -16,6 +16,12 @@ public class SearchResultResponse
     [JsonPropertyName("currentPageNumber")]
     public int CurrentPageNumber { get; set; }
 
+    [JsonPropertyName("pageTypeFacets")]
+    public List<FacetItem> PageTypeFacets { get; set; } = [];
+
+    [JsonPropertyName("providerFacets")]
+    public List<FacetItem> ProviderFacets { get; set; } = [];
+
     // TODO: Spellcheck suggestion — when search returns 0 results, populate this with
     // a corrected query term so the frontend can show "Mente du: <suggestionTerm>?"
     // Optimizely returns this via SuggestionTerm when hits < SpellcheckHitsCutoff.
@@ -51,4 +57,25 @@ public class SearchResultItem
 
     [JsonPropertyName("isFallbackLanguage")]
     public bool IsFallbackLanguage { get; set; }
+
+    [JsonPropertyName("parentContext")]
+    public ParentContext? ParentContext { get; set; }
+}
+
+public class ParentContext
+{
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+}
+
+public class FacetItem
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("value")]
+    public string Value { get; set; } = "";
+
+    [JsonPropertyName("count")]
+    public long Count { get; set; }
 }

--- a/Adapters/Infoportal.Adapters.Elasticsearch/SearchContextMapping.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/SearchContextMapping.cs
@@ -1,0 +1,80 @@
+namespace Infoportal.Adapters.Elasticsearch;
+
+public enum SearchContext
+{
+    All,
+    StartCompany,
+    Schema,
+    Help
+}
+
+public static class SearchContextMapping
+{
+    // Maps content type aliases to search contexts.
+    // When new content types are created in Umbraco, add them here.
+    private static readonly Dictionary<string, SearchContext> ContentTypeToContext = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "sectionArticlePage", SearchContext.StartCompany },
+        { "subsidyPage", SearchContext.StartCompany },
+        { "schemaPage", SearchContext.Schema },
+        { "schemaOverviewPage", SearchContext.Schema },
+        { "schemaAttachmentPage", SearchContext.Schema },
+        { "schemaCollectionPage", SearchContext.Schema },
+        { "helpQuestionPage", SearchContext.Help },
+        { "helpProcessArticlePage", SearchContext.Help },
+    };
+
+    // Reverse lookup: context → list of content type aliases
+    private static readonly Dictionary<string, string[]> ContextToContentTypes =
+        ContentTypeToContext
+            .GroupBy(kv => kv.Value)
+            .ToDictionary(
+                g => g.Key.ToString(),
+                g => g.Select(kv => kv.Key).ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns the content type aliases that belong to the given search context.
+    /// Returns null for "All" or unknown contexts (no filtering needed).
+    /// </summary>
+    public static string[]? GetContentTypesForContext(string? context)
+    {
+        if (string.IsNullOrEmpty(context) || context.Equals(nameof(SearchContext.All), StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return ContextToContentTypes.TryGetValue(context, out var types) ? types : null;
+    }
+
+    /// <summary>
+    /// Returns the search context for a given content type alias.
+    /// Returns null if the content type is not mapped to any context.
+    /// </summary>
+    public static string? GetContextForContentType(string contentTypeAlias)
+    {
+        return ContentTypeToContext.TryGetValue(contentTypeAlias, out var context)
+            ? context.ToString()
+            : null;
+    }
+
+    /// <summary>
+    /// Groups raw content type counts into search context counts.
+    /// Filters out contexts with zero results.
+    /// </summary>
+    public static Dictionary<string, long> GroupByContext(IEnumerable<KeyValuePair<string, long>> contentTypeCounts)
+    {
+        var contextCounts = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (contentType, count) in contentTypeCounts)
+        {
+            var context = GetContextForContentType(contentType);
+            if (context == null) continue;
+
+            if (contextCounts.ContainsKey(context))
+                contextCounts[context] += count;
+            else
+                contextCounts[context] = count;
+        }
+
+        return contextCounts;
+    }
+}

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
@@ -189,46 +189,37 @@ public class ElasticsearchSearchService : ISearchService
 
                 // TODO: Exact/quoted search — if query contains double quotes, disable fuzziness
                 // and stemming to match exact phrases. Optimizely uses Language.None + WithAndAsDefaultOperator.
-                // Example: if (query.Contains('"')) use TextQueryType.Phrase with no fuzziness.
 
                 // TODO: Per-pagetype score boosting — Optimizely applies configurable BoostMatching()
-                // per content type (e.g., themePage boost 1.5, newsArticlePage boost 1.2).
-                // Can be implemented with ES function_score query wrapping the multi_match.
+                // per content type. Can be implemented with ES function_score query.
 
-                // TODO: Freshness decay — Optimizely uses date decay to rank newer content higher.
-                // ES supports this via function_score with decay functions:
-                // .Functions(f => f.Exp(e => e.Field("publishDate").Decay(0.5).Scale("30d").Offset("7d")))
+                // TODO: Freshness decay — ES function_score with decay functions on publishDate.
 
-                // TODO: Provider filtering — when SchemaPage content type exists, add:
-                // 1. "providers" parameter to SearchAsync() and ISearchService
-                // 2. "providerNames" keyword field on SearchDocument + index mapping
-                // 3. Terms filter: b.Filter(f => f.Terms(t => t.Field("providerNames").Terms(...)))
-                // 4. Terms aggregations on "contentType" and "providerNames" for facet counts
-                // Provider filtering applies only to schema pages, not article pages.
+                // Base query: full-text match (aggregations run on this, unfiltered by context)
+                s.Query(q => q.MultiMatch(mm => mm
+                    .Query(query)
+                    .Fields(SearchFields)
+                    .Type(TextQueryType.BestFields)
+                    .Fuzziness(new Fuzziness("AUTO"))
+                ));
 
-                if (!string.IsNullOrEmpty(context) && context != "All")
+                // Context filter applied via post_filter so aggregations count across ALL contexts
+                var contextContentTypes = SearchContextMapping.GetContentTypesForContext(context);
+                if (contextContentTypes != null)
                 {
-                    s.Query(q => q.Bool(b => b
-                        .Must(
-                            m => m.MultiMatch(mm => mm
-                                .Query(query)
-                                .Fields(SearchFields)
-                                .Type(TextQueryType.BestFields)
-                                .Fuzziness(new Fuzziness("AUTO"))
-                            ),
-                            m => m.Term(t => t.Field("contentType").Value(context))
-                        )
+                    var fieldValues = contextContentTypes.Select(t => FieldValue.String(t)).ToList();
+                    s.PostFilter(f => f.Terms(t => t
+                        .Field("contentType")
+                        .Terms(new TermsQueryField(fieldValues))
                     ));
                 }
-                else
-                {
-                    s.Query(q => q.MultiMatch(mm => mm
-                        .Query(query)
-                        .Fields(SearchFields)
-                        .Type(TextQueryType.BestFields)
-                        .Fuzziness(new Fuzziness("AUTO"))
-                    ));
-                }
+
+                // Aggregations for facet counts
+                s.Aggregations(a => a
+                    .Add("contentTypeCounts", agg => agg
+                        .Terms(t => t.Field("contentType").Size(50))
+                    )
+                );
             }, ct);
 
             if (!searchResponse.IsValidResponse)
@@ -241,14 +232,11 @@ public class ElasticsearchSearchService : ISearchService
 
             var totalHits = searchResponse.Total;
 
-            // TODO: Spellcheck / "did you mean" — when totalHits == 0, run a second query
-            // with ES suggest API (term suggester) to propose corrected spellings.
-            // Optimizely returns a SuggestionTerm when results < SpellcheckHitsCutoff (3).
-            // Return the suggestion in SearchResultResponse so the frontend can show
-            // "Fant ingen resultater. Mente du: <suggestion>?"
+            // Build facet counts from aggregations
+            var pageTypeFacets = BuildPageTypeFacets(searchResponse);
 
-            // TODO: Result caching — Optimizely caches results for 30 seconds.
-            // Consider IMemoryCache with a short TTL keyed on (query, culture, page, context).
+            // TODO: Spellcheck / "did you mean" — when totalHits == 0, suggest corrected query.
+            // TODO: Result caching — IMemoryCache with short TTL.
 
             return new SearchResultResponse
             {
@@ -257,7 +245,8 @@ public class ElasticsearchSearchService : ISearchService
                     .Select(hit => MapHitToResultItem(hit)).ToList(),
                 TotalResultCount = (int)totalHits,
                 TotalPages = (int)Math.Ceiling((double)totalHits / pageSize),
-                CurrentPageNumber = pageNumber
+                CurrentPageNumber = pageNumber,
+                PageTypeFacets = pageTypeFacets,
             };
         }
         catch (Exception ex)
@@ -327,19 +316,76 @@ public class ElasticsearchSearchService : ISearchService
     private static string SanitizeForLog(string? value) =>
         value?.Replace("\r", " ").Replace("\n", " ") ?? "";
 
+    private static List<FacetItem> BuildPageTypeFacets(SearchResponse<SearchDocument> searchResponse)
+    {
+        var facets = new List<FacetItem>();
+
+        if (searchResponse.Aggregations == null)
+            return facets;
+
+        if (!searchResponse.Aggregations.TryGetValue("contentTypeCounts", out var agg))
+            return facets;
+
+        if (agg is not Elastic.Clients.Elasticsearch.Aggregations.StringTermsAggregate termsAgg)
+            return facets;
+
+        // Extract raw content type counts from ES buckets
+        var rawCounts = termsAgg.Buckets
+            .Select(b => new KeyValuePair<string, long>(b.Key.ToString(), b.DocCount))
+            .ToList();
+
+        // Group by search context (StartCompany, Schema, Help)
+        var contextCounts = SearchContextMapping.GroupByContext(rawCounts);
+
+        // Build facet list — only include contexts with results
+        foreach (var (contextName, count) in contextCounts)
+        {
+            if (count > 0)
+            {
+                facets.Add(new FacetItem
+                {
+                    Name = contextName,
+                    Value = contextName,
+                    Count = count
+                });
+            }
+        }
+
+        // Add "All" as the sum of all context counts (if any results exist)
+        var allCount = contextCounts.Values.Sum();
+        if (allCount > 0)
+        {
+            facets.Insert(0, new FacetItem
+            {
+                Name = nameof(SearchContext.All),
+                Value = nameof(SearchContext.All),
+                Count = allCount
+            });
+        }
+
+        return facets;
+    }
+
+    private static string StripEmTags(string text) =>
+        text.Replace("<em>", "").Replace("</em>", "");
+
     private static SearchResultItem MapHitToResultItem(Hit<SearchDocument> hit)
     {
         var source = hit.Source!;
         var title = source.Title;
         var ingress = source.Ingress;
 
+        // Use highlighted ingress from ES (frontend renders it as HTML).
+        // Strip <em> tags from title since the frontend highlights it client-side as plain text.
         if (hit.Highlight != null)
         {
             if (hit.Highlight.TryGetValue("title", out var titleHighlight))
-                title = string.Join(" ", titleHighlight);
+                title = StripEmTags(string.Join(" ", titleHighlight));
             if (hit.Highlight.TryGetValue("ingress", out var ingressHighlight))
                 ingress = string.Join(" ", ingressHighlight);
         }
+
+        var searchContext = SearchContextMapping.GetContextForContentType(source.ContentType);
 
         return new SearchResultItem
         {
@@ -351,7 +397,11 @@ public class ElasticsearchSearchService : ISearchService
             Score = hit.Score ?? 0,
             HitId = hit.Id ?? "",
             TrackId = hit.Id ?? "",
-            IsFallbackLanguage = false
+            IsFallbackLanguage = false,
+            ParentContext = searchContext != null ? new ParentContext
+            {
+                Value = searchContext
+            } : null
         };
     }
 }

--- a/astro-infoportal/src/Components/Layout/Header/handlers/headerHandlers.ts
+++ b/astro-infoportal/src/Components/Layout/Header/handlers/headerHandlers.ts
@@ -9,13 +9,43 @@ import { isBrowser } from "../utils/browserUtils";
  * @param menuLanguageList List of available languages
  * @returns Handler function for locale selection
  */
+// Search page slug mapping — search is the only static page with different slugs per language
+const searchSlugMap: Record<string, string> = {
+  nb: "/sok/",
+  nn: "/nn/sok/",
+  en: "/en/search/",
+};
+
+const searchSlugs = new Set(Object.values(searchSlugMap).flatMap(s => [s, s.replace(/\/$/, "")]));
+
+function getLanguageCode(langName: string): string {
+  const n = langName.toLowerCase();
+  if (n.includes("nynorsk") || n === "nn") return "nn";
+  if (n.includes("english") || n === "en") return "en";
+  return "nb";
+}
+
 export const createLocaleSelectHandler = (
   menuLanguageList: any[],
 ) => {
   return (value: string) => {
     if (!isBrowser) return;
     const selected = menuLanguageList.find((l: any) => l.languageName === value);
-    if (selected) location.assign(selected.pageUrl);
+    if (!selected) return;
+
+    const currentPath = location.pathname;
+    const langCode = getLanguageCode(selected.languageName);
+
+    // If on a search page, navigate to the search page in the target language
+    if (searchSlugs.has(currentPath)) {
+      location.assign(searchSlugMap[langCode] + location.search);
+      return;
+    }
+
+    // For Umbraco pages, use the pageUrl from the language list (provided by CMS)
+    if (selected.pageUrl) {
+      location.assign(selected.pageUrl);
+    }
   };
 };
 

--- a/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
+++ b/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
@@ -274,10 +274,29 @@ const useHeaderConfig = (
           };
         }),
         onSelect: (value: string) => {
+          if (!isBrowser) return;
           const lang = menuLanguageList.find((l: any) =>
             (l.languageCode || langCodeMap[l.languageName] || l.languageName) === value
           );
-          if (lang?.pageUrl && isBrowser) {
+          if (!lang) return;
+
+          // Search pages have different slugs per language — handle them explicitly
+          const searchSlugMap: Record<string, string> = {
+            nb: "/sok/",
+            nn: "/nn/sok/",
+            en: "/en/search/",
+          };
+          const searchSlugs = new Set(Object.values(searchSlugMap).flatMap(s => [s, s.replace(/\/$/, "")]));
+          const currentPath = window.location.pathname;
+          const targetLangCode = value;
+
+          if (searchSlugs.has(currentPath) && searchSlugMap[targetLangCode]) {
+            window.location.assign(searchSlugMap[targetLangCode]);
+            return;
+          }
+
+          // For Umbraco pages, use the CMS-provided pageUrl
+          if (lang.pageUrl) {
             window.location.assign(lang.pageUrl);
           }
         },

--- a/astro-infoportal/src/Components/Pages/SearchPage/SearchPage.tsx
+++ b/astro-infoportal/src/Components/Pages/SearchPage/SearchPage.tsx
@@ -1,6 +1,7 @@
 import {
   Divider,
   DsLink,
+  Heading,
   List,
   PageBase,
   SearchItem,
@@ -21,6 +22,7 @@ import SearchInput from "../../Shared/SearchInput/SearchInput";
 import "./SearchPage.scss";
 import { useEffect, useState } from "react";
 import type { SearchPageProps } from "./SearchPage.types";
+import { SearchContext, SearchContextIcons, SearchContextLabels } from "@constants/searchContext";
 
 const PAGE_SIZE = 10;
 
@@ -84,7 +86,8 @@ const SearchPage = ({
   loadingText,
   providerFilterText,
   searchPlaceholder,
-  searchAriaLabel
+  searchAriaLabel,
+  searchHeading
 }: SearchPageProps) => {
   const { maxPaginationButtons, isMobile } = useResponsivePagination();
   const safePageTypeFacets = Array.isArray(pageTypeFacets) ? pageTypeFacets : [];
@@ -143,11 +146,13 @@ const SearchPage = ({
     nextButtonProps,
     calculatedTotalPages,
     pageTypeLabelByValue,
+    livePageTypeFacets,
+    liveProviderFacets,
   } = useSearchPage({
     language: currentLanguage || "nb",
     query: currentQuery || "",
     initialPageNumber: searchResultViewModel?.currentPageNumber ?? 1,
-    currentContext: currentContext || "All",
+    currentContext: currentContext || SearchContext.All,
     providerFacets: safeProviderFacets,
     pageTypeFacets: safePageTypeFacets,
     initialResults: searchResultViewModel || undefined,
@@ -160,58 +165,62 @@ const SearchPage = ({
   const selectedContext = String(
     (filters.pagetypes ?? [])[0] ?? currentContext ?? "All",
   );
+  const hasProviders = (liveProviderFacets ?? safeProviderFacets).length > 0;
   const showProviderFilter =
-    selectedContext === "All" || selectedContext === "Schema";
+    hasProviders && (selectedContext === "All" || selectedContext === SearchContext.Schema);
 
   return (
     <PageBase className="search-page">
+      <Heading as="h2" size="xl">
+        {searchHeading || searchPlaceholder}
+      </Heading>
       <SearchInput
-        placeholder={(searchPlaceholder as any) || ""}
         searchPageUrl={isBrowser ? location.href : ""}
         value={searchValue}
         onChange={setSearchValue}
         onSubmit={handleSearchEnter}
         ariaLabel={searchAriaLabel}
+        autoFocus={!currentQuery}
       />
       {items && items.length > 0 && (
         <Toolbar
           filter={{
             filters: [
               {
+                id: "pagetypes",
                 label: categoriesText || "",
+                title: categoriesText || "",
                 name: "pagetypes",
-                items: safePageTypeFacets
-                  .filter((pt): pt is typeof pt & { name: string; value: string } =>
-                    pt.name != null && pt.value != null
-                  )
+                virtualized: true,
+                removable: false,
+                items: (livePageTypeFacets ?? safePageTypeFacets)
+                  .filter((pt: any) => pt.name != null && pt.value != null)
                   .map((pageType: any) => ({
-                    id: pageType.value,
-                    title: pageType.name,
+                    label: pageType.name,
+                    value: pageType.value,
+                    count: pageType.count,
                     role: "radio" as const,
                     name: "pagetypes",
-                    value: pageType.value,
-                    badge: { label: pageType.count },
                   })),
-                removable: false,
               },
               ...(showProviderFilter
                 ? [
                   {
+                    id: "providers",
                     label: providersText || "",
+                    title: providersText || "",
                     name: "providers",
-                    items: safeProviderFacets
-                      .filter((pf): pf is typeof pf & { name: string; value: string } =>
-                        pf.name != null && pf.value != null
-                      )
+                    searchable: true,
+                    removable: false,
+                    items: (liveProviderFacets ?? safeProviderFacets)
+                      .filter((pf: any) => pf.name != null && pf.value != null)
                       .map((provider: any) => ({
-                        id: provider.value,
-                        title: provider.name,
+                        label: provider.name,
+                        value: provider.value,
+                        count: provider.count,
                         role: "checkbox" as const,
                         name: "providers",
-                        value: provider.value,
-                        badge: { label: provider.count },
                       })),
-                    removable: false,
                   },
                 ]
                 : []),
@@ -221,18 +230,23 @@ const SearchPage = ({
               name: string,
               value: (string | number)[] | undefined,
             ) => {
-              if (!value || value.length === 0) return "";
+              if (!value?.length && name === "pagetypes")
+                return categoriesText || "";
+              if (!value?.length && name === "providers")
+                return providersText || "";
+
               if (name === "pagetypes") {
-                const v = String(value[0]);
+                const v = String(value?.[0]);
                 return pageTypeLabelByValue?.[v] ?? v;
               }
+
               if (name === "providers") {
-                if (value.length >= 3) {
-                  return `${value.length} ${providerFilterText}`;
+                if ((value?.length ?? 0) >= 3) {
+                  return `${value?.length} ${providerFilterText}`;
                 }
-                return (value as (string | number)[]).map(String).join(", ");
+                return value?.map(String).join(", ");
               }
-              return (value as (string | number)[]).map(String).join(", ");
+              return value?.map(String).join(", ");
             },
             onFilterStateChange: (newFilterState: FilterState) => {
               applyFilters(newFilterState);
@@ -251,7 +265,7 @@ const SearchPage = ({
           <Typography as="p">
             {errorText}
           </Typography>}
-        {hasNoResults &&
+        {hasNoResults && currentQuery &&
           <Typography as="p">
             {noResultsText + ''} <strong>{'"' + currentQuery + '"'}</strong>
           </Typography>}
@@ -298,11 +312,14 @@ const SearchPage = ({
                   )}
                 </>
               );
-            } else if (item.parentContext) {
-              const Icon = getIcon(item.parentContext.icon);
+            } else if (item.parentContext?.value) {
+              const contextValue = item.parentContext.value;
+              const iconName = SearchContextIcons[contextValue];
+              const Icon = getIcon(iconName);
+              const contextLabel = SearchContextLabels[currentLanguage || "nb"]?.[contextValue] ?? contextValue;
               if (Icon) {
                 const contextItem: IconItemsInlineItem = {
-                  label: item.parentContext.name,
+                  label: contextLabel,
                   icon: Icon,
                 };
                 summary = (

--- a/astro-infoportal/src/Components/Pages/SearchPage/SearchPage.types.ts
+++ b/astro-infoportal/src/Components/Pages/SearchPage/SearchPage.types.ts
@@ -18,4 +18,5 @@ export interface SearchPageProps {
   providerFilterText?: string;
   searchPlaceholder?: string;
   searchAriaLabel?: string;
+  searchHeading?: string;
 }

--- a/astro-infoportal/src/Components/Pages/SearchPage/SearchPageRoute.astro
+++ b/astro-infoportal/src/Components/Pages/SearchPage/SearchPageRoute.astro
@@ -1,0 +1,58 @@
+---
+import AstroSiteLayout from "@layouts/AstroSiteLayout.astro";
+import { UMBRACO_API_URL } from "@api/umbraco/client";
+import { JSONTransformer } from "@transformers/JSONTransformer";
+import { getGlobalData } from "@constants/globalData";
+import { SearchContext, SearchContextLabels } from "@constants/searchContext";
+import { SearchPageLabels } from "@constants/searchPageLabels";
+
+interface Props {
+  language: string;
+}
+
+const { language } = Astro.props;
+const contextLabels = SearchContextLabels[language];
+const pageLabels = SearchPageLabels[language];
+
+const query = Astro.url.searchParams.get("q") || "";
+const pageNumber = parseInt(Astro.url.searchParams.get("pagenumber") || "1", 10);
+const context = Astro.url.searchParams.get("context") || "";
+
+let searchResultViewModel = undefined;
+
+if (query) {
+  try {
+    const params = new URLSearchParams({ q: query, pagenumber: String(pageNumber) });
+    if (context) params.set("context", context);
+    const res = await fetch(`${UMBRACO_API_URL}/api/search/${language}/page?${params}`);
+    if (res.ok) {
+      searchResultViewModel = await res.json();
+    }
+  } catch (e) {
+    console.error("Failed to pre-fetch search results:", e);
+  }
+}
+
+const searchPageData = {
+  contentType: "searchPage",
+  properties: {
+    currentLanguage: language,
+    currentQuery: query,
+    currentContext: context || SearchContext.All,
+    searchResultViewModel,
+    pageTypeFacets: [
+      { name: contextLabels[SearchContext.All], value: SearchContext.All },
+      { name: contextLabels[SearchContext.StartCompany], value: SearchContext.StartCompany },
+      { name: contextLabels[SearchContext.Schema], value: SearchContext.Schema },
+      { name: contextLabels[SearchContext.Help], value: SearchContext.Help },
+    ],
+    providerFacets: [],
+    ...pageLabels,
+  },
+};
+
+const globalData = getGlobalData(pageLabels.searchPageUrl);
+const pageData = await new JSONTransformer().Transform(searchPageData, globalData);
+---
+
+<AstroSiteLayout pageData={pageData} htmlLanguage={pageLabels.htmlLanguage} title={pageLabels.title} />

--- a/astro-infoportal/src/Components/Shared/SearchInput/SearchInput.tsx
+++ b/astro-infoportal/src/Components/Shared/SearchInput/SearchInput.tsx
@@ -8,7 +8,7 @@ const isBrowser =
   typeof location !== "undefined" && typeof history !== "undefined";
 
 interface SearchInputProps {
-  placeholder: string;
+  placeholder?: string;
   searchPageUrl: string;
   initialValue?: string;
   value?: string;
@@ -17,6 +17,7 @@ interface SearchInputProps {
   name?: string;
   ariaLabel?: string;
   className?: string;
+  autoFocus?: boolean;
 }
 
 const SearchInput = ({
@@ -28,6 +29,7 @@ const SearchInput = ({
   onSubmit,
   ariaLabel,
   className,
+  autoFocus,
 }: SearchInputProps) => {
   const [internalQuery, setInternalQuery] = useState<string>(initialValue);
   const isDesktop = useIsDesktop();
@@ -82,6 +84,7 @@ const SearchInput = ({
           value={query}
           aria-label={ariaLabel || placeholder}
           className="search-input"
+          autoFocus={autoFocus}
         />
         <DsSearch.Clear />
         <DsSearch.Button

--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -1,0 +1,67 @@
+// TODO: Replace with real Umbraco global data when backend supports it.
+// This is shared between the catch-all route and static pages (e.g., search).
+
+export function getGlobalData(searchPageUrl = "/sok/") {
+  return {
+    headerViewModel: {
+      banner: {
+        message: {
+          items: [
+            {
+              html: "\u003cp\u003eVi fornyer Altinn.\u0026nbsp;\u003ca href=\u0022/nyheter/om-nye-altinn/\u0022 class=\u0022ds-link\u0022\u003eLes mer om hva som er nytt.\u003c/a\u003e\u003c/p\u003e",
+              componentName: "RichText",
+            },
+          ],
+          componentName: "RichTextArea",
+        },
+        isActive: true,
+        badgeText: "Beta",
+        colorTheme: "accent",
+        closeButtonText: "Lukk",
+        contentHash: "88628bb068b41760",
+        localStoragePrefix: "infoportal-banner-dismissed",
+        componentName: "BannerBlock",
+      },
+      startAndRunCompany: { text: "Starte og drive bedrift", url: "/starte-og-drive/" },
+      helpPage: { text: "Trenger du hjelp?", url: "/hjelp/" },
+      loginPage: { text: "Logg inn", url: "https://af.at23.altinn.cloud/" },
+      schemaOverviewPage: { text: "Alle skjema og tjenester", url: "/skjemaoversikt/" },
+      inboxPage: { text: "Innboks", url: "https://af.at23.altinn.cloud/" },
+      accessManagementPage: { text: "Tilgangsstyring", url: "https://am.ui.at23.altinn.cloud/accessmanagement/ui" },
+      profilePage: { text: "Din profil", url: "https://af.at23.altinn.cloud/profile" },
+      logOutPage: { text: "Logg ut", url: "https://platform.at23.altinn.cloud/authentication/api/v1/logout" },
+      aboutNewAltinnPage: { text: "Om nye altinn", url: "/nyheter/om-nye-altinn/" },
+      startPage: { text: "", url: "/" },
+      loggedInAsText: "Logget inn som",
+      backButtonText: "Tilbake",
+      chooseLanguageText: "Velg språk",
+      menuLanguageList: [
+        { pageUrl: "/starte-og-drive/", languageTeaser: "Alt innhold er tilgjengelig på bokmål.", languageImage: "/Static/img/no.svg", languageName: "Bokmål", selected: true },
+        { pageUrl: "/nn/starte-og-drive/", languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.", languageImage: "/Static/img/no.svg", languageName: "Nynorsk", selected: false },
+        { pageUrl: "/en/start-and-run-business/", languageTeaser: "Some content is available in English.", languageImage: "/Static/img/gb.svg", languageName: "English", selected: false },
+      ],
+      shortcutText: "Snarveier",
+      menuText: "Meny",
+      searchTextPlaceholder: "Søk i innhold",
+      searchPageUrl,
+      suggestionsTitle: "Utvalgte hurtiglenker",
+      useSearchSuggestions: false,
+      dateOfBirthText: "Fødslesnummer",
+      orgNrText: "Org. nr",
+      hostBaseUrl: "https://at23.altinn.cloud/",
+    },
+    footerViewModel: {
+      startAndRunCompany: { text: "Starte og drive bedrift", url: "/starte-og-drive/" },
+      helpPage: { text: "Hjelp og kontakt", url: "/hjelp/" },
+      address1: "Digitaliseringsdirektoratet,",
+      address2: "Postboks 1382 Vika, 0114 Oslo. Org.nr. 991 825 827",
+      aboutAltinnReference: { text: "Om Altinn", url: "/om-altinn/" },
+      operationalMessagesReference: { text: "Driftsmeldinger", url: "/om-altinn/driftsmeldinger/" },
+      privacyReference: { text: "Personvern", url: "/om-altinn/personvern/" },
+      accessibilityLocation: { text: "Tilgjengelighet", url: "/om-altinn/tilgjengelighet/" },
+      searchPageUrl,
+      searchUrlBody: searchPageUrl,
+    },
+    skipLinkText: "Hopp til hovedinnhold",
+  };
+}

--- a/astro-infoportal/src/Constants/searchContext.ts
+++ b/astro-infoportal/src/Constants/searchContext.ts
@@ -1,0 +1,36 @@
+export const SearchContext = {
+  All: "All",
+  StartCompany: "StartCompany",
+  Schema: "Schema",
+  Help: "Help",
+} as const;
+
+export type SearchContextType = (typeof SearchContext)[keyof typeof SearchContext];
+
+// Icon mapping per context — resolved from @navikt/aksel-icons by name
+export const SearchContextIcons: Record<string, string | undefined> = {
+  [SearchContext.StartCompany]: "Buildings3Icon",
+  [SearchContext.Help]: "InformationSquareIcon",
+};
+
+// Display names per language
+export const SearchContextLabels: Record<string, Record<string, string>> = {
+  nb: {
+    [SearchContext.All]: "Alt innhold",
+    [SearchContext.StartCompany]: "Starte og drive bedrift",
+    [SearchContext.Schema]: "Skjema",
+    [SearchContext.Help]: "Hjelp",
+  },
+  nn: {
+    [SearchContext.All]: "Alt innhald",
+    [SearchContext.StartCompany]: "Starte og drive bedrift",
+    [SearchContext.Schema]: "Skjema",
+    [SearchContext.Help]: "Hjelp",
+  },
+  en: {
+    [SearchContext.All]: "All content",
+    [SearchContext.StartCompany]: "Start and run company",
+    [SearchContext.Schema]: "Forms",
+    [SearchContext.Help]: "Help",
+  },
+};

--- a/astro-infoportal/src/Constants/searchPageLabels.ts
+++ b/astro-infoportal/src/Constants/searchPageLabels.ts
@@ -1,0 +1,65 @@
+export const SearchPageLabels: Record<string, {
+  categoriesText: string;
+  providersText: string;
+  noResultsText: string;
+  errorText: string;
+  lastPageText: string;
+  nextPageText: string;
+  loadingText: string;
+  providerFilterText: string;
+  searchPlaceholder: string;
+  searchAriaLabel: string;
+  searchHeading: string;
+  title: string;
+  searchPageUrl: string;
+  htmlLanguage: string;
+}> = {
+  nb: {
+    categoriesText: "Kategorier",
+    providersText: "Leverandører",
+    noResultsText: "Ingen resultater funnet",
+    errorText: "Noe gikk galt. Prøv igjen senere.",
+    lastPageText: "Forrige",
+    nextPageText: "Neste",
+    loadingText: "Laster...",
+    providerFilterText: "Filtrer på leverandør",
+    searchPlaceholder: "Søk i innhold",
+    searchAriaLabel: "Søk",
+    searchHeading: "Søk på altinn.no",
+    title: "Søk – Altinn",
+    searchPageUrl: "/sok/",
+    htmlLanguage: "nb",
+  },
+  nn: {
+    categoriesText: "Kategoriar",
+    providersText: "Leverandørar",
+    noResultsText: "Ingen resultat funne",
+    errorText: "Noko gjekk gale. Prøv igjen seinare.",
+    lastPageText: "Førre",
+    nextPageText: "Neste",
+    loadingText: "Lastar...",
+    providerFilterText: "Filtrer på leverandør",
+    searchPlaceholder: "Søk i innhald",
+    searchAriaLabel: "Søk",
+    searchHeading: "Søk på altinn.no",
+    title: "Søk – Altinn",
+    searchPageUrl: "/nn/sok/",
+    htmlLanguage: "nn",
+  },
+  en: {
+    categoriesText: "Categories",
+    providersText: "Providers",
+    noResultsText: "No results found",
+    errorText: "Something went wrong. Please try again later.",
+    lastPageText: "Previous",
+    nextPageText: "Next",
+    loadingText: "Loading...",
+    providerFilterText: "Filter by provider",
+    searchPlaceholder: "Search content",
+    searchAriaLabel: "Search",
+    searchHeading: "Search on altinn.no",
+    title: "Search – Altinn",
+    searchPageUrl: "/en/search/",
+    htmlLanguage: "en",
+  },
+};

--- a/astro-infoportal/src/Services/Hooks/UseSearch.ts
+++ b/astro-infoportal/src/Services/Hooks/UseSearch.ts
@@ -2,6 +2,7 @@ import type { FilterState } from "@altinn/altinn-components";
 import { usePagination } from "@digdir/designsystemet-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { createSearchApi } from "../API/SearchClient";
+import { SearchContext } from "@constants/searchContext";
 
 type BrowserQueryState = {
   query?: string;
@@ -56,6 +57,8 @@ export type UseSearchPageReturn = {
   nextButtonProps: UsePaginationReturn["nextButtonProps"];
   providerLabelByValue?: Record<string, string>;
   pageTypeLabelByValue?: Record<string, string>;
+  livePageTypeFacets: any[];
+  liveProviderFacets: any[];
 };
 
 export function useSearchPage(
@@ -91,8 +94,26 @@ export function useSearchPage(
   );
   const [filters, setFilters] = useState<FilterState>(() => ({
     providers: [],
-    pagetypes: [currentContext || "All"],
+    pagetypes: [currentContext || SearchContext.All],
   }));
+
+  // Live facets updated from API response, merged with static labels
+  const mergeFacets = (staticFacets: any[], apiFacets: any[]) => {
+    if (!apiFacets?.length) return staticFacets;
+    return staticFacets
+      .map((f: any) => {
+        const live = apiFacets.find((a: any) => a.value === f.value);
+        return { ...f, count: live?.count ?? 0 };
+      })
+      .filter((f: any) => f.value === SearchContext.All || f.count > 0);
+  };
+
+  const [livePageTypeFacets, setLivePageTypeFacets] = useState<any[]>(
+    () => mergeFacets(pageTypeFacets, initialResults?.pageTypeFacets),
+  );
+  const [liveProviderFacets, setLiveProviderFacets] = useState<any[]>(
+    () => initialResults?.providerFacets ?? providerFacets,
+  );
 
   const selectedProviders = (filters.providers ?? []) as string[];
   const totalItems =
@@ -116,8 +137,8 @@ export function useSearchPage(
 
   const pageTypeLabelByValue = useMemo(
     () =>
-      Object.fromEntries((pageTypeFacets ?? []).map((f: any) => [f.value, f.name])),
-    [pageTypeFacets],
+      Object.fromEntries((livePageTypeFacets ?? pageTypeFacets ?? []).map((f: any) => [f.value, f.name])),
+    [livePageTypeFacets, pageTypeFacets],
   );
 
   const writeUrl = useCallback((q: string, context?: string) => {
@@ -162,6 +183,14 @@ export function useSearchPage(
           setTotalResultCount(0);
           setHasNoResults(true);
         }
+
+        // Update live facet counts from API response
+        if (result?.pageTypeFacets) {
+          setLivePageTypeFacets(mergeFacets(pageTypeFacets, result.pageTypeFacets));
+        }
+        if (result?.providerFacets) {
+          setLiveProviderFacets(result.providerFacets);
+        }
       } catch (err: any) {
         if (err?.name === "AbortError") return;
         // eslint-disable-next-line no-console
@@ -200,7 +229,7 @@ export function useSearchPage(
         const prevPageType = String((prev?.pagetypes ?? [])[0] ?? "");
         writeUrl(query, pageType || currentContext);
 
-        if (pageType !== prevPageType && pageType === "All") {
+        if (pageType !== prevPageType && pageType === SearchContext.All) {
           if (isBrowser) location.reload();
           return merged;
         }
@@ -227,5 +256,7 @@ export function useSearchPage(
     prevButtonProps,
     nextButtonProps,
     pageTypeLabelByValue,
+    livePageTypeFacets,
+    liveProviderFacets,
   };
 }

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -3,6 +3,7 @@
 import { fetchUmbracoContent } from '@api/umbraco/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
+import { getGlobalData } from '@constants/globalData';
 
 const path = Astro.url.pathname;
 
@@ -23,69 +24,7 @@ if (path.startsWith('/api/') || path.match(/\.[a-zA-Z0-9]+$/)) {
 
 let umbracoPageData: any = null;
 
-// TODO: Replace with real Umbraco global data when backend supports it
-let globalData: any = {
-  headerViewModel: {
-    banner: {
-      message: {
-        items: [
-          {
-            html: "\u003cp\u003eVi fornyer Altinn.\u0026nbsp;\u003ca href=\u0022/nyheter/om-nye-altinn/\u0022 class=\u0022ds-link\u0022\u003eLes mer om hva som er nytt.\u003c/a\u003e\u003c/p\u003e",
-            componentName: "RichText",
-          },
-        ],
-        componentName: "RichTextArea",
-      },
-      isActive: true,
-      badgeText: "Beta",
-      colorTheme: "accent",
-      closeButtonText: "Lukk",
-      contentHash: "88628bb068b41760",
-      localStoragePrefix: "infoportal-banner-dismissed",
-      componentName: "BannerBlock",
-    },
-    startAndRunCompany: { text: "Starte og drive bedrift", url: "/starte-og-drive/" },
-    helpPage: { text: "Trenger du hjelp?", url: "/hjelp/" },
-    loginPage: { text: "Logg inn", url: "https://af.at23.altinn.cloud/" },
-    schemaOverviewPage: { text: "Alle skjema og tjenester", url: "/skjemaoversikt/" },
-    inboxPage: { text: "Innboks", url: "https://af.at23.altinn.cloud/" },
-    accessManagementPage: { text: "Tilgangsstyring", url: "https://am.ui.at23.altinn.cloud/accessmanagement/ui" },
-    profilePage: { text: "Din profil", url: "https://af.at23.altinn.cloud/profile" },
-    logOutPage: { text: "Logg ut", url: "https://platform.at23.altinn.cloud/authentication/api/v1/logout" },
-    aboutNewAltinnPage: { text: "Om nye altinn", url: "/nyheter/om-nye-altinn/" },
-    startPage: { text: "", url: "/" },
-    loggedInAsText: "Logget inn som",
-    backButtonText: "Tilbake",
-    chooseLanguageText: "Velg språk",
-    menuLanguageList: [
-      { pageUrl: "/starte-og-drive/", languageTeaser: "Alt innhold er tilgjengelig på bokmål.", languageImage: "/Static/img/no.svg", languageName: "Bokmål", selected: true },
-      { pageUrl: "/nn/starte-og-drive/", languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.", languageImage: "/Static/img/no.svg", languageName: "Nynorsk", selected: false },
-      { pageUrl: "/en/start-and-run-business/", languageTeaser: "Some content is available in English.", languageImage: "/Static/img/gb.svg", languageName: "English", selected: false },
-    ],
-    shortcutText: "Snarveier",
-    menuText: "Meny",
-    searchTextPlaceholder: "Søk i innhold",
-    searchPageUrl: "/sok/",
-    suggestionsTitle: "Utvalgte hurtiglenker",
-    useSearchSuggestions: false,
-    dateOfBirthText: "Fødslesnummer",
-    orgNrText: "Org. nr",
-    hostBaseUrl: "https://at23.altinn.cloud/",
-  },
-  footerViewModel: {
-    startAndRunCompany: { text: "Starte og drive bedrift", url: "/starte-og-drive/" },
-    helpPage: { text: "Hjelp og kontakt", url: "/hjelp/" },
-    address1: "Digitaliseringsdirektoratet,",
-    address2: "Postboks 1382 Vika, 0114 Oslo. Org.nr. 991 825 827",
-    aboutAltinnReference: { text: "Om Altinn", url: "/om-altinn/" },
-    operationalMessagesReference: { text: "Driftsmeldinger", url: "/om-altinn/driftsmeldinger/" },
-    privacyReference: { text: "Personvern", url: "/om-altinn/personvern/" },
-    accessibilityLocation: { text: "Tilgjengelighet", url: "/om-altinn/tilgjengelighet/" },
-    searchPageUrl: "/sok/",
-    searchUrlBody: "/sok/",
-  },
-  skipLinkText: "Hopp til hovedinnhold",
-};
+let globalData: any = getGlobalData();
 
 const [pageResult] = await Promise.allSettled([
   fetchUmbracoContent(path),

--- a/astro-infoportal/src/pages/en/search.astro
+++ b/astro-infoportal/src/pages/en/search.astro
@@ -1,0 +1,5 @@
+---
+import SearchPageRoute from "@components/Pages/SearchPage/SearchPageRoute.astro";
+---
+
+<SearchPageRoute language="en" />

--- a/astro-infoportal/src/pages/nn/sok.astro
+++ b/astro-infoportal/src/pages/nn/sok.astro
@@ -1,0 +1,5 @@
+---
+import SearchPageRoute from "@components/Pages/SearchPage/SearchPageRoute.astro";
+---
+
+<SearchPageRoute language="nn" />

--- a/astro-infoportal/src/pages/sok.astro
+++ b/astro-infoportal/src/pages/sok.astro
@@ -1,0 +1,5 @@
+---
+import SearchPageRoute from "@components/Pages/SearchPage/SearchPageRoute.astro";
+---
+
+<SearchPageRoute language="nb" />

--- a/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
+++ b/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
@@ -21,7 +21,8 @@ public class ReindexApiController : ControllerBase
     }
 
     [HttpPost]
-    [ValidateAntiForgeryToken]
+    // TODO: Re-enable [ValidateAntiForgeryToken] when called from Umbraco backoffice UI. 
+    // This needs to be disabled for now to allow trigger locally.
     public IActionResult TriggerReindex()
     {
         if (!IsAuthorized())


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Static Astro search pages for nb (/sok), nn (/nn/sok), en (/en/search)
- Shared SearchPageRoute.astro with i18n labels from constants
- SSR pre-fetch of search results from Elasticsearch backend
- Live facet counts via ES aggregations grouped by search context
- SearchContext enum and mapping on backend and frontend
- ParentContext icons (Buildings3Icon, InformationSquareIcon) per result
- Language switcher: custom handler for search pages since they are not Umbraco CMS pages and have different slugs per language
- Extract globalData into shared constants file

## Related Issue(s)
https://github.com/Altinn/altinn-infoportal-optimizely/issues/532

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
