### PR TITLE
feat: add language/metadata helpers and expand search filters

### DIFF
--- a/Adapters/Infoportal.Adapters.Elasticsearch/SearchContextMapping.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/SearchContextMapping.cs
@@ -11,15 +11,16 @@ public enum SearchContext
 public static class SearchContextMapping
 {
     // Maps content type aliases to search contexts.
-    // When new content types are created in Umbraco, add them here.
+    // Entries for content types that do not yet exist in Umbraco are harmless:
+    // they simply never match until the content type is created and content is published.
+    // Keep this list in sync with SearchContextMapping.ts on the frontend.
     private static readonly Dictionary<string, SearchContext> ContentTypeToContext = new(StringComparer.OrdinalIgnoreCase)
     {
         { "sectionArticlePage", SearchContext.StartCompany },
         { "subsidyPage", SearchContext.StartCompany },
         { "schemaPage", SearchContext.Schema },
-        { "schemaOverviewPage", SearchContext.Schema },
-        { "schemaAttachmentPage", SearchContext.Schema },
         { "schemaCollectionPage", SearchContext.Schema },
+        { "schemaAttachmentPage", SearchContext.Schema },
         { "helpQuestionPage", SearchContext.Help },
         { "helpProcessArticlePage", SearchContext.Help },
     };

--- a/astro-infoportal/src/Components/Pages/SearchPage/SearchPageRoute.astro
+++ b/astro-infoportal/src/Components/Pages/SearchPage/SearchPageRoute.astro
@@ -6,6 +6,7 @@ import { SearchContext, getSearchContextLabels } from "@constants/searchContext"
 import { t, type Locale } from "@i18n/index";
 import { elasticsearchConfig } from "@api/elasticsearch/client";
 import { resolveEnvironment } from "@api/altinn/environments";
+import { fetchUmbracoStartPage } from "@api/umbraco/client";
 import { searchPages } from "../../../Services/Elasticsearch";
 
 interface Props {
@@ -69,7 +70,13 @@ const searchPageData = {
 };
 
 const altinnEndpoints = resolveEnvironment(Astro.url.hostname);
-const globalData = getGlobalData(locale, searchPageUrl, altinnEndpoints);
+const searchCultures = {
+  nb: { path: "/sok/" },
+  nn: { path: "/nn/sok/" },
+  en: { path: "/en/search/" },
+};
+const startPageData = await fetchUmbracoStartPage(locale);
+const globalData = getGlobalData(locale, searchPageUrl, altinnEndpoints, searchCultures, startPageData, "searchPage");
 const pageData = await new JSONTransformer().Transform(searchPageData, globalData);
 ---
 

--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -1,49 +1,44 @@
 import type { PlatformEndpoints } from "@api/altinn/environments";
 import { resolveEnvironment } from "@api/altinn/environments";
+import {
+  buildMenuLanguageList,
+  type CultureRoutes,
+} from "@constants/languages";
+import { SearchContext } from "@constants/searchContext";
+import {
+  buildBanner,
+  buildLink,
+  isHelpPageType,
+  resolvePickerUrl,
+} from "@constants/startPageLinks";
 import { type Locale, t } from "@i18n/index";
-
-// TODO: Replace with real Umbraco global data when backend supports it.
-// This is shared between the catch-all route and static pages (e.g., search).
 
 export function getGlobalData(
   locale: Locale = "nb",
   searchPageUrl = "/sok/",
   endpoints: PlatformEndpoints = resolveEnvironment(null),
+  cultures: CultureRoutes = {},
+  startPage?: { properties?: Record<string, unknown> },
+  currentPageContentType?: string,
 ) {
   const afBase = endpoints.afBaseUrl.replace(/\/$/, "");
   const amUiBase = endpoints.amUiBaseUrl.replace(/\/$/, "");
   const platformBase = endpoints.platformBaseUrl.replace(/\/$/, "");
+  const p = startPage?.properties;
 
   return {
     headerViewModel: {
-      banner: {
-        message: {
-          items: [
-            {
-              html: "\u003cp\u003eVi fornyer Altinn.\u0026nbsp;\u003ca href=\u0022/nyheter/om-nye-altinn/\u0022 class=\u0022ds-link\u0022\u003eLes mer om hva som er nytt.\u003c/a\u003e\u003c/p\u003e",
-              componentName: "RichText",
-            },
-          ],
-          componentName: "RichTextArea",
-        },
-        isActive: true,
-        badgeText: "Beta",
-        colorTheme: "accent",
-        closeButtonText: t("banner.closeButton", locale),
-        contentHash: "88628bb068b41760",
-        localStoragePrefix: "infoportal-banner-dismissed",
-        componentName: "BannerBlock",
-      },
-      startAndRunCompany: {
-        text: t("header.startAndRunCompany", locale),
-        url: "/starte-og-drive/",
-      },
-      helpPage: { text: t("header.help", locale), url: "/hjelp/" },
+      banner: buildBanner(p?.banner, t("banner.closeButton", locale)),
+      startAndRunCompany: buildLink(
+        p?.startAndRunCompany,
+        t("header.startAndRunCompany", locale),
+      ),
+      helpPage: buildLink(p?.helpPage, t("header.help", locale)),
       loginPage: { text: t("header.login", locale), url: `${afBase}/` },
-      schemaOverviewPage: {
-        text: t("header.allSchemas", locale),
-        url: "/skjemaoversikt/",
-      },
+      schemaOverviewPage: buildLink(
+        p?.schemaReference,
+        t("header.allSchemas", locale),
+      ),
       inboxPage: { text: t("header.inbox", locale), url: `${afBase}/` },
       accessManagementPage: {
         text: t("header.accessManagement", locale),
@@ -57,39 +52,15 @@ export function getGlobalData(
         text: t("header.logout", locale),
         url: `${platformBase}/authentication/api/v1/logout`,
       },
-      aboutNewAltinnPage: {
-        text: t("header.aboutNewAltinn", locale),
-        url: "/nyheter/om-nye-altinn/",
-      },
+      aboutNewAltinnPage: buildLink(
+        p?.aboutNewAltinnReference,
+        t("header.aboutNewAltinn", locale),
+      ),
       startPage: { text: "", url: "/" },
       loggedInAsText: t("header.loggedInAs", locale),
       backButtonText: t("header.back", locale),
       chooseLanguageText: t("header.chooseLanguage", locale),
-      // languageTeaser and languageName are not locale-dependent — each describes
-      // the language in its own language. Not provided by Umbraco, so hardcoded here.
-      menuLanguageList: [
-        {
-          pageUrl: "/starte-og-drive/",
-          languageTeaser: "Alt innhold er tilgjengelig på bokmål.",
-          languageImage: "/Static/img/no.svg",
-          languageName: "Bokmål",
-          selected: true,
-        },
-        {
-          pageUrl: "/nn/starte-og-drive/",
-          languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.",
-          languageImage: "/Static/img/no.svg",
-          languageName: "Nynorsk",
-          selected: false,
-        },
-        {
-          pageUrl: "/en/start-and-run-business/",
-          languageTeaser: "Some content is available in English.",
-          languageImage: "/Static/img/gb.svg",
-          languageName: "English",
-          selected: false,
-        },
-      ],
+      menuLanguageList: buildMenuLanguageList(locale, cultures),
       shortcutText: t("header.shortcuts", locale),
       menuText: t("header.menu", locale),
       searchTextPlaceholder: t("header.searchPlaceholder", locale),
@@ -101,31 +72,37 @@ export function getGlobalData(
       hostBaseUrl: endpoints.hostBaseUrl,
     },
     footerViewModel: {
-      startAndRunCompany: {
-        text: t("footer.startAndRunCompany", locale),
-        url: "/starte-og-drive/",
-      },
-      helpPage: { text: t("footer.helpAndContact", locale), url: "/hjelp/" },
-      address1: "Digitaliseringsdirektoratet,",
-      address2: "Postboks 1382 Vika, 0114 Oslo. Org.nr. 991 825 827",
-      aboutAltinnReference: {
-        text: t("footer.aboutAltinn", locale),
-        url: "/om-altinn/",
-      },
-      operationalMessagesReference: {
-        text: t("footer.operationalMessages", locale),
-        url: "/om-altinn/driftsmeldinger/",
-      },
-      privacyReference: {
-        text: t("footer.privacy", locale),
-        url: "/om-altinn/personvern/",
-      },
-      accessibilityLocation: {
-        text: t("footer.accessibility", locale),
-        url: "/om-altinn/tilgjengelighet/",
-      },
+      startAndRunCompany: buildLink(
+        p?.startAndRunCompany,
+        t("footer.startAndRunCompany", locale),
+      ),
+      helpPage: buildLink(p?.helpPage, t("footer.helpAndContact", locale)),
+      address1: (p?.address1 as string) ?? "",
+      address2: (p?.address2 as string) ?? "",
+      aboutAltinnReference: buildLink(
+        p?.aboutAltinnReference,
+        t("footer.aboutAltinn", locale),
+      ),
+      operationalMessagesReference: buildLink(
+        p?.operationalMessagesReference,
+        t("footer.operationalMessages", locale),
+      ),
+      privacyReference: buildLink(
+        p?.privacyReference,
+        t("footer.privacy", locale),
+      ),
+      accessibilityLocation: buildLink(
+        p?.accessibilityLocation,
+        t("footer.accessibility", locale),
+      ),
+      searchContext:
+        currentPageContentType === "schemaOverviewPage"
+          ? SearchContext.Schema
+          : "",
       searchPageUrl,
-      searchUrlBody: searchPageUrl,
+      searchUrlBody: isHelpPageType(currentPageContentType)
+        ? (resolvePickerUrl(p?.helpPage) ?? searchPageUrl)
+        : searchPageUrl,
     },
     skipLinkText: t("common.skipToContent", locale),
     locale,

--- a/astro-infoportal/src/Constants/languages.ts
+++ b/astro-infoportal/src/Constants/languages.ts
@@ -1,0 +1,53 @@
+import type { Locale } from "@i18n/index";
+
+type LanguageMeta = {
+  locale: Locale;
+  languageName: string;
+  languageTeaser: string;
+  languageImage: string;
+};
+
+// languageName and languageTeaser are each expressed in their own language
+// (Nynorsk is labelled "Nynorsk" even to a Bokmål reader), so they are not t()-driven.
+export const SUPPORTED_LOCALES: readonly LanguageMeta[] = [
+  {
+    locale: "nb",
+    languageName: "Bokmål",
+    languageTeaser: "Alt innhold er tilgjengelig på bokmål.",
+    languageImage: "/Static/img/no.svg",
+  },
+  {
+    locale: "nn",
+    languageName: "Nynorsk",
+    languageTeaser: "Noko av innhaldet er tilgjengeleg på nynorsk.",
+    languageImage: "/Static/img/no.svg",
+  },
+  {
+    locale: "en",
+    languageName: "English",
+    languageTeaser: "Some content is available in English.",
+    languageImage: "/Static/img/gb.svg",
+  },
+];
+
+const LOCALE_HOME: Record<Locale, string> = {
+  nb: "/",
+  nn: "/nn/",
+  en: "/en/",
+};
+
+export type CultureRoute = { path: string };
+export type CultureRoutes = Partial<Record<Locale, CultureRoute>>;
+
+export function buildMenuLanguageList(
+  currentLocale: Locale,
+  cultures: CultureRoutes = {},
+) {
+  return SUPPORTED_LOCALES.map((l) => ({
+    pageUrl: cultures[l.locale]?.path ?? LOCALE_HOME[l.locale],
+    languageTeaser: l.languageTeaser,
+    languageImage: l.languageImage,
+    languageName: l.languageName,
+    selected: l.locale === currentLocale,
+  }));
+}

--- a/astro-infoportal/src/Constants/metadata.ts
+++ b/astro-infoportal/src/Constants/metadata.ts
@@ -1,0 +1,17 @@
+import type { Locale } from "@i18n/index";
+
+export function buildMetadata(umbracoPageData: any, locale: Locale) {
+  const p = umbracoPageData?.properties ?? {};
+  const name = umbracoPageData?.name ?? "";
+
+  const metaTitle = (p.metaTitle as string) || name;
+  const title = metaTitle ? `Altinn - ${metaTitle}` : "Altinn";
+
+  return {
+    htmlLanguage: locale,
+    title,
+    metaDescription: (p.metaDescription as string) || "",
+    metaKeywords: (p.metaKeywords as string) || "",
+    canonicalUrl: (p.canonicalUrl as string) || "",
+  };
+}

--- a/astro-infoportal/src/Constants/startPageLinks.ts
+++ b/astro-infoportal/src/Constants/startPageLinks.ts
@@ -1,0 +1,74 @@
+const HELP_PAGE_CONTENT_TYPES = new Set([
+  "helpLandingPage",
+  "helpDrilldownPage",
+  "helpStartPage",
+  "helpQuestionPage",
+  "helpProcessArticlePage",
+  "helpSearchPage",
+]);
+
+export function isHelpPageType(contentType: string | undefined): boolean {
+  return contentType ? HELP_PAGE_CONTENT_TYPES.has(contentType) : false;
+}
+
+// Resolves the route path of an Umbraco MultiNodeTreePicker value.
+// The Delivery API serializes picked content as an array of items with { route: { path } }.
+export function resolvePickerUrl(pickerValue: unknown): string | null {
+  if (!pickerValue) return null;
+  const first = Array.isArray(pickerValue) ? pickerValue[0] : pickerValue;
+  const path = (first as { route?: { path?: string } })?.route?.path;
+  return path ?? null;
+}
+
+export function buildLink(
+  pickerValue: unknown,
+  text: string,
+): { text: string; url: string } | null {
+  const url = resolvePickerUrl(pickerValue);
+  if (!url) return null;
+  return { text, url };
+}
+
+type RichTextValue = string | { markup?: string } | undefined | null;
+
+function resolveRichText(value: RichTextValue): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  return value.markup ?? null;
+}
+
+// Simple 64-bit FNV-1a hash, rendered as hex. Used to version banner dismissal:
+// when the message changes, the hash changes, so users see the new banner.
+function hashMessage(html: string): string {
+  let h = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < html.length; i++) {
+    h = ((h ^ BigInt(html.charCodeAt(i))) * prime) & mask;
+  }
+  return h.toString(16).padStart(16, "0");
+}
+
+export function buildBanner(pickerValue: unknown, closeButtonText: string) {
+  if (!pickerValue) return null;
+  const first = Array.isArray(pickerValue) ? pickerValue[0] : pickerValue;
+  const props = (first as { properties?: Record<string, unknown> })?.properties;
+  if (!props) return null;
+
+  const html = resolveRichText(props.message as RichTextValue);
+  if (!html) return null;
+
+  return {
+    message: {
+      items: [{ html, componentName: "RichText" }],
+      componentName: "RichTextArea",
+    },
+    isActive: Boolean(props.isActive),
+    badgeText: (props.badgeText as string) ?? "",
+    colorTheme: (props.colorTheme as string) ?? "accent",
+    closeButtonText,
+    contentHash: hashMessage(html),
+    localStoragePrefix: "infoportal-banner-dismissed",
+    componentName: "BannerBlock",
+  };
+}

--- a/astro-infoportal/src/Services/Elasticsearch/SearchContextMapping.ts
+++ b/astro-infoportal/src/Services/Elasticsearch/SearchContextMapping.ts
@@ -5,13 +5,15 @@ const SearchContext = {
   Help: "Help",
 } as const;
 
+// Entries for content types that do not yet exist in Umbraco are harmless:
+// they simply never match until the content type is created and content is published.
+// Keep this list in sync with SearchContextMapping.cs on the backend.
 const contentTypeToContext: Record<string, string> = {
   sectionArticlePage: SearchContext.StartCompany,
   subsidyPage: SearchContext.StartCompany,
   schemaPage: SearchContext.Schema,
-  schemaOverviewPage: SearchContext.Schema,
-  schemaAttachmentPage: SearchContext.Schema,
   schemaCollectionPage: SearchContext.Schema,
+  schemaAttachmentPage: SearchContext.Schema,
   helpQuestionPage: SearchContext.Help,
   helpProcessArticlePage: SearchContext.Help,
 };

--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -1,18 +1,21 @@
 import { env } from "cloudflare:workers";
 
-export const UMBRACO_API_URL = env.UMBRACO_API_URL || 'https://infoportal.at22.dis-core.altinn.cloud/';
+export const UMBRACO_API_URL =
+  env.UMBRACO_API_URL || "https://infoportal.at22.dis-core.altinn.cloud/";
 
 export async function fetchUmbracoContent(path: string) {
-    // Uses Umbraco Content Delivery API pattern
-    const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content/item/${path}`;
+  // Uses Umbraco Content Delivery API pattern
+  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content/item/${path}`;
 
-    const response = await fetch(url);
+  const response = await fetch(url);
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch from Umbraco: ${response.statusText} ${url}`);
-    }
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch from Umbraco: ${response.statusText} ${url}`,
+    );
+  }
 
-    return await response.json();
+  return await response.json();
 }
 
 export async function fetchUmbracoChildren(path: string, take = 100) {
@@ -21,7 +24,9 @@ export async function fetchUmbracoChildren(path: string, take = 100) {
   const response = await fetch(url);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch children from Umbraco: ${response.statusText} ${url}`);
+    throw new Error(
+      `Failed to fetch children from Umbraco: ${response.statusText} ${url}`,
+    );
   }
 
   const data = await response.json();
@@ -34,20 +39,43 @@ export async function fetchUmbracoAncestors(path: string) {
   const response = await fetch(url);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ancestors from Umbraco: ${response.statusText} ${url}`);
+    throw new Error(
+      `Failed to fetch ancestors from Umbraco: ${response.statusText} ${url}`,
+    );
   }
 
   const data = await response.json();
   return data.items ?? [];
 }
 
-export async function fetchUmbracoRelated(path: string, contentType: string, relation: string, value: string) {
+export async function fetchUmbracoStartPage(locale?: string) {
+  const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?filter=contentType:startPage&take=1`;
+
+  const headers: Record<string, string> = {};
+  if (locale) headers["Accept-Language"] = locale;
+
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) return null;
+
+  const data = await response.json();
+  return data.items?.[0] ?? null;
+}
+
+export async function fetchUmbracoRelated(
+  path: string,
+  contentType: string,
+  relation: string,
+  value: string,
+) {
   const url = `${UMBRACO_API_URL}/umbraco/delivery/api/v2/content?fetch=descendants:${path}&filter=contentType:${contentType}&filter=${relation}:${value}&fields=`;
 
   const response = await fetch(url);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch related content from Umbraco: ${response.statusText} ${url}`);
+    throw new Error(
+      `Failed to fetch related content from Umbraco: ${response.statusText} ${url}`,
+    );
   }
 
   const data = await response.json();

--- a/astro-infoportal/src/layouts/AstroSiteLayout.astro
+++ b/astro-infoportal/src/layouts/AstroSiteLayout.astro
@@ -5,7 +5,7 @@ import ApplicationInsightsFilterJS from "../bundles/ApplicationInsightsFilterJS.
 const { pageData, htmlLanguage, title, canonicalUrl, metaNoIndex, metaDescription, metaKeywords, seoScript, enableAppInsightsFiltering } = Astro.props;
 ---
 <!doctype html>
-<html class="ap-profile" lang={htmlLanguage || "no"}>
+<html class="ap-profile" lang={htmlLanguage || "nb"}>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -14,6 +14,17 @@ const { pageData, htmlLanguage, title, canonicalUrl, metaNoIndex, metaDescriptio
     {metaNoIndex && <meta name="robots" content="noindex" />}
     {metaDescription && <meta name="description" content={metaDescription} />}
     {metaKeywords && <meta name="keywords" content={metaKeywords} />}
+    <link rel="icon" type="image/x-icon" href="/assets/favicon/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon/favicon-16x16.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon-180x180.png" />
+    <link rel="manifest" href="/assets/favicon/manifest.json" crossorigin="use-credentials" />
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" />
+    <meta name="apple-mobile-web-app-title" content="Altinn" />
+    <meta name="application-name" content="Altinn" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <meta name="msapplication-TileImage" content="/assets/favicon/mstile-144x144.png" />
+    <meta name="theme-color" content="#ffffff" />
     <link rel="stylesheet" href="https://altinncdn.no/fonts/inter/v4.1/inter.css" crossorigin="anonymous">
     {seoScript && <Fragment set:html={seoScript} />}
     {enableAppInsightsFiltering && <ApplicationInsightsFilterJS/>}

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -1,11 +1,12 @@
 ---
 
-import { fetchUmbracoContent } from '@api/umbraco/client';
+import { fetchUmbracoContent, fetchUmbracoStartPage } from '@api/umbraco/client';
 import { fetchFromOldPortal } from '@api/oldportal/client';
 import { shouldFetchFromOldPortal } from '@api/oldportal/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
 import { getGlobalData } from '@constants/globalData';
+import { buildMetadata } from '@constants/metadata';
 import { resolveEnvironment } from '@api/altinn/environments';
 import type { Locale } from '@i18n/index';
 import { env } from "cloudflare:workers";
@@ -35,10 +36,14 @@ if (path.startsWith('/api/') || path.match(/\.[a-zA-Z0-9]+$/)) {
 
 let umbracoPageData: any = null;
 
-let globalData: any = getGlobalData(locale, "/sok/", altinnEndpoints);
+// On a locale-root URL the requested page IS the startPage — reuse the fetch.
+const isLocaleRoot = /^\/(nn\/?|en\/?)?$/.test(path);
+const pagePromise = fetchUmbracoContent(path);
+const startPagePromise = isLocaleRoot ? pagePromise : fetchUmbracoStartPage(locale);
 
-const [pageResult] = await Promise.allSettled([
-  fetchUmbracoContent(path),
+const [pageResult, startPageResult] = await Promise.allSettled([
+  pagePromise,
+  startPagePromise,
 ]);
 
 if (pageResult.status === 'rejected') {
@@ -47,9 +52,14 @@ if (pageResult.status === 'rejected') {
 }
 umbracoPageData = pageResult.value;
 
+const startPageData = startPageResult.status === 'fulfilled' ? startPageResult.value : null;
+
+let globalData: any = getGlobalData(locale, "/sok/", altinnEndpoints, umbracoPageData?.cultures, startPageData, umbracoPageData?.contentType);
+
 const pageData = await new JSONTransformer().Transform(umbracoPageData, globalData);
+const metadata = buildMetadata(umbracoPageData, locale);
 
 Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=86400");
 ---
 
-<AstroSiteLayout pageData={pageData} />
+<AstroSiteLayout pageData={pageData} {...metadata} />

--- a/umbraco-infoportal/Search/ContentTextExtractor.cs
+++ b/umbraco-infoportal/Search/ContentTextExtractor.cs
@@ -25,14 +25,20 @@ public class ContentTextExtractor
         @"<umb-rte-block data-content-key=""(?<guid>[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12})""></umb-rte-block>",
         RegexOptions.Compiled);
 
-    // Content types to index. Add new page types here as they are created.
-    // TODO: Add helpQuestionPage, etc. when those content types exist.
+    // Content types to index. Aliases for content types that do not yet exist in Umbraco
+    // are harmless: publish events only fire for types that exist, so unmatched entries are ignored.
+    // Keep aligned with SearchContextMapping so every indexed type has a filter context.
     // TODO: Consider moving this to a backoffice setting or a "hideFromSearch" composition
     // property so admins can control which pages are indexed without code changes.
     private static readonly HashSet<string> IndexableContentTypes =
     [
         "sectionArticlePage",
-        "schemaPage"
+        "subsidyPage",
+        "schemaPage",
+        "schemaCollectionPage",
+        "schemaAttachmentPage",
+        "helpQuestionPage",
+        "helpProcessArticlePage"
     ];
 
     private static readonly HashSet<string> TextEditors =

--- a/umbraco-infoportal/uSync/v17/ContentTypes/startpage.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/startpage.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ContentType Key="d4bf360e-8730-46ea-9758-5fc4a48990dd" Alias="startPage" Level="1">
   <Info>
     <Name>Forside</Name>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Language and metadata setup:
- Constants/languages.ts: SUPPORTED_LOCALES + buildMenuLanguageList for the nb/nn/en language switcher (labels/flags shown in each language itself)
- Constants/metadata.ts: buildMetadata helper that resolves meta title, description, keywords, and canonical URL from Umbraco page properties
- Constants/startPageLinks.ts: helpers for MultiNodeTreePicker link resolution, help-page-type detection, and dismissible banner content hashing
- Refactor globalData.ts, AstroSiteLayout.astro, [...slug].astro, and umbraco/client.ts to consume the new helpers and locale-aware routing
- Remove src/pages/index.astro; catch-all route now owns the root
- Update startpage.config uSync schema to match new page properties

Search filter expansion:
- SearchContextMapping (C# + TS): map subsidyPage, schemaCollectionPage, schemaAttachmentPage, helpQuestionPage, helpProcessArticlePage; drop schemaOverviewPage
- ContentTextExtractor.IndexableContentTypes: pre-register the same aliases so new content types are picked up automatically when content is published

## Related Issue(s)
[- #{558}](https://github.com/Altinn/altinn-infoportal-optimizely/issues/558)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
