### PR TITLE
fix: Set redirect URI from configuration

### DIFF
--- a/umbraco-infoportal/CustomAuthentication/ConfigureMicrosoftEntraIdAuthenticationOptions.cs
+++ b/umbraco-infoportal/CustomAuthentication/ConfigureMicrosoftEntraIdAuthenticationOptions.cs
@@ -58,6 +58,20 @@ public class ConfigureMicrosoftEntraIdAuthenticationOptions : IConfigureNamedOpt
 
         options.NonceCookie.SecurePolicy = CookieSecurePolicy.Always;
         options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
+
+        var applicationUrl = _configuration["Umbraco:CMS:WebRouting:UmbracoApplicationUrl"];
+        if (!string.IsNullOrEmpty(applicationUrl))
+        {
+            options.Events = new OpenIdConnectEvents
+            {
+                OnRedirectToIdentityProvider = context =>
+                {
+                    context.ProtocolMessage.RedirectUri =
+                        $"{applicationUrl.TrimEnd('/')}{callbackPath}";
+                    return Task.CompletedTask;
+                }
+            };
+        }
     }
 
     public void Configure(string? name, OpenIdConnectOptions options)


### PR DESCRIPTION
Dette sikrer at uansett hva `Request.Host` er, vil `redirect_uri` til Entra ID alltid bruke den konfigurerte `UmbracoApplicationUrl` (`https://cms.at23.altinn.info`) + callback-path. Entra ID redirecter da tilbake til riktig URL.

`https://cms.at23.altinn.info/signin-entra` må selvfølgelig være registrert som gyldig redirect URI i Entra ID app-registreringen.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
