### PR TITLE
fix: add missing uSync.Core.Extensions using in RichTextPropertyConve…

### DIFF
--- a/umbraco-infoportal/RichTextPropertyConverter.cs
+++ b/umbraco-infoportal/RichTextPropertyConverter.cs
@@ -7,6 +7,7 @@ using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Models.Blocks;
 using System.Text.RegularExpressions;
 using System.Text.Json;
+using uSync.Core.Extensions;
 
 // Injecting the IPublishedContentCache for fetching content from the Umbraco cache
 public class RichTextPropertyConverter : IPropertyValueConverter


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Resolves CS1061 build error on ConvertToJsonNode extension method by importing the same namespace already used in ContentPickerConverter.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
