### PR TITLE
fix: align key vault configuration

### DIFF
--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           env:
             - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
               value: "true"
-            - name: AkvUri
+            - name: KeyVault__AkvUri
               valueFrom:
                 configMapKeyRef:
                   name: umbraco-dis-vault

--- a/umbraco-infoportal/Options/KeyVaultOptions.cs
+++ b/umbraco-infoportal/Options/KeyVaultOptions.cs
@@ -1,0 +1,11 @@
+namespace umbraco_infoportal.Options;
+
+public class KeyVaultOptions
+{
+    public const string SectionName = "KeyVault";
+    public const string AkvUriKey = $"{SectionName}:{nameof(AkvUri)}";
+
+    public string? AkvUri { get; set; }
+
+    public bool? Enabled { get; set; }
+}

--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -13,8 +13,14 @@ KeyVaultOptions keyVaultOptions = builder.Configuration
 
 bool keyVaultEnabled = keyVaultOptions.Enabled ?? !builder.Environment.IsDevelopment();
 
-if (keyVaultEnabled && !string.IsNullOrWhiteSpace(keyVaultOptions.AkvUri))
+if (keyVaultEnabled)
 {
+    if (string.IsNullOrWhiteSpace(keyVaultOptions.AkvUri))
+    {
+        throw new InvalidOperationException(
+            $"Configuration value '{KeyVaultOptions.AkvUriKey}' must be configured when Key Vault is enabled.");
+    }
+
     if (!Uri.TryCreate(keyVaultOptions.AkvUri, UriKind.Absolute, out Uri? keyVaultEndpoint))
     {
         throw new InvalidOperationException(

--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -1,17 +1,24 @@
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
+using umbraco_infoportal.Options;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
-string? keyVaultUri = builder.Configuration["KeyVault:AkvUri"];
-bool keyVaultEnabled = builder.Configuration.GetValue<bool?>("KeyVault:Enabled")
-    ?? !builder.Environment.IsDevelopment();
+builder.Services.Configure<KeyVaultOptions>(
+    builder.Configuration.GetSection(KeyVaultOptions.SectionName));
 
-if (keyVaultEnabled && !string.IsNullOrWhiteSpace(keyVaultUri))
+KeyVaultOptions keyVaultOptions = builder.Configuration
+    .GetSection(KeyVaultOptions.SectionName)
+    .Get<KeyVaultOptions>() ?? new();
+
+bool keyVaultEnabled = keyVaultOptions.Enabled ?? !builder.Environment.IsDevelopment();
+
+if (keyVaultEnabled && !string.IsNullOrWhiteSpace(keyVaultOptions.AkvUri))
 {
-    if (!Uri.TryCreate(keyVaultUri, UriKind.Absolute, out Uri? keyVaultEndpoint))
+    if (!Uri.TryCreate(keyVaultOptions.AkvUri, UriKind.Absolute, out Uri? keyVaultEndpoint))
     {
-        throw new InvalidOperationException("Configuration value 'KeyVault:VaultUri' must be an absolute URI.");
+        throw new InvalidOperationException(
+            $"Configuration value '{KeyVaultOptions.AkvUriKey}' must be an absolute URI.");
     }
 
     builder.Configuration.AddAzureKeyVault(keyVaultEndpoint, new DefaultAzureCredential());

--- a/umbraco-infoportal/appsettings.Production.json
+++ b/umbraco-infoportal/appsettings.Production.json
@@ -33,7 +33,6 @@
     "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   },
   "KeyVault": {
-    "Enabled": true,
-    "AkvUri": "https://product-infopor-f13d1aeb.vault.azure.net/"
+    "Enabled": true
   }
 }


### PR DESCRIPTION
## Summary
- bind the Key Vault settings through a typed options class in the app
- fix the startup validation message and use the KeyVault section consistently
- publish the Kubernetes env var as KeyVault__AkvUri so .NET maps it to KeyVault:AkvUri

## Testing
- not run locally: the available SDK is .NET 8.0.101 while the project targets net10.0