### PR TITLE
fix: increased max HTTP request headersize for Chrome users

### DIFF
--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -1,8 +1,14 @@
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using umbraco_infoportal.Options;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.Limits.MaxRequestHeadersTotalSize = 65536; 
+});
 
 builder.Services.Configure<KeyVaultOptions>(
     builder.Configuration.GetSection(KeyVaultOptions.SectionName));

--- a/umbraco-infoportal/appsettings.Production.json
+++ b/umbraco-infoportal/appsettings.Production.json
@@ -33,7 +33,6 @@
     "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   },
   "KeyVault": {
-    "Enabled": true,
-    "AkvUri": "https://product-infopor-f13d1aeb.vault.azure.net/"
+    "Enabled": true
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Changed `options.Limits.MaxRequestHeadersTotalSize = 65536; ` because of a HTTP 431 error when using Google Chrome Web Browser
