### PR TITLE
chore: split vendor assets and improve caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -441,3 +441,6 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+
+# MacOS
+.DS_Store

--- a/astro-infoportal/astro.config.mjs
+++ b/astro-infoportal/astro.config.mjs
@@ -59,5 +59,18 @@ export default defineConfig({
   integrations: [react({experimentalReactChildren: true})],
   vite: {
     plugins: [viteClientFix()],
+    build: {
+      minify: 'esbuild',
+      cssMinify: 'esbuild',
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              return 'vendor';
+            }
+          },
+        },
+      },
+    },
   },
 });

--- a/astro-infoportal/public/_headers
+++ b/astro-infoportal/public/_headers
@@ -1,0 +1,3 @@
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+


### PR DESCRIPTION
Improve production JS/CSS chunking and cache behavior

**Issue**: https://github.com/Altinn/altinn-infoportal-optimizely/issues/581

**Description**
This PR makes the production asset strategy for the Astro frontend more explicit and cache-friendly.

The current build was already minified by Vite/Astro, but most client-side code was emitted in a small number of large hashed assets. That meant app code and third-party dependencies could be bundled together in a way that made browser caching less effective across deployments. This change keeps the existing Vite/Astro build pipeline, but adds a conservative Rollup chunking rule so dependencies from `node_modules` are emitted into a separate `vendor` chunk.

It also adds Cloudflare static asset headers for Astro’s fingerprinted assets under `/_astro/*`. Since these files include content hashes in their filenames, they can safely be cached long-term with `immutable`; when the code changes, Vite/Astro generates a new filename and browsers will request the updated file.

**What Changed**
- Added explicit Vite production build settings in `astro.config.mjs`:
  - `minify: "esbuild"`
  - `cssMinify: "esbuild"`
  - `manualChunks` for separating third-party dependencies into `vendor`
- Added `public/_headers` with long-lived immutable cache headers for `/_astro/*`.

**Expected Result**
- Browser asset updates remain safe because Astro/Vite filenames are content-hashed.
- Repeat visitors can reuse unchanged vendor assets across deployments.
- App code changes should no longer force all third-party code to be downloaded again.
- Cloudflare serves fingerprinted static assets with stronger browser cache headers.
- The build output is easier to reason about:
  - app JS
  - vendor JS
  - app CSS
  - vendor CSS

There is still a Vite warning for a large vendor chunk. That is expected with the current architecture because `SiteLayout` imports the full component registry and design system. A deeper follow-up would be lazy-loading page/block components instead of importing everything through `App.Components.ts`.
