### PR TITLE
Potential fix for code scanning alert no. 138: Missing cross-site request forgery token validation

### DIFF
--- a/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
+++ b/umbraco-infoportal/Search/Controllers/ReindexApiController.cs
@@ -21,8 +21,7 @@ public class ReindexApiController : ControllerBase
     }
 
     [HttpPost]
-    // TODO: Re-enable [ValidateAntiForgeryToken] when called from Umbraco backoffice UI. 
-    // This needs to be disabled for now to allow trigger locally.
+    [ValidateAntiForgeryToken]
     public IActionResult TriggerReindex()
     {
         if (!IsAuthorized())


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/info.altinn.no/security/code-scanning/138](https://github.com/Altinn/info.altinn.no/security/code-scanning/138)

General fix: Add anti-forgery validation to the POST action so the framework rejects forged requests lacking a valid CSRF token.

Best fix for this file: In `umbraco-infoportal/Search/Controllers/ReindexApiController.cs`, apply `[ValidateAntiForgeryToken]` directly to `TriggerReindex` (right under `[HttpPost]`) and remove/update the TODO indicating it is disabled. This preserves existing behavior for authorized valid callers while adding CSRF enforcement for POST requests. No functional logic changes are needed in the method body.

What to change:
- File: `umbraco-infoportal/Search/Controllers/ReindexApiController.cs`
- Region: around lines 23–26 (`TriggerReindex` attributes)
- Add attribute: `[ValidateAntiForgeryToken]`
- No new imports required (type is available via existing `Microsoft.AspNetCore.Mvc` import)


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
