### PR TITLE
feat: Update Umbraco blob storage config to use env var

### DIFF
--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/README.md
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/README.md
@@ -23,22 +23,16 @@ Set `umbraco_sp_object_id` in `terraform.tfvars` to the object ID of the Umbraco
 umbraco_sp_object_id = "<object-id>"
 ```
 
-### 2. appsettings.json
+### 2. Kustomization env var
 
-Add the blob service URI and container name. The storage account name is available in the Terraform output `storage_account_name`.
+The blob service URI is injected as an environment variable via the kustomization patch. The storage account name is available in the Terraform output `storage_account_name`.
 
-```json
-"Umbraco": {
-  "Storage": {
-    "AzureBlob": {
-      "Media": {
-        "ConnectionString": "https://<storage-account-name>.blob.core.windows.net",
-        "ContainerName": "umbraco"
-      }
-    }
-  }
-}
+```yaml
+- name: Umbraco__Storage__AzureBlob__Media__ConnectionString
+  value: https://<storage-account-name>.blob.core.windows.net
 ```
+
+The container name defaults to `umbraco` and can be set similarly via `Umbraco__Storage__AzureBlob__Media__ContainerName` if needed.
 
 ### 3. Composer
 

--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -20,6 +20,15 @@ patches:
         path: /spec/groupObjectId
         value: 42688626-6503-4d1d-8aa4-e1e5fef2b4be
   - target:
+      kind: Deployment
+      name: umbraco
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__Storage__AzureBlob__Media__ConnectionString
+          value: https://infoportalmediaat224w17.blob.core.windows.net
+  - target:
       kind: HTTPRoute
       name: umbraco
     patch: |-


### PR DESCRIPTION
Move blob service URI configuration from appsettings.json to kustomization patch as an environment variable. Container name defaults to `umbraco` and can be overridden if needed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
