### PR TITLE
feat: Add infoportal media storage account for AT22

### DIFF
--- a/.github/workflows/infoportal-media-sa-at22.yml
+++ b/.github/workflows/infoportal-media-sa-at22.yml
@@ -1,0 +1,88 @@
+name: infoportal-media-sa-at22 deploy
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/infoportal-media-sa-at22.yml
+      - infrastructure/altinn-portaler-test/infoportal-media-sa-at22/**
+      - infrastructure/modules/infoportal-media-sa/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/infoportal-media-sa-at22.yml
+      - infrastructure/altinn-portaler-test/infoportal-media-sa-at22/**
+      - infrastructure/modules/infoportal-media-sa/**
+  workflow_dispatch:
+    inputs:
+      log_level:
+        required: true
+        description: Terraform Log Level
+        default: ERROR
+        type: choice
+        options:
+          - TRACE
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+
+env:
+  TF_STATE_NAME: infoportal-media-sa-at22.tfstate
+  WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/infoportal-media-sa-at22
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Plan
+    environment: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Plan
+        uses: Altinn/altinn-platform/actions/terraform/plan@b6f2be96753810a89f98e3d41e04c2d63a4102cf # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: test
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    environment: test
+    if: github.ref == 'refs/heads/main'
+    needs: plan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Apply
+        uses: Altinn/altinn-platform/actions/terraform/apply@b6f2be96753810a89f98e3d41e04c2d63a4102cf # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: test
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
@@ -17,10 +17,10 @@ locals {
 module "media_sa" {
   source = "../../modules/infoportal-media-sa"
 
-  environment          = "at22"
-  location             = azurerm_resource_group.main.location
-  resource_group_name  = azurerm_resource_group.main.name
+  environment               = "at22"
+  location                  = azurerm_resource_group.main.location
+  resource_group_name       = azurerm_resource_group.main.name
   storage_account_base_name = "infoportalmediaat22"
-  umbraco_sp_object_id = var.umbraco_sp_object_id
-  tags                 = local.tags
+  umbraco_sp_object_id      = var.umbraco_sp_object_id
+  tags                      = local.tags
 }

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
@@ -1,0 +1,26 @@
+resource "azurerm_resource_group" "main" {
+  name     = "infoportal-media-sa-at22"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+locals {
+  tags = {
+    finops_environment = "at22"
+    finops_product     = "infoportal"
+    repository         = "https://github.com/Altinn/info.altinn.no"
+    env                = "at22"
+    product            = "infoportal"
+  }
+}
+
+module "media_sa" {
+  source = "../../modules/infoportal-media-sa"
+
+  environment          = "at22"
+  location             = azurerm_resource_group.main.location
+  resource_group_name  = azurerm_resource_group.main.name
+  storage_account_base_name = "infoportalmediaat22"
+  umbraco_sp_object_id = var.umbraco_sp_object_id
+  tags                 = local.tags
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/outputs.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/outputs.tf
@@ -1,0 +1,14 @@
+output "storage_account_name" {
+  description = "Name of the media storage account"
+  value       = module.media_sa.storage_account_name
+}
+
+output "storage_account_id" {
+  description = "Resource ID of the media storage account"
+  value       = module.media_sa.storage_account_id
+}
+
+output "primary_blob_endpoint" {
+  description = "Primary blob service endpoint URL"
+  value       = module.media_sa.primary_blob_endpoint
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/providers.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.14.8"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.68.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.8.1"
+    }
+  }
+
+  backend "azurerm" {
+    use_azuread_auth = true
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/terraform.tfvars
@@ -1,1 +1,1 @@
-# umbraco_sp_object_id = ""
+# umbraco_sp_object_id = "<object-id>"

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/terraform.tfvars
@@ -1,0 +1,1 @@
+# umbraco_sp_object_id = ""

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/variables.tf
@@ -1,0 +1,5 @@
+variable "umbraco_sp_object_id" {
+  description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
+  type        = string
+  default     = ""
+}

--- a/infrastructure/modules/infoportal-media-sa/main.tf
+++ b/infrastructure/modules/infoportal-media-sa/main.tf
@@ -1,0 +1,33 @@
+resource "random_string" "storage_suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+resource "azurerm_storage_account" "media" {
+  name                     = "${var.storage_account_base_name}${random_string.storage_suffix.result}"
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "ZRS"
+  account_kind             = "StorageV2"
+
+  blob_properties {
+    versioning_enabled = true
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_container" "media" {
+  name                  = "media"
+  storage_account_id    = azurerm_storage_account.media.id
+  container_access_type = "private"
+}
+
+resource "azurerm_role_assignment" "umbraco_blob_contributor" {
+  count                = var.umbraco_sp_object_id != "" ? 1 : 0
+  scope                = azurerm_storage_account.media.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = var.umbraco_sp_object_id
+}

--- a/infrastructure/modules/infoportal-media-sa/outputs.tf
+++ b/infrastructure/modules/infoportal-media-sa/outputs.tf
@@ -1,0 +1,14 @@
+output "storage_account_name" {
+  description = "Name of the media storage account"
+  value       = azurerm_storage_account.media.name
+}
+
+output "storage_account_id" {
+  description = "Resource ID of the media storage account"
+  value       = azurerm_storage_account.media.id
+}
+
+output "primary_blob_endpoint" {
+  description = "Primary blob service endpoint URL"
+  value       = azurerm_storage_account.media.primary_blob_endpoint
+}

--- a/infrastructure/modules/infoportal-media-sa/variables.tf
+++ b/infrastructure/modules/infoportal-media-sa/variables.tf
@@ -1,0 +1,31 @@
+variable "environment" {
+  description = "Environment name (e.g. tt02, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for the storage account"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the Azure resource group"
+  type        = string
+}
+
+variable "storage_account_base_name" {
+  description = "Base name for the storage account — a 4-char random suffix is appended (total max 24 chars, lowercase alphanumeric)"
+  type        = string
+}
+
+variable "umbraco_sp_object_id" {
+  description = "Object ID of the Umbraco managed identity granted Storage Blob Data Contributor. Leave empty to skip the role assignment."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to all taggable resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Infrastructure as code for provisioning Azure storage account and associated resources for infoportal media in the AT22 test environment, including GitHub Actions workflow for automated deployment.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
