### PR TITLE
feat: add prep environment to altinn environment resolver

### DIFF
--- a/astro-infoportal/src/api/altinn/environments.ts
+++ b/astro-infoportal/src/api/altinn/environments.ts
@@ -52,6 +52,14 @@ export const ENVIRONMENTS: EnvironmentDefinition[] = [
     hostBaseUrl: "https://at23.altinn.cloud/",
   },
   {
+    key: "prep",
+    hostnamePattern: "prep.info",
+    platformBaseUrl: "https://platform.tt02.altinn.no",
+    afBaseUrl: "https://af.tt02.altinn.no",
+    amUiBaseUrl: "https://am.ui.tt02.altinn.no",
+    hostBaseUrl: "https://tt02.altinn.no/",
+  },
+  {
     key: "at24",
     hostnamePattern: "at24",
     platformBaseUrl: "https://platform.at24.altinn.cloud",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds prep.info.altinn.no as a new environment that reuses tt02's platform, af, am, and host URLs.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
