### PR TITLE
fix: pin github actions to specific commit

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -39,7 +39,8 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.0
+        # Pinning to a specific commit to ensure consistent behavior. Version v4.1.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
         with:
           cosign-release: 'v3.0.5'
 
@@ -47,13 +48,15 @@ jobs:
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        # Pinning to a specific commit to ensure consistent behavior. Version v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        # Pinning to a specific commit to ensure consistent behavior. Version v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +66,8 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        # Pinning to a specific commit to ensure consistent behavior. Version 6.0.0
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: ${{ github.event.inputs.tag }}
@@ -72,7 +76,8 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v7
+        # # Pinning to a specific commit to ensure consistent behavior. Version 7.1.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./umbraco-infoportal/Dockerfile


### PR DESCRIPTION
Pin GitHub Actions to a specific commit.

Issue: https://github.com/Altinn/altinn-infoportal-optimizely/issues/574

The expected result is that these security warnings will disappear after merge. 
<img width="805" height="353" alt="Screenshot 2026-04-28 at 11 13 55" src="https://github.com/user-attachments/assets/e485cb8e-d405-425e-826e-9a0207c5c96e" />
