### PR TITLE
fix: align HeroArticlePageBase rendering with legacy Optimizely

### DIFF
--- a/astro-infoportal/src/Components/Blocks/UrlBlock/UrlBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/UrlBlock/UrlBlock.tsx
@@ -1,18 +1,16 @@
 import { DsLink } from "@altinn/altinn-components";
 
-const UrlBlock = ({
-  linkText,
-  url,
-  openInNewWindow,
-}: any) => {
+const UrlBlock = ({ linkText, url, openInNewWindow }: any) => {
   if (!url || !linkText) {
     return null;
   }
 
   return (
-    <DsLink href={url} target={openInNewWindow ? "_blank" : undefined}>
-      {linkText}
-    </DsLink>
+    <div>
+      <DsLink href={url} target={openInNewWindow ? "_blank" : undefined}>
+        {linkText}
+      </DsLink>
+    </div>
   );
 };
 

--- a/astro-infoportal/src/Components/Pages/HeroArticlePageBase/HeroArticlePageBase.tsx
+++ b/astro-infoportal/src/Components/Pages/HeroArticlePageBase/HeroArticlePageBase.tsx
@@ -45,7 +45,11 @@ const HeroArticlePageBase = ({
         {lastUpdateText && <Divider />}
       </ArticleHeader>
 
-      {mainBody && <RichTextArea {...mainBody} />}
+      {mainBody && (
+        <Typography as="div">
+          <RichTextArea {...mainBody} />
+        </Typography>
+      )}
 
       {hasTimeline && (
         <Section align="start" spacing={4}>
@@ -59,7 +63,10 @@ const HeroArticlePageBase = ({
                   </DsLink>
                 );
                 return (
-                  <div className="timeline-header-custom" key={`timeline-nav-${i}`}>
+                  <div
+                    className="timeline-header-custom"
+                    key={`timeline-nav-${i}`}
+                  >
                     {i !== timeline.length - 1 ? (
                       <TimelineSegment
                         border="solid"
@@ -96,9 +103,7 @@ const HeroArticlePageBase = ({
                 >
                   <div className="timeline-item__title">
                     <span className="timeline-item__circle">{i + 1}</span>
-                    <h3 className="timeline-item__heading">
-                      {item.heading}
-                    </h3>
+                    <h3 className="timeline-item__heading">{item.heading}</h3>
                   </div>
                   {item.content && <ContentArea {...item.content} />}
                 </Section>

--- a/astro-infoportal/src/Components/Pages/SubsidyPage/SubsidyPage.tsx
+++ b/astro-infoportal/src/Components/Pages/SubsidyPage/SubsidyPage.tsx
@@ -45,7 +45,11 @@ const SubsidyPage = ({
         {lastUpdateText && <Divider />}
       </ArticleHeader>
 
-      {mainBody && <RichTextArea {...mainBody} />}
+      {mainBody && (
+        <Typography as="div">
+          <RichTextArea {...mainBody} />
+        </Typography>
+      )}
 
       {hasTimeline && (
         <Section align="start" spacing={4}>
@@ -59,7 +63,10 @@ const SubsidyPage = ({
                   </DsLink>
                 );
                 return (
-                  <div className="timeline-header-custom" key={`timeline-nav-${i}`}>
+                  <div
+                    className="timeline-header-custom"
+                    key={`timeline-nav-${i}`}
+                  >
                     {i !== timeline!.length - 1 ? (
                       <TimelineSegment
                         border="solid"

--- a/astro-infoportal/src/Components/Shared/ContentArea/ContentArea.tsx
+++ b/astro-infoportal/src/Components/Shared/ContentArea/ContentArea.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@digdir/designsystemet-react";
-import type { ContentAreaProps, ContentAreaItem } from "./ContentArea.types";
 import * as Components from "../../../App.Components";
+import type { ContentAreaItem, ContentAreaProps } from "./ContentArea.types";
 import "./ContentArea.scss";
 
 interface GroupedItems {
@@ -10,24 +10,35 @@ interface GroupedItems {
 }
 
 const ContentArea = ({ items }: ContentAreaProps) => {
-  const itemListOfLists: GroupedItems[] = [];
   if (!items) {
-    return itemListOfLists;
+    return null;
   }
+  const itemListOfLists: GroupedItems[] = [];
   for (let i = 0; i < items.length; i++) {
     const currentItem = items[i];
     const newItems: ContentAreaItem[] = [];
     const startIndex = i;
     newItems.push(currentItem);
-    if (currentItem.componentName === "SchemaAccordianBlock" || currentItem.componentName === "AccordionBlock") {
+    if (
+      currentItem.componentName === "SchemaAccordianBlock" ||
+      currentItem.componentName === "AccordionBlock"
+    ) {
       let j = i + 1;
-      while (j < items.length && (items[j].componentName === "SchemaAccordianBlock" || items[j].componentName === "AccordionBlock")) {
+      while (
+        j < items.length &&
+        (items[j].componentName === "SchemaAccordianBlock" ||
+          items[j].componentName === "AccordionBlock")
+      ) {
         newItems.push(items[j]);
         j++;
       }
       i = j - 1;
     }
-    itemListOfLists.push({ type: currentItem.componentName, items: newItems, startIndex: startIndex });
+    itemListOfLists.push({
+      type: currentItem.componentName,
+      items: newItems,
+      startIndex: startIndex,
+    });
   }
 
   const resolveDisplayClass = (item: ContentAreaItem): string => {
@@ -42,11 +53,17 @@ const ContentArea = ({ items }: ContentAreaProps) => {
         if (type === "SchemaAccordianBlock" || type === "AccordionBlock") {
           const cssDisplayOption = resolveDisplayClass(items[0]);
           return (
-            <Card data-color="neutral" key={`group-${idx1}`} className={cssDisplayOption}>
+            <Card
+              data-color="neutral"
+              key={`group-${idx1}`}
+              className={cssDisplayOption}
+            >
               {items.map((item: any, idx2: number) => {
                 const Comp = (Components as any)[item.componentName];
                 if (!Comp) {
-                  console.error(`Component "${item.componentName}" not found in Components registry`);
+                  console.error(
+                    `Component "${item.componentName}" not found in Components registry`,
+                  );
                   return null;
                 }
                 const itemKey = `${type}:${startIndex}:${idx2}`;
@@ -59,7 +76,9 @@ const ContentArea = ({ items }: ContentAreaProps) => {
           const cssDisplayOption = resolveDisplayClass(item);
           const Comp = (Components as any)[item.componentName];
           if (!Comp) {
-            console.error(`Component "${item.componentName}" not found in Components registry`);
+            console.error(
+              `Component "${item.componentName}" not found in Components registry`,
+            );
             return null;
           }
           const itemKey = `${type}:${startIndex}:${idx2}`;

--- a/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
+++ b/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
@@ -1,13 +1,27 @@
+import { type Locale, t } from "@i18n/index";
 import { fetchUmbracoAncestors } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
 
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return "";
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `${day}.${month}.${d.getFullYear()}`;
+}
+
 export class HeroArticlePageBaseTransformer implements IJSONTransformer {
-  public async Transform(cmsPageData: any): Promise<any> {
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const mainBody = cmsPageData.properties.mainBody;
+    const locale: Locale = globalData?.locale ?? "nb";
+    const lastUpdatedDateString = formatDate(cmsPageData.updateDate ?? "");
+    const lastUpdatedDateText = lastUpdatedDateString
+      ? t("common.lastUpdated", locale)
+      : undefined;
 
     return {
       componentName: "HeroArticlePageBase",
@@ -16,6 +30,10 @@ export class HeroArticlePageBaseTransformer implements IJSONTransformer {
       mainIntro: cmsPageData.properties.mainIntro,
       mainBody: mainBody ? { ...mainBody, addAnchors: true } : mainBody,
       breadcrumb: breadcrumb,
+      timeline: cmsPageData.properties.timeline ?? [],
+      bottomContentArea: cmsPageData.properties.bottomContentArea ?? undefined,
+      lastUpdatedDateText,
+      lastUpdatedDateString: lastUpdatedDateString || undefined,
       isUserLoggedIn: false,
     };
   }

--- a/astro-infoportal/src/transformers/SubsidyPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SubsidyPageTransformer.ts
@@ -1,29 +1,44 @@
 import type { SubsidyPageProps } from "@components/Pages/SubsidyPage/SubsidyPage.types";
+import { type Locale, t } from "@i18n/index";
+import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
 
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return "";
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `${day}.${month}.${d.getFullYear()}`;
+}
+
 export class SubsidyPageTransformer implements IJSONTransformer {
-  public async Transform(cmsPageData: any): Promise<SubsidyPageProps> {
-    const mainBody = cmsPageData.properties.mainBody;
+  public async Transform(
+    cmsPageData: any,
+    globalData?: any,
+  ): Promise<SubsidyPageProps> {
+    const props = cmsPageData.properties ?? {};
+    const locale: Locale = globalData?.locale ?? "nb";
+
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+
+    const mainBody = props.mainBody;
+    const lastUpdatedDateString = formatDate(cmsPageData.updateDate ?? "");
+    const lastUpdatedDateText = lastUpdatedDateString
+      ? t("common.lastUpdated", locale)
+      : undefined;
 
     return {
       componentName: "SubsidyPage",
       pageName: cmsPageData.name,
-      mainIntro: cmsPageData.properties.mainIntro || undefined,
-      timeline: cmsPageData.properties.timeline || [],
-      breadcrumb: cmsPageData.properties.breadcrumb || undefined,
-      lastUpdatedDateText:
-        cmsPageData.properties.lastUpdatedDateText || undefined,
-      lastUpdatedDateString:
-        cmsPageData.properties.lastUpdatedDateString || undefined,
-      bottomContentArea: cmsPageData.properties.bottomContentArea || undefined,
-      commonBottomArea: cmsPageData.properties.commonBottomArea || undefined,
-      agency: cmsPageData.properties.agency || undefined,
-      coordinator: cmsPageData.properties.coordinator || undefined,
-      industryConnection:
-        cmsPageData.properties.industryConnection || undefined,
-      purposeConnection: cmsPageData.properties.purposeConnection || undefined,
-      ...cmsPageData.properties,
+      mainIntro: props.mainIntro || undefined,
       mainBody: mainBody ? { ...mainBody, addAnchors: true } : undefined,
+      timeline: props.timeline || [],
+      breadcrumb,
+      lastUpdatedDateText,
+      lastUpdatedDateString: lastUpdatedDateString || undefined,
+      bottomContentArea: props.bottomContentArea || undefined,
     };
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Pass lastUpdatedDateText/lastUpdatedDateString, timeline, and bottomContentArea from HeroArticlePageBaseTransformer; format updateDate as dd.MM.yyyy and localize the label via i18n.
- Restore <Typography as="div"> wrapper around mainBody so the rich-text body sits inside the data-size="md" container.
- Wrap UrlBlock's DsLink in a div so standalone CMS links render as block-level items.
- Fix ContentArea early-return type so it returns null instead of GroupedItems[], which broke its JSX element type.

## Related Issue(s)
https://github.com/Altinn/altinn-infoportal-optimizely/issues/549
https://github.com/Altinn/altinn-infoportal-optimizely/issues/551

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
