### PR TITLE
fix: correct tsconfig path alias casing for Linux compatibility

### DIFF
--- a/astro-infoportal/tsconfig.json
+++ b/astro-infoportal/tsconfig.json
@@ -13,7 +13,7 @@
         "*"
       ],
       "@components/*": [
-        "components/*"
+        "Components/*"
       ],
       "@layouts/*": [
         "layouts/*"
@@ -31,13 +31,13 @@
         "api/*"
       ],
       "@constants/*": [
-        "constants/*"
+        "Constants/*"
       ],
       "@services/*": [
-        "services/*"
+        "Services/*"
       ],
       "@models/*": [
-        "models/*"
+        "Models/*"
       ],
       "@transformers/*": [
         "transformers/*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The path aliases @components, @constants, @services, @models mapped to lowercase directories but the actual directories are PascalCase. This broke Rollup resolution oncase-sensitive Linux filesystems.        

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
