### PR TITLE
feat: index SEO meta fields with dedicated relevance weights

### DIFF
--- a/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchOptions.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/ElasticsearchOptions.cs
@@ -11,10 +11,17 @@ public class ElasticsearchOptions
     public string? ApiKey { get; set; }
     public int PageSize { get; set; } = 10;
 
+    // Properties skipped by the generic body-text loop in ContentTextExtractor.
+    // metaTitle/metaDescription/metaKeywords are excluded here because they are
+    // promoted to dedicated SearchDocument fields with their own relevance weights —
+    // the extractor reads them out-of-loop into MetaTitle/MetaDescription/MetaKeywords.
     public List<string> ExcludedProperties { get; set; } =
     [
         "umbracoUrlName",
         "canonicalUrl",
-        "showInNavigation"
+        "showInNavigation",
+        "metaTitle",
+        "metaDescription",
+        "metaKeywords"
     ];
 }

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchDocument.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Models/SearchDocument.cs
@@ -22,6 +22,15 @@ public class SearchDocument
     [JsonPropertyName("body")]
     public string Body { get; set; } = "";
 
+    [JsonPropertyName("metaTitle")]
+    public string MetaTitle { get; set; } = "";
+
+    [JsonPropertyName("metaDescription")]
+    public string MetaDescription { get; set; } = "";
+
+    [JsonPropertyName("metaKeywords")]
+    public string MetaKeywords { get; set; } = "";
+
     [JsonPropertyName("url")]
     public string Url { get; set; } = "";
 

--- a/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
+++ b/Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs
@@ -19,10 +19,20 @@ public class ElasticsearchSearchService : ISearchService
     private static readonly HashSet<string> _createdIndices = [];
     private static readonly string[] SupportedCultures = ["nb", "nn", "en"];
 
-    // TODO: Configurable field weights — Optimizely stores these in XML (RelativeImportance.xml)
-    // with per-field weights for title, ingress, body, metaKeywords, metaDescription.
-    // Consider moving to appsettings.json or a separate config when fine-tuning is needed.
-    private static readonly Fields SearchFields = new[] { "title^3", "ingress^2", "body" };
+    // Field weights mirror the legacy Optimizely RelativeImportance.xml intent
+    // (title/metaTitle highest, curated keywords next, ingress, then description, then body).
+    // IMPORTANT: keep in sync with astro-infoportal/src/Services/Elasticsearch/SearchService.ts SEARCH_FIELDS
+    // — user-facing search runs through the TS path; this C# query is only for backend/admin.
+    // TODO: make weights configurable via appsettings.json when tuning is needed.
+    private static readonly Fields SearchFields = new[]
+    {
+        "title^3",
+        "metaTitle^3",
+        "metaKeywords^2.5",
+        "ingress^2",
+        "metaDescription^1.5",
+        "body",
+    };
 
     // Solr-format synonyms loaded from an embedded text resource.
     // Includes one-way entries (a => b) ported from Optimizely Find,
@@ -104,7 +114,10 @@ public class ElasticsearchSearchService : ISearchService
                         .IntegerNumber("contentId")
                         .Keyword("contentGuid")
                         .Text("title", t => t.Analyzer(indexAnalyzerName).SearchAnalyzer(searchAnalyzerName))
+                        .Text("metaTitle", t => t.Analyzer(indexAnalyzerName).SearchAnalyzer(searchAnalyzerName))
                         .Text("ingress", t => t.Analyzer(indexAnalyzerName).SearchAnalyzer(searchAnalyzerName))
+                        .Text("metaDescription", t => t.Analyzer(indexAnalyzerName).SearchAnalyzer(searchAnalyzerName))
+                        .Text("metaKeywords", t => t.Analyzer(indexAnalyzerName).SearchAnalyzer(searchAnalyzerName))
                         .Text("body", t => t.Analyzer(indexAnalyzerName).SearchAnalyzer(searchAnalyzerName))
                         .Text("bestBetTriggers", t => t.Analyzer(BestBetTriggersAnalyzer).SearchAnalyzer(BestBetTriggersAnalyzer))
                         .Keyword("url")
@@ -175,6 +188,11 @@ public class ElasticsearchSearchService : ISearchService
             tokenFilters[NorwegianSynonymFilter] = new SynonymGraphTokenFilter
             {
                 Synonyms = NorwegianSynonyms,
+                // Skip synonym rules whose head term resolves to nothing after preceding
+                // filters (e.g. when a head term is a Norwegian stopword like "om").
+                // Without this the index settings fail with "term: <x> was completely
+                // eliminated by analyzer".
+                Lenient = true,
             };
             tokenFilters["norwegian_stop_filter"] = new StopTokenFilter
             {
@@ -195,11 +213,18 @@ public class ElasticsearchSearchService : ISearchService
             analyzers[NorwegianSynonymAnalyzer] = new CustomAnalyzer
             {
                 Tokenizer = "standard",
+                // IMPORTANT: stop-filter must run BEFORE synonyms.
+                // If synonyms run first, expanding a stopword head term (e.g. "om" in the
+                // group "vedrørende, om, med omsyn til, som gjeld") leaves multi-word
+                // synonym tokens in place after the stop-filter removes the original.
+                // Combined with multi_match best_fields + operator AND, the resulting bool
+                // query becomes over-strict and yields zero hits even when the doc clearly
+                // contains the user's terms.
                 Filter =
                 [
                     "lowercase",
-                    NorwegianSynonymFilter,
                     "norwegian_stop_filter",
+                    NorwegianSynonymFilter,
                     "norwegian_stemmer_filter",
                 ],
             };

--- a/astro-infoportal/src/Services/Elasticsearch/SearchService.ts
+++ b/astro-infoportal/src/Services/Elasticsearch/SearchService.ts
@@ -12,10 +12,24 @@ import type {
   SearchSuggestionResponse,
 } from "./types";
 
+// Field weights mirror legacy Optimizely RelativeImportance.xml intent
+// (title/metaTitle highest, curated keywords next, ingress, then description, then body).
+// IMPORTANT: keep in sync with
+//   Adapters/Infoportal.Adapters.Elasticsearch/Services/ElasticsearchSearchService.cs SearchFields.
+// This is the user-facing query path; the C# SearchAsync is only for backend/admin use.
+//
 // bestBetTriggers carries editorial trigger phrases (dialect, deprecated terms,
-// synonyms) that may not appear in the page itself. High boost so pages with
+// synonyms) that may not appear in the page itself. Highest boost so pages with
 // matching triggers rank above fuzzy hits. See umbraco-infoportal/Search/BestBets/.
-const SEARCH_FIELDS = ["title^3", "ingress^2", "body", "bestBetTriggers^5"];
+const SEARCH_FIELDS = [
+  "title^3",
+  "metaTitle^3",
+  "metaKeywords^2.5",
+  "ingress^2",
+  "metaDescription^1.5",
+  "body",
+  "bestBetTriggers^5",
+];
 const DEFAULT_PAGE_SIZE = 10;
 
 function getIndexName(config: ElasticsearchConfig, culture: string): string {

--- a/umbraco-infoportal/Search/ContentTextExtractor.cs
+++ b/umbraco-infoportal/Search/ContentTextExtractor.cs
@@ -38,7 +38,8 @@ public class ContentTextExtractor
         "schemaCollectionPage",
         "schemaAttachmentPage",
         "helpQuestionPage",
-        "helpProcessArticlePage"
+        "helpProcessArticlePage",
+        "newsArticlePage"
     ];
 
     private static readonly HashSet<string> TextEditors =
@@ -75,11 +76,41 @@ public class ContentTextExtractor
 
         var textSegments = new List<string>();
         string ingress = "";
+        string metaTitle = "";
+        string metaDescription = "";
+        string metaKeywords = "";
 
-        foreach (var propertyType in contentType.PropertyTypes)
+        // Use CompositionPropertyTypes (not PropertyTypes) so we also iterate properties
+        // inherited from compositions — e.g. SEO/meta fields that live on a shared SEO composition.
+        foreach (var propertyType in contentType.CompositionPropertyTypes)
         {
             if (_options.ExcludedProperties.Contains(propertyType.Alias))
+            {
+                // metaTitle/metaDescription/metaKeywords are excluded from `body`
+                // (avoiding double-counting), but still read into dedicated fields below.
+                if (propertyType.Alias is "metaTitle" or "metaDescription" or "metaKeywords")
+                {
+                    var metaEditorAlias = GetEditorAlias(propertyType);
+                    if (metaEditorAlias == null)
+                        continue;
+
+                    var metaValue = GetPropertyValue(content, propertyType, culture);
+                    if (metaValue == null)
+                        continue;
+
+                    var metaText = ExtractTextFromValue(metaValue, metaEditorAlias);
+                    if (string.IsNullOrWhiteSpace(metaText))
+                        continue;
+
+                    switch (propertyType.Alias)
+                    {
+                        case "metaTitle": metaTitle = metaText; break;
+                        case "metaDescription": metaDescription = metaText; break;
+                        case "metaKeywords": metaKeywords = metaText; break;
+                    }
+                }
                 continue;
+            }
 
             var editorAlias = GetEditorAlias(propertyType);
             if (editorAlias == null)
@@ -115,6 +146,9 @@ public class ContentTextExtractor
             TitleSuggest = string.IsNullOrWhiteSpace(title) ? [] : [title],
             Ingress = ingress,
             Body = string.Join(" ", textSegments),
+            MetaTitle = metaTitle,
+            MetaDescription = metaDescription,
+            MetaKeywords = metaKeywords,
             Url = url,
             ContentType = content.ContentType.Alias,
             Culture = culture,


### PR DESCRIPTION
Adds metaTitle/metaDescription/metaKeywords as first-class indexed Elasticsearch fields, mirroring legacy Optimizely Find behavior.

## Description
- SearchDocument gets three new string fields
- Index mapping adds the fields with the Norwegian analyzer chain
- SearchFields weights: title^3, metaTitle^3, metaKeywords^2.5, ingress^2, metaDescription^1.5, body, bestBetTriggers^5
- ExcludedProperties grows to include meta aliases so they are routed to dedicated fields instead of double-counting in body
- ContentTextExtractor reads meta properties out-of-loop into the dedicated SearchDocument fields
- Astro SearchService.ts SEARCH_FIELDS mirrors the C# weights

Bugs uncovered during testing, fixed in the same change:

- Switch property iteration from contentType.PropertyTypes to contentType.CompositionPropertyTypes. Composition-inherited properties (including the SEO group and other shared compositions) were invisible to the extractor before, so meta fields could never have been indexed regardless of the rest of this work
- Add newsArticlePage to IndexableContentTypes
- Reorder the Norwegian search analyzer so the stop filter runs before the synonym filter, with lenient=true on the synonym filter. Prior ordering let stopwords like "om" expand into multi-word synonym alternatives, polluting bool queries with operator AND (synonym rules whose head term is a stopword are now silently skipped)

**Requires a full reindex on deploy: mapping change adds new fields, analyzer change requires index recreation.**

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/377

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
