### PR TITLE
feat: Add Elasticsearch secret management for tt02

### DIFF
--- a/syncroot/tt02/elasticsearch-secrets.yaml
+++ b/syncroot/tt02/elasticsearch-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: elasticsearch
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: elasticsearch-keyvault
+    kind: SecretStore
+  target:
+    name: elasticsearch
+    creationPolicy: Owner
+  data:
+    - secretKey: endpoint
+      remoteRef:
+        key: elasticsearch-endpoint
+    - secretKey: api-key
+      remoteRef:
+        key: elasticsearch-api-key

--- a/syncroot/tt02/elasticsearch-secretstore.yaml
+++ b/syncroot/tt02/elasticsearch-secretstore.yaml
@@ -1,0 +1,11 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: elasticsearch-keyvault
+spec:
+  provider:
+    azurekv:
+      authType: WorkloadIdentity
+      vaultUrl: "https://infoportal-es-tt02-6i5q.vault.azure.net"
+      serviceAccountRef:
+        name: umbraco

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - elasticsearch-secretstore.yaml
+  - elasticsearch-secrets.yaml
 
 images:
 - name: umbraco
@@ -14,6 +16,26 @@ patches:
       - op: add
         path: /spec/tags/env
         value: tt02
+  - target:
+      kind: Deployment
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Elasticsearch__Endpoint
+          valueFrom:
+            secretKeyRef:
+              name: elasticsearch
+              key: endpoint
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Elasticsearch__ApiKey
+          valueFrom:
+            secretKeyRef:
+              name: elasticsearch
+              key: api-key
   - target:
       kind: HTTPRoute
       name: umbraco


### PR DESCRIPTION
Configure external secrets and environment variables to inject Elasticsearch endpoint and API key credentials into the Umbraco deployment from Azure Key Vault.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
