### PR TITLE
feat: add Norwegian synonyms and best bets to Elasticsearch search

### DIFF
--- a/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchDocument.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchDocument.cs
@@ -39,4 +39,12 @@ public class SearchDocument
 
     [JsonPropertyName("titleSuggest")]
     public string[] TitleSuggest { get; set; } = [];
+
+    // Editorial trigger phrases that should surface this page even when the
+    // phrases don't appear in its body/title. Populated by the indexer from
+    // the Best Bets list; usually empty. Indexed with a whitespace+lowercase
+    // analyzer — no stemming, no stopwords — to preserve dialect/inflected
+    // variants exactly.
+    [JsonPropertyName("bestBetTriggers")]
+    public string[] BestBetTriggers { get; set; } = [];
 }

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
@@ -1,6 +1,7 @@
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Analysis;
 using Elastic.Clients.Elasticsearch.Core.Search;
+using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Infoportal.Adapters.Elasticsearch.Models;
@@ -21,6 +22,28 @@ public class ElasticsearchSearchService : ISearchService
     // with per-field weights for title, ingress, body, metaKeywords, metaDescription.
     // Consider moving to appsettings.json or a separate config when fine-tuning is needed.
     private static readonly Fields SearchFields = new[] { "title^3", "ingress^2", "body" };
+
+    // Ported from Optimizely Find synonym export. Solr format, unidirectional (=>).
+    // Applied at search time via a custom search_analyzer, so changes don't require reindex.
+    private static readonly string[] NorwegianSynonyms =
+    [
+        "aksjebok => aksjeeierbok",
+        "bakgrunnsjekk => søknad om bakgrunnssjekk",
+        "frikort => skattekort",
+        "fylkesmann => statsforvalter, statsforvalteren",
+        "samordnet registermelding => samordnet registreringsmelding",
+        "vergeregnskap => fullstendighetserklæring",
+    ];
+
+    private const string NorwegianSynonymAnalyzer = "norwegian_synonym";
+    private const string NorwegianSynonymFilter = "norwegian_synonym_filter";
+
+    // Whitespace + lowercase only — preserves dialect/inflected variants exactly
+    // (e.g. "sjølmeldinga" does not stem to "sjølmeld"). Applied to the
+    // bestBetTriggers field so editorial trigger phrases match as typed.
+    private const string BestBetTriggersAnalyzer = "bestbet_triggers";
+
+    private static bool IsNorwegian(string culture) => culture is "nb" or "nn";
 
     public ElasticsearchSearchService(
         ElasticsearchClientFactory clientFactory,
@@ -58,16 +81,22 @@ public class ElasticsearchSearchService : ISearchService
             }
 
             var analyzerName = GetAnalyzerName(culture);
+            var isNorwegian = IsNorwegian(culture);
+            var searchAnalyzerName = isNorwegian ? NorwegianSynonymAnalyzer : analyzerName;
 
-            var createResponse = await _client.Indices.CreateAsync(indexName, c => c
-                .Mappings(m => m
+            var createResponse = await _client.Indices.CreateAsync(indexName, c =>
+            {
+                c.Settings(s => s.Analysis(BuildAnalysis(isNorwegian)));
+
+                c.Mappings(m => m
                     .Properties(p => p
                         .Keyword("id")
                         .IntegerNumber("contentId")
                         .Keyword("contentGuid")
-                        .Text("title", t => t.Analyzer(analyzerName))
-                        .Text("ingress", t => t.Analyzer(analyzerName))
-                        .Text("body", t => t.Analyzer(analyzerName))
+                        .Text("title", t => t.Analyzer(analyzerName).SearchAnalyzer(searchAnalyzerName))
+                        .Text("ingress", t => t.Analyzer(analyzerName).SearchAnalyzer(searchAnalyzerName))
+                        .Text("body", t => t.Analyzer(analyzerName).SearchAnalyzer(searchAnalyzerName))
+                        .Text("bestBetTriggers", t => t.Analyzer(BestBetTriggersAnalyzer).SearchAnalyzer(BestBetTriggersAnalyzer))
                         .Keyword("url")
                         .Keyword("contentType")
                         .Keyword("culture")
@@ -75,7 +104,8 @@ public class ElasticsearchSearchService : ISearchService
                         .Date("updateDate")
                         .Completion("titleSuggest")
                     )
-                ), ct);
+                );
+            }, ct);
 
             if (createResponse.IsValidResponse)
             {
@@ -111,6 +141,58 @@ public class ElasticsearchSearchService : ISearchService
         {
             _logger.LogWarning(ex, "Failed to delete index {IndexName}", indexName);
         }
+    }
+
+    // Builds the index-level analysis config. Always includes the bestbet_triggers
+    // analyzer (whitespace + lowercase, no stemming) so editorial trigger phrases
+    // match as typed. For Norwegian cultures, also adds a custom analyzer that
+    // mirrors the built-in "norwegian" analyzer with a synonym_graph filter
+    // inserted before stemming, so synonyms are expanded at query time.
+    private static IndexSettingsAnalysis BuildAnalysis(bool isNorwegian)
+    {
+        var tokenFilters = new TokenFilters();
+        var analyzers = new Analyzers
+        {
+            [BestBetTriggersAnalyzer] = new CustomAnalyzer
+            {
+                Tokenizer = "whitespace",
+                Filter = ["lowercase"],
+            },
+        };
+
+        if (isNorwegian)
+        {
+            tokenFilters[NorwegianSynonymFilter] = new SynonymGraphTokenFilter
+            {
+                Synonyms = NorwegianSynonyms,
+            };
+            tokenFilters["norwegian_stop_filter"] = new StopTokenFilter
+            {
+                Stopwords = new Union<StopWordLanguage, ICollection<string>>(StopWordLanguage.Norwegian),
+            };
+            tokenFilters["norwegian_stemmer_filter"] = new StemmerTokenFilter
+            {
+                Language = "norwegian",
+            };
+
+            analyzers[NorwegianSynonymAnalyzer] = new CustomAnalyzer
+            {
+                Tokenizer = "standard",
+                Filter =
+                [
+                    "lowercase",
+                    NorwegianSynonymFilter,
+                    "norwegian_stop_filter",
+                    "norwegian_stemmer_filter",
+                ],
+            };
+        }
+
+        return new IndexSettingsAnalysis
+        {
+            TokenFilters = tokenFilters,
+            Analyzers = analyzers,
+        };
     }
 
     public async Task IndexDocumentAsync(SearchDocument document, CancellationToken ct = default)

--- a/astro-infoportal/src/Services/Elasticsearch/SearchService.ts
+++ b/astro-infoportal/src/Services/Elasticsearch/SearchService.ts
@@ -12,7 +12,10 @@ import type {
   SearchSuggestionResponse,
 } from "./types";
 
-const SEARCH_FIELDS = ["title^3", "ingress^2", "body"];
+// bestBetTriggers carries editorial trigger phrases (dialect, deprecated terms,
+// synonyms) that may not appear in the page itself. High boost so pages with
+// matching triggers rank above fuzzy hits. See umbraco-infoportal/Search/BestBets/.
+const SEARCH_FIELDS = ["title^3", "ingress^2", "body", "bestBetTriggers^5"];
 const DEFAULT_PAGE_SIZE = 10;
 
 function getIndexName(config: ElasticsearchConfig, culture: string): string {

--- a/astro-infoportal/src/pages/api/search/[language]/page.ts
+++ b/astro-infoportal/src/pages/api/search/[language]/page.ts
@@ -34,9 +34,8 @@ export const GET: APIRoute = async ({ params, url }) => {
   );
   const context = url.searchParams.get("context") ?? undefined;
 
-  const config = elasticsearchConfig;
   const result = await searchPages(
-    config,
+    elasticsearchConfig,
     query,
     language,
     pageNumber,

--- a/umbraco-infoportal/Search/BestBets/BestBet.cs
+++ b/umbraco-infoportal/Search/BestBets/BestBet.cs
@@ -1,0 +1,5 @@
+namespace umbraco_infoportal.Search.BestBets;
+
+public sealed record BestBet(
+    string Title,
+    IReadOnlyList<string> TriggerPhrases);

--- a/umbraco-infoportal/Search/BestBets/BestBetData.cs
+++ b/umbraco-infoportal/Search/BestBets/BestBetData.cs
@@ -1,0 +1,85 @@
+namespace umbraco_infoportal.Search.BestBets;
+
+// TEMPORARY: hardcoded until an admin UI in the Umbraco backoffice replaces this.
+// Ported from Optimizely Search & Navigation "Best Bets" (All Websites / All languages).
+//
+// Each bet is identified by its page title. During indexing, the extractor
+// looks up the page title here and, if a bet matches, writes the bet's
+// trigger phrases onto the indexed document's BestBetTriggers field.
+// At search time, Elasticsearch matches user queries against those triggers
+// (with a high boost), so dialect/synonym/editorial variants that don't
+// appear in page text still surface the page.
+//
+// Titles are reproduced verbatim from the Optimizely export. Preserve casing,
+// diacritics (ø å æ), special chars (§, – en-dash).
+//
+// Trigger phrases are enumerated intentionally: Norwegian bokmål + nynorsk +
+// inflected forms appear as separate entries. Matching must NOT stem —
+// the Elasticsearch analyzer for this field uses whitespace + lowercase only.
+public static class BestBetData
+{
+    private static readonly string[] SkattemeldingTriggers =
+    [
+        "skattemelding",
+        "skattemeldingen",
+        "skattemeldinga",
+        "selvangivelse",
+        "selvangivelsen",
+        "sjølmelding",
+        "sjølmeldinga",
+    ];
+
+    public static readonly IReadOnlyList<BestBet> All =
+    [
+        new BestBet(
+            "Søknad om autorisasjon og lisens som helsepersonell",
+            [
+                "autorisasjon som helsefagarbeider",
+                "søknad om autorisasjon",
+                "søknad autorisasjon",
+                "autorisasjon lege",
+                "godkjenning",
+                "lisens",
+                "lege",
+                "sykepleier",
+                "helse",
+                "autorisasjon",
+            ]),
+        new BestBet(
+            "Skattemelding for formue- og inntektsskatt - lønnstakere og pensjonister mv.",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Skattemelding for formue- og inntektsskatt – personlig næringsdrivende mv",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Skattemelding for formues- og inntektsskatt - aksjeselskap mv.",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Skattemelding for forhåndsfastsetting av skatt på formue og inntekt",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Skattemelding for forhåndsfastsetting av skatt på inntekt utenlandsk arbeidstaker/Tax return for advance assessment of foreign employee",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Skattemelding for person som ikke har mottatt forhåndsutfylt skattemelding for formues- og inntektsskatt",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Skattemelding for selskap som omfattes av petroleumsskatteloven § 1",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Søknad om utsatt frist for levering av skattemelding for formues- og inntektsskatt - lønnstakere og pensjonister m.v.",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Søknad om utsatt frist for levering av klienters skattemelding for formues- og inntektsskatt",
+            SkattemeldingTriggers),
+        new BestBet(
+            "Søknad om utsatt frist for levering av skattemelding for formues- og inntektsskatt - næringsdrivende",
+            SkattemeldingTriggers),
+    ];
+
+    private static readonly Dictionary<string, BestBet> ByTitle =
+        All.ToDictionary(b => b.Title, StringComparer.Ordinal);
+
+    public static BestBet? FindByTitle(string? title) =>
+        title != null && ByTitle.TryGetValue(title, out var bet) ? bet : null;
+}

--- a/umbraco-infoportal/Search/ContentTextExtractor.cs
+++ b/umbraco-infoportal/Search/ContentTextExtractor.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Infoportal.Adapters.Elasticsearch;
 using Infoportal.Adapters.Elasticsearch.Models;
 using Microsoft.Extensions.Options;
+using umbraco_infoportal.Search.BestBets;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Core.Web;
@@ -97,6 +98,7 @@ public class ContentTextExtractor
             ?? "";
 
         var url = GetContentUrl(content, culture) ?? "";
+        var bet = BestBetData.FindByTitle(title);
 
         return new SearchDocument
         {
@@ -111,7 +113,8 @@ public class ContentTextExtractor
             ContentType = content.ContentType.Alias,
             Culture = culture,
             PublishDate = content.PublishDate,
-            UpdateDate = content.UpdateDate
+            UpdateDate = content.UpdateDate,
+            BestBetTriggers = bet?.TriggerPhrases.ToArray() ?? []
         };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ported from the legacy Optimizely Search & Navigation setup:

- Norwegian synonyms (6 rules) applied at search time via a synonym_graph filter, so edits don't require reindex. Nb/nn only.
- Best bets (11 pinned pages) indexed as a bestBetTriggers field on matching pages. Trigger phrases use a whitespace+lowercase analyzer so dialect variants like "sjølmeldinga" match exactly. Main search boosts bestBetTriggers^5 so pinned pages rank above fuzzy hits.

Bet data lives in umbraco-infoportal/Search/BestBets/BestBetData.cs as a hardcoded list — temporary until an admin UI replaces it.

Requires POST /api/search/reindex after deploy.
## Related Issue(s)
[- #{569}](https://github.com/Altinn/altinn-infoportal-optimizely/issues/569)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
