### PR TITLE
fix: Update page title fallback to "Altinn - Start"

### DIFF
--- a/astro-infoportal/src/layouts/AstroSiteLayout.astro
+++ b/astro-infoportal/src/layouts/AstroSiteLayout.astro
@@ -9,7 +9,7 @@ const { pageData, htmlLanguage, title, canonicalUrl, metaNoIndex, metaDescriptio
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{title || "Altinn"}</title>
+    <title>{title || "Altinn - Start"}</title>
     {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
     {metaNoIndex && <meta name="robots" content="noindex" />}
     {metaDescription && <meta name="description" content={metaDescription} />}


### PR DESCRIPTION
Update page title fallback to "Altinn - Start"