### PR TITLE
feat:Added Content Delivery API support for relations

### DIFF
--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
 
-export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:43450';
+export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:39790';
 
 export async function fetchUmbracoContent(path: string) {
     // Uses Umbraco Content Delivery API pattern
@@ -35,6 +35,19 @@ export async function fetchUmbracoAncestors(path: string) {
 
   if (!response.ok) {
     throw new Error(`Failed to fetch ancestors from Umbraco: ${response.statusText} ${url}`);
+  }
+
+  const data = await response.json();
+  return data.items ?? [];
+}
+
+export async function fetchUmbracoRelated(path: string, contentType: string, relation: string, value: string) {
+  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?fetch=descendants:${path}&filter=contentType:${contentType}&filter=${relation}:${value}&fields=`;
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch related content from Umbraco: ${response.statusText} ${url}`);
   }
 
   const data = await response.json();

--- a/astro-infoportal/src/transformers/SubCategoryPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SubCategoryPageTransformer.ts
@@ -1,6 +1,6 @@
 import type { IJSONTransformer } from "./IJSONTransformer";
 import type { SubCategoryPageProps } from "@components/Pages/SubCategoryPage/SubCategoryPage.types";
-import { fetchUmbracoAncestors, fetchUmbracoChildren } from "../api/umbraco/client";
+import { fetchUmbracoAncestors, fetchUmbracoChildren, fetchUmbracoRelated } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import { BlockTransformer } from "./BlockTransformer";
 
@@ -21,10 +21,14 @@ export class SubCategoryPageTransformer implements IJSONTransformer {
       ? BlockTransformer.TransformBlocks(props.promoArea)
       : undefined;
 
-    // Schemas: subcategory pages have no schema children in the CMS content tree.
-    // The old .NET schemaRelationsService mapped schemas to subcategories externally.
-    // For now we pass an empty array; this can be populated once a relations source is available.
-    const schemas: any[] = [];
+    const related = await fetchUmbracoRelated("/skjemaoversikt", "schemaPage", "subCategory", cmsPageData.id);
+
+    const schemas = related.map((s: any) => ({
+          title: s.name,
+          url: s.route?.path,
+          componentName: "SchemaData"
+        }));
+
 
     // Sidebar: "Alle tjenester" title, parent category as selected mainItem,
     // sibling subcategories as subItems with category prefix stripped.

--- a/umbraco-infoportal/AbstractRelationFilter.cs
+++ b/umbraco-infoportal/AbstractRelationFilter.cs
@@ -1,0 +1,79 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.DeliveryApi;
+using Umbraco.Cms.Core.Models;
+
+public abstract class AbstractRelationFilter : IFilterHandler, IContentIndexHandler
+{
+    public string FilterName;
+    public string FieldName;
+    public string[] ContentTypes;
+
+    public AbstractRelationFilter(string filterName, string fieldName, string[] contentTypes)
+    {
+        FilterName = filterName;
+        FieldName = fieldName;
+        ContentTypes = contentTypes;
+    }
+
+    // Querying
+    public bool CanHandle(string query)
+        => query.StartsWith(FilterName + ":", StringComparison.OrdinalIgnoreCase);
+
+    public FilterOption BuildFilterOption(string filter)
+    {
+        return new FilterOption
+        {
+            FieldName = FieldName,
+            Values = [filter[(FilterName.Length + 1)..]],
+            Operator = FilterOperation.Contains
+        };
+    }
+
+    // Indexing
+    public IEnumerable<IndexFieldValue> GetFieldValues(IContent content, string? culture)
+    {
+        if (!ContentTypes.Contains(content.ContentType.Alias))
+        {
+            return [];
+        }
+        
+        string? fieldValue = content.GetValue<string>(FieldName);
+
+        if (fieldValue is null)
+        {
+            return [];
+        }
+
+        return
+        [
+            new IndexFieldValue
+            {
+                FieldName = FieldName,
+                Values = ToGuidArray(fieldValue)
+            }
+        ];
+    }
+
+    public static object[] ToGuidArray(string rawContent)
+    {
+        List<object> guids = [];
+
+        foreach (string udi in rawContent.Split(","))
+        {
+            Guid guid = new GuidUdi(new Uri(udi)).Guid; 
+            guids.Add(guid);
+        }
+
+        return [..guids];
+    }
+
+    public IEnumerable<IndexField> GetFields() =>
+    [
+        new IndexField
+        {
+            FieldName = FieldName,
+            FieldType = FieldType.StringRaw,
+            VariesByCulture = false
+        }
+    ];
+}

--- a/umbraco-infoportal/IndustryFilter.cs
+++ b/umbraco-infoportal/IndustryFilter.cs
@@ -1,0 +1,6 @@
+using Umbraco.Cms.Core.DeliveryApi;
+
+public class IndustryFilter : AbstractRelationFilter, IFilterHandler, IContentIndexHandler
+{
+    public IndustryFilter() : base("industry", "industries", ["subsidyPage"]) {}
+}

--- a/umbraco-infoportal/PurposeFilter.cs
+++ b/umbraco-infoportal/PurposeFilter.cs
@@ -1,0 +1,6 @@
+using Umbraco.Cms.Core.DeliveryApi;
+
+public class PurposeFilter : AbstractRelationFilter, IFilterHandler, IContentIndexHandler
+{
+    public PurposeFilter() : base("purpose", "purposes", ["purposePage"]) {}
+}

--- a/umbraco-infoportal/SubCategoryFilter.cs
+++ b/umbraco-infoportal/SubCategoryFilter.cs
@@ -1,0 +1,6 @@
+using Umbraco.Cms.Core.DeliveryApi;
+
+public class SubCategoryFilter : AbstractRelationFilter, IFilterHandler, IContentIndexHandler
+{
+    public SubCategoryFilter() : base("subCategory", "subCategories", ["schemaPage", "schemaAttachmentPage", "schemaCollectionPage"]) {}
+}


### PR DESCRIPTION
Added custom filters for Content Delivery API, following this guide:

https://github.com/umbraco/UmbracoDocs/blob/main/18/umbraco-cms/reference/content-delivery-api/extension-api-for-querying.md

This allows to query which forms belongs to a sub-category like this:

/umbraco/delivery/api/v2/content?fetch=descendants:/skjemaoversikt/&filter=contentType:schemaPage&filter=subCategory:449ce25e-f747-47c0-b9f0-4dc1dec192b9&fields

It also allows to query which subsidy pages belongs to a specific purpose or a specific industry.

Changes in Astro to populate the subCategory page is also included.

