### PR TITLE
fix: article sorting order

### DIFF
--- a/astro-infoportal/src/Constants/cache.ts
+++ b/astro-infoportal/src/Constants/cache.ts
@@ -1,0 +1,25 @@
+const SHORT_CMS_CACHE =
+  "public, max-age=0, s-maxage=300, stale-while-revalidate=86400";
+
+function isLocalHost(hostname: string): boolean {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "::1" ||
+    hostname.endsWith(".localhost")
+  );
+}
+
+function isNonProductionHost(hostname: string): boolean {
+  return (
+    isLocalHost(hostname) ||
+    hostname.includes("at22") ||
+    hostname.includes("test") ||
+    hostname.endsWith(".workers.dev") ||
+    hostname.endsWith(".pages.dev")
+  );
+}
+
+export function pageCacheControl(hostname: string): string {
+  return isNonProductionHost(hostname) ? "no-store" : SHORT_CMS_CACHE;
+}

--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -51,11 +51,19 @@ export async function fetchUmbracoContent(path: string, culture?: string) {
   return await response.json();
 }
 
-export async function fetchUmbracoChildren(path: string, take = 100, culture?: string) {
+export async function fetchUmbracoChildren(
+  path: string,
+  take = 100,
+  culture?: string,
+  sort?: string,
+) {
   const params = new URLSearchParams({
     fetch: `children:${path}`,
     take: String(take),
   });
+  if (sort) {
+    params.append("sort", sort);
+  }
   const url = deliveryUrl("/umbraco/delivery/api/v2/content", params.toString());
 
   const response = await fetch(url, { headers: cultureHeader(culture) });
@@ -68,6 +76,14 @@ export async function fetchUmbracoChildren(path: string, take = 100, culture?: s
 
   const data = await response.json();
   return data.items ?? [];
+}
+
+export async function fetchUmbracoChildrenInEditorOrder(
+  path: string,
+  take = 100,
+  culture?: string,
+) {
+  return fetchUmbracoChildren(path, take, culture, "sortOrder:asc");
 }
 
 export async function fetchUmbracoAncestors(path: string, culture?: string) {

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -6,6 +6,7 @@ import { shouldFetchFromOldPortal } from '@api/oldportal/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
 import { getGlobalData } from '@constants/globalData';
+import { pageCacheControl } from '@constants/cache';
 import { buildMetadata } from '@constants/metadata';
 import { resolveEnvironment } from '@api/altinn/environments';
 import type { Locale } from '@i18n/index';
@@ -61,7 +62,7 @@ let globalData: any = getGlobalData(locale, "/sok/", altinnEndpoints, umbracoPag
 const pageData = await new JSONTransformer().Transform(umbracoPageData, globalData);
 const metadata = buildMetadata(umbracoPageData, locale);
 
-Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=86400");
+Astro.response.headers.set("Cache-Control", pageCacheControl(Astro.url.hostname));
 ---
 
 <AstroSiteLayout pageData={pageData} {...metadata} />

--- a/astro-infoportal/src/pages/index.astro
+++ b/astro-infoportal/src/pages/index.astro
@@ -3,6 +3,7 @@ import { fetchUmbracoContent } from '@api/umbraco/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
 import { getGlobalData } from '@constants/globalData';
+import { pageCacheControl } from '@constants/cache';
 import { resolveEnvironment } from '@api/altinn/environments';
 import type { Locale } from '@i18n/index';
 
@@ -39,7 +40,7 @@ const globalData: any = getGlobalData(
 
 const pageData = await new JSONTransformer().Transform(umbracoPageData, globalData);
 
-Astro.response.headers.set("Cache-Control", "public, max-age=0, s-maxage=86400");
+Astro.response.headers.set("Cache-Control", pageCacheControl(Astro.url.hostname));
 ---
 
 <AstroSiteLayout pageData={pageData} />

--- a/astro-infoportal/src/transformers/ThemePageTransformer.ts
+++ b/astro-infoportal/src/transformers/ThemePageTransformer.ts
@@ -1,5 +1,5 @@
 import type { IJSONTransformer } from "./IJSONTransformer";
-import { fetchUmbracoAncestors, fetchUmbracoChildren, fetchUmbracoContent } from "../api/umbraco/client";
+import { fetchUmbracoAncestors, fetchUmbracoChildrenInEditorOrder, fetchUmbracoContent } from "../api/umbraco/client";
 import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { Locale } from "@i18n/index";
@@ -13,6 +13,16 @@ const articleContentTypes = new Set([
   "schemaPage",
 ]);
 
+const childLinkContentTypes = new Set([
+  "articlePage",
+  "sectionArticlePage",
+]);
+
+const contentTypesWithChildLinks = new Set([
+  "sectionArticlePage",
+  "themeContainerPage",
+]);
+
 export class ThemePageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData.properties ?? {};
@@ -21,7 +31,7 @@ export class ThemePageTransformer implements IJSONTransformer {
     const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
-    const allChildren = await fetchUmbracoChildren(cmsPageData.route.path, 100, locale);
+    const allChildren = await fetchUmbracoChildrenInEditorOrder(cmsPageData.route.path, 100, locale);
     const children = allChildren.filter(
       (c: any) => c.properties?.showInNavigation !== false,
     );
@@ -29,6 +39,7 @@ export class ThemePageTransformer implements IJSONTransformer {
     const themeGroups = await Promise.all(
       children.map(async (child: any) => {
         const isArticle = articleContentTypes.has(child.contentType);
+        const shouldFetchChildLinks = contentTypesWithChildLinks.has(child.contentType);
         let intro = child.properties?.mainIntro ?? null;
         let childPages: any[] = [];
 
@@ -41,10 +52,12 @@ export class ThemePageTransformer implements IJSONTransformer {
           }
         }
 
-        if (!isArticle) {
-          const allChildPages = await fetchUmbracoChildren(child.route.path, 100, locale);
+        if (shouldFetchChildLinks && child.route?.path) {
+          const allChildPages = await fetchUmbracoChildrenInEditorOrder(child.route.path, 100, locale);
           childPages = allChildPages.filter(
-            (c: any) => c.properties?.showInNavigation !== false,
+            (c: any) =>
+              childLinkContentTypes.has(c.contentType) &&
+              c.properties?.showInNavigation !== false,
           );
         }
 


### PR DESCRIPTION
Correct sorting order for the articles that are shown for users.

Issue: https://github.com/Altinn/altinn-infoportal-optimizely/issues/585

Result:
<img width="799" height="1259" alt="Screenshot 2026-04-28 at 14 20 59" src="https://github.com/user-attachments/assets/c2ae744d-cd37-4cb2-a6cb-a03f706a7f68" />
