### PR TITLE
feat: Add blob storage role assignments for developer groups

### DIFF
--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
@@ -17,10 +17,12 @@ locals {
 module "media_sa" {
   source = "../../modules/infoportal-media-sa"
 
-  environment               = "at22"
-  location                  = azurerm_resource_group.main.location
-  resource_group_name       = azurerm_resource_group.main.name
-  storage_account_base_name = "infoportalmediaat22"
-  umbraco_sp_object_id      = var.umbraco_sp_object_id
-  tags                      = local.tags
+  environment                       = "at22"
+  location                          = azurerm_resource_group.main.location
+  resource_group_name               = azurerm_resource_group.main.name
+  storage_account_base_name         = "infoportalmediaat22"
+  umbraco_sp_object_id              = var.umbraco_sp_object_id
+  blob_reader_group_object_ids      = var.blob_reader_group_object_ids
+  blob_contributor_group_object_ids = var.blob_contributor_group_object_ids
+  tags                              = local.tags
 }

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/terraform.tfvars
@@ -1,1 +1,9 @@
 umbraco_sp_object_id = "37bad695-20a0-4b9c-8374-bd182c5cdad4" # infop-at22-vllfov-sql-uami
+
+blob_reader_group_object_ids = [
+  "9d64c20c-250b-4976-be0d-237374413cac", # DIS AKS Reader Dev IP
+]
+
+blob_contributor_group_object_ids = [
+  "42688626-6503-4d1d-8aa4-e1e5fef2b4be", # DIS AKS Admin Dev IP
+]

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/variables.tf
@@ -3,3 +3,15 @@ variable "umbraco_sp_object_id" {
   type        = string
   default     = ""
 }
+
+variable "blob_reader_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Reader on the storage account."
+  type        = list(string)
+  default     = []
+}
+
+variable "blob_contributor_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Contributor on the storage account."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/main.tf
@@ -17,10 +17,12 @@ locals {
 module "media_sa" {
   source = "../../modules/infoportal-media-sa"
 
-  environment               = "at23"
-  location                  = azurerm_resource_group.main.location
-  resource_group_name       = azurerm_resource_group.main.name
-  storage_account_base_name = "infoportalmediaat23"
-  umbraco_sp_object_id      = var.umbraco_sp_object_id
-  tags                      = local.tags
+  environment                       = "at23"
+  location                          = azurerm_resource_group.main.location
+  resource_group_name               = azurerm_resource_group.main.name
+  storage_account_base_name         = "infoportalmediaat23"
+  umbraco_sp_object_id              = var.umbraco_sp_object_id
+  blob_reader_group_object_ids      = var.blob_reader_group_object_ids
+  blob_contributor_group_object_ids = var.blob_contributor_group_object_ids
+  tags                              = local.tags
 }

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/terraform.tfvars
@@ -1,1 +1,9 @@
 umbraco_sp_object_id = "45dace5e-24df-4562-9912-e95389901e12" # infop-at23-vtjzsk-sql-uami
+
+blob_reader_group_object_ids = [
+  "9d64c20c-250b-4976-be0d-237374413cac", # DIS AKS Reader Dev IP
+]
+
+blob_contributor_group_object_ids = [
+  "42688626-6503-4d1d-8aa4-e1e5fef2b4be", # DIS AKS Admin Dev IP
+]

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/variables.tf
@@ -3,3 +3,15 @@ variable "umbraco_sp_object_id" {
   type        = string
   default     = ""
 }
+
+variable "blob_reader_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Reader on the storage account."
+  type        = list(string)
+  default     = []
+}
+
+variable "blob_contributor_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Contributor on the storage account."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/modules/infoportal-media-sa/main.tf
+++ b/infrastructure/modules/infoportal-media-sa/main.tf
@@ -32,3 +32,17 @@ resource "azurerm_role_assignment" "umbraco_blob_contributor" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = var.umbraco_sp_object_id
 }
+
+resource "azurerm_role_assignment" "developer_blob_reader" {
+  for_each             = toset(var.blob_reader_group_object_ids)
+  scope                = azurerm_storage_account.media.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = each.value
+}
+
+resource "azurerm_role_assignment" "developer_blob_contributor" {
+  for_each             = toset(var.blob_contributor_group_object_ids)
+  scope                = azurerm_storage_account.media.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = each.value
+}

--- a/infrastructure/modules/infoportal-media-sa/variables.tf
+++ b/infrastructure/modules/infoportal-media-sa/variables.tf
@@ -24,6 +24,18 @@ variable "umbraco_sp_object_id" {
   default     = ""
 }
 
+variable "blob_reader_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Reader on the storage account."
+  type        = list(string)
+  default     = []
+}
+
+variable "blob_contributor_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Contributor on the storage account."
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "Tags to apply to all taggable resources"
   type        = map(string)


### PR DESCRIPTION
Add variables and role assignments to grant Storage Blob Data Reader and Storage Blob Data Contributor roles to Azure AD groups across infoportal media storage accounts.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
