### PR TITLE
refactor: Improve breadcrumb visibility logic

### DIFF
--- a/astro-infoportal/src/transformers/BreadcrumbsTransformer.ts
+++ b/astro-infoportal/src/transformers/BreadcrumbsTransformer.ts
@@ -1,15 +1,20 @@
 export class BreadcrumbsTransformer {
   static Transform(ancestors: any, cmsPageData: any): any {
-    var breadcrumbs = [{
+    const breadcrumbs = [{
       linkItem: {
         text: "Start",
         url: "/",
         componentName: "LinkItem"
       }
     }];
-    
-    ancestors.map((item:any) => {
-      if (item.properties.showInNavigation && item.contentType !== "categoryListPage" && item.contentType !== "startPage") {
+
+    ancestors.forEach((item:any) => {
+      const isBreadcrumbVisible =
+        item.contentType !== "startPage" &&
+        item.contentType !== "themeContainerPage" &&
+        (item.properties?.showInNavigation !== false || item.contentType === "themePage");
+
+      if (isBreadcrumbVisible) {
         breadcrumbs.push({
             linkItem: {
               text: item.name,


### PR DESCRIPTION
Fix breadcrumb hierarchy for article pages under theme containers

**issue**: https://github.com/Altinn/altinn-infoportal-optimizely/issues/547

**Description**

This change fixes incorrect breadcrumbs for pages under the “Starte bedrift” section.

The issue was caused by breadcrumb generation relying too heavily on `showInNavigation` for all ancestor types. In the current Umbraco structure, “Starte bedrift” is a `themePage` with `showInNavigation: false`, while “Før oppstart” is a `themeContainerPage` with `showInNavigation: true`. That caused the breadcrumb to hide the structural parent we want and show the container we do not want.

The breadcrumb logic in astro-infoportal/src/transformers/BreadcrumbsTransformer.ts now:
- excludes `startPage`
- excludes `themeContainerPage`
- includes `themePage` even when `showInNavigation` is `false`

**Before**
Start > Starte og drive bedrift > Før oppstart > Planlegg etableringen

**After**
Start > Starte og drive bedrift > Starte bedrift > Planlegg etableringen

**Why**
This aligns the breadcrumb with the intended content hierarchy instead of the intermediate container structure used in Umbraco.

**Verification**
Verified against the live Umbraco ancestor data for:
`/starte-og-drive/starte/for-oppstart/planlegg-etableringen/`