### PR TITLE
feat: add Altinn platform API integration for logged-in header

### DIFF
--- a/astro-infoportal/src/Components/Pages/SearchPage/SearchPageRoute.astro
+++ b/astro-infoportal/src/Components/Pages/SearchPage/SearchPageRoute.astro
@@ -5,6 +5,7 @@ import { getGlobalData } from "@constants/globalData";
 import { SearchContext, getSearchContextLabels } from "@constants/searchContext";
 import { t, type Locale } from "@i18n/index";
 import { elasticsearchConfig } from "@api/elasticsearch/client";
+import { resolveEnvironment } from "@api/altinn/environments";
 import { searchPages } from "../../../Services/Elasticsearch";
 
 interface Props {
@@ -67,7 +68,8 @@ const searchPageData = {
   },
 };
 
-const globalData = getGlobalData(locale, searchPageUrl);
+const altinnEndpoints = resolveEnvironment(Astro.url.hostname);
+const globalData = getGlobalData(locale, searchPageUrl, altinnEndpoints);
 const pageData = await new JSONTransformer().Transform(searchPageData, globalData);
 ---
 

--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -1,9 +1,19 @@
-import { t, type Locale } from "@i18n/index";
+import type { PlatformEndpoints } from "@api/altinn/environments";
+import { resolveEnvironment } from "@api/altinn/environments";
+import { type Locale, t } from "@i18n/index";
 
 // TODO: Replace with real Umbraco global data when backend supports it.
 // This is shared between the catch-all route and static pages (e.g., search).
 
-export function getGlobalData(locale: Locale = "nb", searchPageUrl = "/sok/") {
+export function getGlobalData(
+  locale: Locale = "nb",
+  searchPageUrl = "/sok/",
+  endpoints: PlatformEndpoints = resolveEnvironment(null),
+) {
+  const afBase = endpoints.afBaseUrl.replace(/\/$/, "");
+  const amUiBase = endpoints.amUiBaseUrl.replace(/\/$/, "");
+  const platformBase = endpoints.platformBaseUrl.replace(/\/$/, "");
+
   return {
     headerViewModel: {
       banner: {
@@ -24,15 +34,33 @@ export function getGlobalData(locale: Locale = "nb", searchPageUrl = "/sok/") {
         localStoragePrefix: "infoportal-banner-dismissed",
         componentName: "BannerBlock",
       },
-      startAndRunCompany: { text: t("header.startAndRunCompany", locale), url: "/starte-og-drive/" },
+      startAndRunCompany: {
+        text: t("header.startAndRunCompany", locale),
+        url: "/starte-og-drive/",
+      },
       helpPage: { text: t("header.help", locale), url: "/hjelp/" },
-      loginPage: { text: t("header.login", locale), url: "https://af.at23.altinn.cloud/" },
-      schemaOverviewPage: { text: t("header.allSchemas", locale), url: "/skjemaoversikt/" },
-      inboxPage: { text: t("header.inbox", locale), url: "https://af.at23.altinn.cloud/" },
-      accessManagementPage: { text: t("header.accessManagement", locale), url: "https://am.ui.at23.altinn.cloud/accessmanagement/ui" },
-      profilePage: { text: t("header.profile", locale), url: "https://af.at23.altinn.cloud/profile" },
-      logOutPage: { text: t("header.logout", locale), url: "https://platform.at23.altinn.cloud/authentication/api/v1/logout" },
-      aboutNewAltinnPage: { text: t("header.aboutNewAltinn", locale), url: "/nyheter/om-nye-altinn/" },
+      loginPage: { text: t("header.login", locale), url: `${afBase}/` },
+      schemaOverviewPage: {
+        text: t("header.allSchemas", locale),
+        url: "/skjemaoversikt/",
+      },
+      inboxPage: { text: t("header.inbox", locale), url: `${afBase}/` },
+      accessManagementPage: {
+        text: t("header.accessManagement", locale),
+        url: `${amUiBase}/accessmanagement/ui`,
+      },
+      profilePage: {
+        text: t("header.profile", locale),
+        url: `${afBase}/profile`,
+      },
+      logOutPage: {
+        text: t("header.logout", locale),
+        url: `${platformBase}/authentication/api/v1/logout`,
+      },
+      aboutNewAltinnPage: {
+        text: t("header.aboutNewAltinn", locale),
+        url: "/nyheter/om-nye-altinn/",
+      },
       startPage: { text: "", url: "/" },
       loggedInAsText: t("header.loggedInAs", locale),
       backButtonText: t("header.back", locale),
@@ -40,9 +68,27 @@ export function getGlobalData(locale: Locale = "nb", searchPageUrl = "/sok/") {
       // languageTeaser and languageName are not locale-dependent — each describes
       // the language in its own language. Not provided by Umbraco, so hardcoded here.
       menuLanguageList: [
-        { pageUrl: "/starte-og-drive/", languageTeaser: "Alt innhold er tilgjengelig på bokmål.", languageImage: "/Static/img/no.svg", languageName: "Bokmål", selected: true },
-        { pageUrl: "/nn/starte-og-drive/", languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.", languageImage: "/Static/img/no.svg", languageName: "Nynorsk", selected: false },
-        { pageUrl: "/en/start-and-run-business/", languageTeaser: "Some content is available in English.", languageImage: "/Static/img/gb.svg", languageName: "English", selected: false },
+        {
+          pageUrl: "/starte-og-drive/",
+          languageTeaser: "Alt innhold er tilgjengelig på bokmål.",
+          languageImage: "/Static/img/no.svg",
+          languageName: "Bokmål",
+          selected: true,
+        },
+        {
+          pageUrl: "/nn/starte-og-drive/",
+          languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.",
+          languageImage: "/Static/img/no.svg",
+          languageName: "Nynorsk",
+          selected: false,
+        },
+        {
+          pageUrl: "/en/start-and-run-business/",
+          languageTeaser: "Some content is available in English.",
+          languageImage: "/Static/img/gb.svg",
+          languageName: "English",
+          selected: false,
+        },
       ],
       shortcutText: t("header.shortcuts", locale),
       menuText: t("header.menu", locale),
@@ -52,17 +98,32 @@ export function getGlobalData(locale: Locale = "nb", searchPageUrl = "/sok/") {
       useSearchSuggestions: false,
       dateOfBirthText: t("header.dateOfBirth", locale),
       orgNrText: t("header.orgNr", locale),
-      hostBaseUrl: "https://at23.altinn.cloud/",
+      hostBaseUrl: endpoints.hostBaseUrl,
     },
     footerViewModel: {
-      startAndRunCompany: { text: t("footer.startAndRunCompany", locale), url: "/starte-og-drive/" },
+      startAndRunCompany: {
+        text: t("footer.startAndRunCompany", locale),
+        url: "/starte-og-drive/",
+      },
       helpPage: { text: t("footer.helpAndContact", locale), url: "/hjelp/" },
       address1: "Digitaliseringsdirektoratet,",
       address2: "Postboks 1382 Vika, 0114 Oslo. Org.nr. 991 825 827",
-      aboutAltinnReference: { text: t("footer.aboutAltinn", locale), url: "/om-altinn/" },
-      operationalMessagesReference: { text: t("footer.operationalMessages", locale), url: "/om-altinn/driftsmeldinger/" },
-      privacyReference: { text: t("footer.privacy", locale), url: "/om-altinn/personvern/" },
-      accessibilityLocation: { text: t("footer.accessibility", locale), url: "/om-altinn/tilgjengelighet/" },
+      aboutAltinnReference: {
+        text: t("footer.aboutAltinn", locale),
+        url: "/om-altinn/",
+      },
+      operationalMessagesReference: {
+        text: t("footer.operationalMessages", locale),
+        url: "/om-altinn/driftsmeldinger/",
+      },
+      privacyReference: {
+        text: t("footer.privacy", locale),
+        url: "/om-altinn/personvern/",
+      },
+      accessibilityLocation: {
+        text: t("footer.accessibility", locale),
+        url: "/om-altinn/tilgjengelighet/",
+      },
       searchPageUrl,
       searchUrlBody: searchPageUrl,
     },

--- a/astro-infoportal/src/api/altinn/client.ts
+++ b/astro-infoportal/src/api/altinn/client.ts
@@ -1,0 +1,118 @@
+import type { AltinnPlatformConfig } from "./config";
+import { getAltinnPlatformConfig } from "./config";
+
+export interface AuthContext {
+  isAuthenticated: boolean;
+  token: string | null;
+  partyUuid: string | null;
+  config: AltinnPlatformConfig;
+}
+
+function parseCookies(cookieHeader: string | null): Record<string, string> {
+  if (!cookieHeader) return {};
+  const result: Record<string, string> = {};
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValue] = part.split("=");
+    const name = rawName?.trim();
+    if (!name) continue;
+    result[name] = decodeURIComponent(rawValue.join("=").trim());
+  }
+  return result;
+}
+
+function base64UrlDecode(input: string): string {
+  const padded = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding =
+    padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  return atob(padded + padding);
+}
+
+function isJwtValid(token: string): boolean {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return false;
+    const payload = JSON.parse(base64UrlDecode(parts[1]));
+    if (typeof payload?.exp !== "number") return false;
+    return payload.exp * 1000 > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+function getRequestHostname(request: Request): string | null {
+  const hostHeader = request.headers.get("host");
+  if (hostHeader) return hostHeader.split(":")[0];
+  try {
+    return new URL(request.url).hostname;
+  } catch {
+    return null;
+  }
+}
+
+export function getAuthContext(request: Request): AuthContext {
+  const config = getAltinnPlatformConfig(getRequestHostname(request));
+  const cookies = parseCookies(request.headers.get("cookie"));
+  const token = cookies[config.jwtCookieName] ?? null;
+  const partyUuid = cookies[config.partyUuidCookieName] ?? null;
+  const isAuthenticated = !!token && isJwtValid(token);
+  return {
+    isAuthenticated,
+    token: isAuthenticated ? token : null,
+    partyUuid,
+    config,
+  };
+}
+
+export interface PlatformFetchOptions {
+  method?: string;
+  body?: BodyInit | null;
+  headers?: Record<string, string>;
+}
+
+export async function altinnPlatformFetch(
+  auth: AuthContext,
+  url: string,
+  options: PlatformFetchOptions = {},
+): Promise<Response | null> {
+  if (!auth.isAuthenticated || !auth.token) return null;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${auth.token}`,
+    ...(options.headers ?? {}),
+  };
+
+  if (auth.config.subscriptionKey) {
+    headers[auth.config.subscriptionKeyHeaderName] =
+      auth.config.subscriptionKey;
+  }
+
+  return fetch(url, {
+    method: options.method ?? "GET",
+    headers,
+    body: options.body ?? null,
+  });
+}
+
+export function isValidUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export function emptyFavoritesGroup() {
+  return {
+    name: "Favorites",
+    isFavorite: true,
+    parties: [] as string[],
+  };
+}

--- a/astro-infoportal/src/api/altinn/config.ts
+++ b/astro-infoportal/src/api/altinn/config.ts
@@ -1,0 +1,35 @@
+import { env } from "cloudflare:workers";
+import type { PlatformEndpoints } from "./environments";
+import { resolveEnvironment } from "./environments";
+
+export interface AltinnPlatformConfig {
+  endpoints: PlatformEndpoints;
+  subscriptionKey?: string;
+  subscriptionKeyHeaderName: string;
+  jwtCookieName: string;
+  partyUuidCookieName: string;
+}
+
+export function getAltinnPlatformConfig(
+  hostname: string | null | undefined,
+): AltinnPlatformConfig {
+  const endpoints = resolveEnvironment(hostname);
+  return {
+    endpoints,
+    subscriptionKey: env.ALTINN_SUBSCRIPTION_KEY || undefined,
+    subscriptionKeyHeaderName:
+      env.ALTINN_SUBSCRIPTION_KEY_HEADER_NAME || "Ocp-Apim-Subscription-Key",
+    jwtCookieName: env.ALTINN_JWT_COOKIE_NAME || "AltinnStudioRuntime",
+    partyUuidCookieName: env.ALTINN_PARTY_UUID_COOKIE_NAME || "AltinnPartyUuid",
+  };
+}
+
+export function getProfileApiBaseUrl(config: AltinnPlatformConfig): string {
+  return `${config.endpoints.platformBaseUrl.replace(/\/$/, "")}/profile/api/v1`;
+}
+
+export function getAccessManagementApiBaseUrl(
+  config: AltinnPlatformConfig,
+): string {
+  return `${config.endpoints.platformBaseUrl.replace(/\/$/, "")}/accessmanagement/api/v1`;
+}

--- a/astro-infoportal/src/api/altinn/environments.ts
+++ b/astro-infoportal/src/api/altinn/environments.ts
@@ -1,0 +1,106 @@
+export interface PlatformEndpoints {
+  platformBaseUrl: string;
+  afBaseUrl: string;
+  amUiBaseUrl: string;
+  hostBaseUrl: string;
+}
+
+export interface EnvironmentDefinition extends PlatformEndpoints {
+  key: string;
+  hostnamePattern: string;
+}
+
+export const ENVIRONMENTS: EnvironmentDefinition[] = [
+  {
+    key: "tt02",
+    hostnamePattern: "tt02",
+    platformBaseUrl: "https://platform.tt02.altinn.no",
+    afBaseUrl: "https://af.tt02.altinn.no",
+    amUiBaseUrl: "https://am.ui.tt02.altinn.no",
+    hostBaseUrl: "https://tt02.altinn.no/",
+  },
+  {
+    key: "at21",
+    hostnamePattern: "at21",
+    platformBaseUrl: "https://platform.at21.altinn.cloud",
+    afBaseUrl: "https://af.at23.altinn.cloud",
+    amUiBaseUrl: "https://am.ui.at21.altinn.cloud",
+    hostBaseUrl: "https://at21.altinn.cloud/",
+  },
+  {
+    key: "at22",
+    hostnamePattern: "at22",
+    platformBaseUrl: "https://platform.at22.altinn.cloud",
+    afBaseUrl: "https://af.at23.altinn.cloud",
+    amUiBaseUrl: "https://am.ui.at22.altinn.cloud",
+    hostBaseUrl: "https://at22.altinn.cloud/",
+  },
+  {
+    key: "at23",
+    hostnamePattern: "at23",
+    platformBaseUrl: "https://platform.at23.altinn.cloud",
+    afBaseUrl: "https://af.at23.altinn.cloud",
+    amUiBaseUrl: "https://am.ui.at23.altinn.cloud",
+    hostBaseUrl: "https://at23.altinn.cloud/",
+  },
+  {
+    key: "inte",
+    hostnamePattern: "inte.info",
+    platformBaseUrl: "https://platform.at23.altinn.cloud",
+    afBaseUrl: "https://af.at23.altinn.cloud",
+    amUiBaseUrl: "https://am.ui.at23.altinn.cloud",
+    hostBaseUrl: "https://at23.altinn.cloud/",
+  },
+  {
+    key: "at24",
+    hostnamePattern: "at24",
+    platformBaseUrl: "https://platform.at24.altinn.cloud",
+    afBaseUrl: "https://af.at23.altinn.cloud",
+    amUiBaseUrl: "https://am.ui.at24.altinn.cloud",
+    hostBaseUrl: "https://at24.altinn.cloud/",
+  },
+  {
+    key: "production",
+    hostnamePattern: "",
+    platformBaseUrl: "https://platform.altinn.no",
+    afBaseUrl: "https://af.altinn.no",
+    amUiBaseUrl: "https://am.ui.altinn.no",
+    hostBaseUrl: "https://altinn.no/",
+  },
+];
+
+const SORTED_PATTERNS = ENVIRONMENTS.filter((e) => e.hostnamePattern).sort(
+  (a, b) => b.hostnamePattern.length - a.hostnamePattern.length,
+);
+
+const DEV_FALLBACK_KEY = "at23";
+
+function isDevHost(host: string): boolean {
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host.endsWith(".workers.dev")
+  );
+}
+
+export function resolveEnvironment(
+  hostname: string | null | undefined,
+): PlatformEndpoints {
+  const host = (hostname ?? "").toLowerCase();
+
+  if (host) {
+    for (const env of SORTED_PATTERNS) {
+      if (host.includes(env.hostnamePattern.toLowerCase())) {
+        return env;
+      }
+    }
+
+    if (isDevHost(host)) {
+      const devEnv = ENVIRONMENTS.find((e) => e.key === DEV_FALLBACK_KEY);
+      if (devEnv) return devEnv;
+    }
+  }
+
+  const production = ENVIRONMENTS.find((e) => e.key === "production");
+  return production ?? ENVIRONMENTS[0];
+}

--- a/astro-infoportal/src/api/altinn/types.ts
+++ b/astro-infoportal/src/api/altinn/types.ts
@@ -1,0 +1,61 @@
+export interface AuthorizedParty {
+  partyUuid: string;
+  name?: string | null;
+  organizationNumber?: string | null;
+  dateOfBirth?: string | null;
+  partyId: number;
+  type: "None" | "Person" | "Organization" | "SelfIdentified" | number;
+  unitType?: string | null;
+  isDeleted: boolean;
+  onlyHierarchyElementWithNoAccess: boolean;
+  authorizedResources: string[];
+  authorizedRoles: string[];
+  subunits: AuthorizedParty[];
+}
+
+export interface ProfileGroup {
+  name?: string | null;
+  isFavorite: boolean;
+  parties: string[];
+}
+
+export interface ProfileSettingPreference {
+  language?: string | null;
+  preSelectedPartyId?: number | null;
+  doNotPromptForParty?: boolean | null;
+  preselectedPartyUuid?: string | null;
+  showClientUnits?: boolean | null;
+  shouldShowSubEntities: boolean;
+  shouldShowDeletedEntities?: boolean | null;
+}
+
+export interface PartyDto {
+  partyId: number;
+  partyUuid?: string | null;
+  partyTypeName: string | number;
+  orgNumber?: string | null;
+  unitType?: string | null;
+  name?: string | null;
+  isDeleted: boolean;
+  personDateOfBirth?: string | null;
+  onlyHierarchyElementWithNoAccess: boolean;
+}
+
+export interface UserProfile {
+  userId: number;
+  userUuid?: string | null;
+  userName?: string | null;
+  phoneNumber?: string | null;
+  email?: string | null;
+  partyId: number;
+  party?: PartyDto | null;
+  userType: string | number;
+  profileSettingPreference?: ProfileSettingPreference | null;
+  isReserved: boolean;
+}
+
+export interface CurrentUserResponse {
+  selfAccountUuid: string | null;
+  currentAccountUuid: string | null;
+  showDeletedEntities?: boolean | null;
+}

--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -1,6 +1,6 @@
 import { env } from "cloudflare:workers";
 
-export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:39790';
+export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'http://localhost:43450';
 
 export async function fetchUmbracoContent(path: string) {
     // Uses Umbraco Content Delivery API pattern

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -4,10 +4,12 @@ import { fetchUmbracoContent } from '@api/umbraco/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
 import { getGlobalData } from '@constants/globalData';
+import { resolveEnvironment } from '@api/altinn/environments';
 import type { Locale } from '@i18n/index';
 
 const path = Astro.url.pathname;
 const locale = (Astro.currentLocale || "nb") as Locale;
+const altinnEndpoints = resolveEnvironment(Astro.url.hostname);
 
 
 // Ignore internal Vite/framework paths
@@ -26,7 +28,7 @@ if (path.startsWith('/api/') || path.match(/\.[a-zA-Z0-9]+$/)) {
 
 let umbracoPageData: any = null;
 
-let globalData: any = getGlobalData(locale);
+let globalData: any = getGlobalData(locale, "/sok/", altinnEndpoints);
 
 const [pageResult] = await Promise.allSettled([
   fetchUmbracoContent(path),

--- a/astro-infoportal/src/pages/api/users/authorized-parties.ts
+++ b/astro-infoportal/src/pages/api/users/authorized-parties.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  getAuthContext,
+  jsonResponse,
+} from "../../../api/altinn/client";
+import { getAccessManagementApiBaseUrl } from "../../../api/altinn/config";
+import type { AuthorizedParty } from "../../../api/altinn/types";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  const auth = getAuthContext(request);
+
+  if (!auth.isAuthenticated) {
+    return jsonResponse([] as AuthorizedParty[]);
+  }
+
+  try {
+    const response = await altinnPlatformFetch(
+      auth,
+      `${getAccessManagementApiBaseUrl(auth.config)}/authorizedparties?includeAltinn2=true`,
+    );
+
+    if (!response || !response.ok) {
+      return jsonResponse(
+        { error: "Failed to retrieve authorized parties" },
+        500,
+      );
+    }
+
+    const parties = (await response.json()) as AuthorizedParty[] | null;
+    return jsonResponse(parties ?? []);
+  } catch {
+    return jsonResponse(
+      { error: "Failed to retrieve authorized parties" },
+      500,
+    );
+  }
+};

--- a/astro-infoportal/src/pages/api/users/current.ts
+++ b/astro-infoportal/src/pages/api/users/current.ts
@@ -1,0 +1,48 @@
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  getAuthContext,
+  jsonResponse,
+} from "../../../api/altinn/client";
+import { getProfileApiBaseUrl } from "../../../api/altinn/config";
+import type {
+  CurrentUserResponse,
+  UserProfile,
+} from "../../../api/altinn/types";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  const auth = getAuthContext(request);
+
+  if (!auth.isAuthenticated) {
+    const body: CurrentUserResponse = {
+      selfAccountUuid: null,
+      currentAccountUuid: null,
+    };
+    return jsonResponse(body);
+  }
+
+  try {
+    const response = await altinnPlatformFetch(
+      auth,
+      `${getProfileApiBaseUrl(auth.config)}/users/current`,
+    );
+
+    if (!response || !response.ok) {
+      return jsonResponse({ error: "Failed to retrieve user profile" }, 500);
+    }
+
+    const profile = (await response.json()) as UserProfile | null;
+
+    const body: CurrentUserResponse = {
+      selfAccountUuid: profile?.party?.partyUuid ?? null,
+      currentAccountUuid: auth.partyUuid,
+      showDeletedEntities:
+        profile?.profileSettingPreference?.shouldShowDeletedEntities ?? null,
+    };
+    return jsonResponse(body);
+  } catch {
+    return jsonResponse({ error: "Failed to retrieve user profile" }, 500);
+  }
+};

--- a/astro-infoportal/src/pages/api/users/favorites.ts
+++ b/astro-infoportal/src/pages/api/users/favorites.ts
@@ -1,0 +1,35 @@
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  emptyFavoritesGroup,
+  getAuthContext,
+  jsonResponse,
+} from "../../../api/altinn/client";
+import { getProfileApiBaseUrl } from "../../../api/altinn/config";
+import type { ProfileGroup } from "../../../api/altinn/types";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request }) => {
+  const auth = getAuthContext(request);
+
+  if (!auth.isAuthenticated) {
+    return jsonResponse(emptyFavoritesGroup());
+  }
+
+  try {
+    const response = await altinnPlatformFetch(
+      auth,
+      `${getProfileApiBaseUrl(auth.config)}/users/current/party-groups/favorites`,
+    );
+
+    if (!response || !response.ok) {
+      return jsonResponse(emptyFavoritesGroup());
+    }
+
+    const group = (await response.json()) as ProfileGroup | null;
+    return jsonResponse(group ?? emptyFavoritesGroup());
+  } catch {
+    return jsonResponse({ error: "Failed to retrieve favorite parties" }, 500);
+  }
+};

--- a/astro-infoportal/src/pages/api/users/favorites/[partyUuid].ts
+++ b/astro-infoportal/src/pages/api/users/favorites/[partyUuid].ts
@@ -1,0 +1,61 @@
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  getAuthContext,
+  isValidUuid,
+  jsonResponse,
+} from "../../../../api/altinn/client";
+import { getProfileApiBaseUrl } from "../../../../api/altinn/config";
+
+export const prerender = false;
+
+async function forward(
+  request: Request,
+  partyUuid: string | undefined,
+  method: "PUT" | "DELETE",
+) {
+  const auth = getAuthContext(request);
+
+  if (!auth.isAuthenticated) {
+    return jsonResponse(
+      { error: "User must be authenticated to modify favorites" },
+      400,
+    );
+  }
+
+  if (!partyUuid || !isValidUuid(partyUuid)) {
+    return jsonResponse({ error: "Invalid party UUID" }, 400);
+  }
+
+  try {
+    const response = await altinnPlatformFetch(
+      auth,
+      `${getProfileApiBaseUrl(auth.config)}/users/current/party-groups/favorites/${partyUuid}`,
+      { method },
+    );
+
+    if (!response || !response.ok) {
+      return jsonResponse(
+        {
+          error: `Failed to ${method === "PUT" ? "add" : "remove"} favorite party`,
+        },
+        500,
+      );
+    }
+
+    return new Response(null, { status: 204 });
+  } catch {
+    return jsonResponse(
+      {
+        error: `Failed to ${method === "PUT" ? "add" : "remove"} favorite party`,
+      },
+      500,
+    );
+  }
+}
+
+export const PUT: APIRoute = ({ request, params }) =>
+  forward(request, params.partyUuid, "PUT");
+
+export const DELETE: APIRoute = ({ request, params }) =>
+  forward(request, params.partyUuid, "DELETE");

--- a/astro-infoportal/src/pages/api/users/preferences/show-deleted-entities.ts
+++ b/astro-infoportal/src/pages/api/users/preferences/show-deleted-entities.ts
@@ -1,0 +1,56 @@
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  getAuthContext,
+  jsonResponse,
+} from "../../../../api/altinn/client";
+import { getProfileApiBaseUrl } from "../../../../api/altinn/config";
+import type { ProfileSettingPreference } from "../../../../api/altinn/types";
+
+export const prerender = false;
+
+export const PUT: APIRoute = async ({ request }) => {
+  const auth = getAuthContext(request);
+
+  if (!auth.isAuthenticated) {
+    return jsonResponse(
+      { error: "User must be authenticated to update preferences" },
+      400,
+    );
+  }
+
+  let shouldShowDeletedEntities: boolean;
+  try {
+    const body = await request.json();
+    if (typeof body !== "boolean") {
+      return jsonResponse({ error: "Request body must be a boolean" }, 400);
+    }
+    shouldShowDeletedEntities = body;
+  } catch {
+    return jsonResponse({ error: "Invalid request body" }, 400);
+  }
+
+  try {
+    const response = await altinnPlatformFetch(
+      auth,
+      `${getProfileApiBaseUrl(auth.config)}/users/current/profilesettings`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ shouldShowDeletedEntities }),
+      },
+    );
+
+    if (!response || !response.ok) {
+      return jsonResponse({ error: "Failed to update preference" }, 500);
+    }
+
+    const updated = (await response.json()) as ProfileSettingPreference | null;
+    return jsonResponse({
+      shouldShowDeletedEntities:
+        updated?.shouldShowDeletedEntities ?? shouldShowDeletedEntities,
+    });
+  } catch {
+    return jsonResponse({ error: "Failed to update preference" }, 500);
+  }
+};

--- a/astro-infoportal/tsconfig.json
+++ b/astro-infoportal/tsconfig.json
@@ -7,43 +7,42 @@
     "**/*"
   ],
   "compilerOptions": {
-    "baseUrl": "./src",
     "paths": {
       "/*": [
-        "*"
+        "./src/*"
       ],
       "@components/*": [
-        "Components/*"
+        "./src/Components/*"
       ],
       "@layouts/*": [
-        "layouts/*"
+        "./src/layouts/*"
       ],
       "@pages/*": [
-        "pages/*"
+        "./src/pages/*"
       ],
       "@styles/*": [
-        "styles/*"
+        "./src/styles/*"
       ],
       "@utils/*": [
-        "utils/*"
+        "./src/utils/*"
       ],
       "@api/*": [
-        "api/*"
+        "./src/api/*"
       ],
       "@constants/*": [
-        "Constants/*"
+        "./src/Constants/*"
       ],
       "@services/*": [
-        "Services/*"
+        "./src/Services/*"
       ],
       "@models/*": [
-        "Models/*"
+        "./src/Models/*"
       ],
       "@transformers/*": [
-        "transformers/*"
+        "./src/transformers/*"
       ],
       "@i18n/*": [
-        "i18n/*"
+        "./src/i18n/*"
       ]
     },
     "lib": [
@@ -55,8 +54,7 @@
     "useDefineForClassFields": true,
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,

--- a/astro-infoportal/wrangler.jsonc
+++ b/astro-infoportal/wrangler.jsonc
@@ -13,6 +13,8 @@
   "preview_urls": true,
   // Elasticsearch: ELASTICSEARCH_API_KEY is set per environment via deployment secrets.
   // ELASTICSEARCH_URL is overridden per environment in deployment config.
+  // Altinn platform: endpoints resolve from the request hostname (see src/api/altinn/environments.ts).
+  // ALTINN_SUBSCRIPTION_KEY is an optional secret (empty unless APIM gating is enabled).
   "vars": {
     "ELASTICSEARCH_URL": "http://localhost:9200",
     "ELASTICSEARCH_INDEX_PREFIX": "infoportal"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implements server-side proxy endpoints that relay the browser's Altinn JWT cookie to the Profile and Access Management platform APIs, enabling the global header to show the logged-in user, authorized parties, and favorites across all Altinn environments.

Endpoints under /api/users/:
  - current, authorized-parties, favorites (GET)
  - favorites/{uuid} (PUT/DELETE)
  - preferences/show-deleted-entities (PUT)

Platform URLs (platform, af, am.ui, host) resolve at runtime from the request hostname, mirroring the AltinnEnvironmentResolver pattern from the .NET reference. The same resolver drives the header menu links in globalData.ts so login/inbox/profile/logout URLs always point at the correct environment. Local dev and *.workers.dev previews fall back to at23.

Note: authentication only works when the Worker is served from a subdomain of the Altinn auth domain **(.altinn.no / .altinn.cloud)** so the browser attaches the AltinnStudioRuntime and AltinnPartyUuid cookies. On localhost and *.workers.dev the cookies are not in scope and all /api/users/* endpoints return the unauthenticated payload.

Also:
  - tsconfig: migrate off deprecated baseUrl+relative paths to explicit ./src/* path mappings; enable esModuleInterop
  - umbraco client: align default local dev port with launchSettings (43450)

**Can only test Altinn auth domain (.altinn.no / .altinn.cloud)**
  
## Related Issue(s)
[- #{535}](https://github.com/Altinn/altinn-infoportal-optimizely/issues/535)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
