### PR TITLE
feat: Add Umbraco CMS URL configuration to all environments

### DIFF
--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -26,11 +26,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://cms.at22.altinn.info
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.at22.altinn.info
       - op: add
@@ -67,3 +62,4 @@ patches:
         path: /spec/hostnames
         value:
           - infoportal.at22.dis-core.altinn.cloud
+          - cms.at22.altinn.info

--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -26,6 +26,11 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://infoportal.at22.dis-core.altinn.cloud
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.at22.altinn.info
       - op: add

--- a/syncroot/at22/kustomization.yaml
+++ b/syncroot/at22/kustomization.yaml
@@ -26,6 +26,16 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://cms.at22.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__Security__BackOfficeHost
+          value: https://cms.at22.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__Storage__AzureBlob__Media__ConnectionString
           value: https://infoportalmediaat224w17.blob.core.windows.net
       - op: add

--- a/syncroot/at23/kustomization.yaml
+++ b/syncroot/at23/kustomization.yaml
@@ -24,11 +24,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://cms.at23.altinn.info
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.at23.altinn.info
       - op: add

--- a/syncroot/at23/kustomization.yaml
+++ b/syncroot/at23/kustomization.yaml
@@ -24,6 +24,11 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://infoportal.at23.dis-core.altinn.cloud
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.at23.altinn.info
       - op: add

--- a/syncroot/at23/kustomization.yaml
+++ b/syncroot/at23/kustomization.yaml
@@ -24,6 +24,16 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://cms.at23.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__Security__BackOfficeHost
+          value: https://cms.at23.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__Storage__AzureBlob__Media__ConnectionString
           value: https://infoportalmediaat23n73s.blob.core.windows.net
       - op: add

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -26,11 +26,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://cms.prod.altinn.info
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.prod.altinn.info
       - op: add
@@ -67,3 +62,4 @@ patches:
         path: /spec/hostnames
         value:
           - infoportal.prod.dis-core.altinn.cloud
+          - cms.prod.altinn.info

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -26,6 +26,11 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://infoportal.prod.dis-core.altinn.cloud
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.prod.altinn.info
       - op: add

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -26,6 +26,16 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://cms.prod.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__Security__BackOfficeHost
+          value: https://cms.prod.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__Storage__AzureBlob__Media__ConnectionString
           value: https://infoportalmediaprodl08r.blob.core.windows.net
       - op: add

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -26,6 +26,11 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://infoportal.tt02.dis-core.altinn.cloud
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.tt02.altinn.info
       - op: add

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -26,11 +26,6 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
-          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://cms.tt02.altinn.info
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
           name: Umbraco__CMS__Security__BackOfficeHost
           value: https://cms.tt02.altinn.info
       - op: add
@@ -67,3 +62,4 @@ patches:
         path: /spec/hostnames
         value:
           - infoportal.tt02.dis-core.altinn.cloud
+          - cms.tt02.altinn.info

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -26,6 +26,16 @@ patches:
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
+          name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
+          value: https://cms.tt02.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: Umbraco__CMS__Security__BackOfficeHost
+          value: https://cms.tt02.altinn.info
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
           name: Umbraco__Storage__AzureBlob__Media__ConnectionString
           value: https://infoportalmediatt02q9ew.blob.core.windows.net
       - op: add

--- a/umbraco-infoportal/CustomAuthentication/ConfigureMicrosoftEntraIdAuthenticationOptions.cs
+++ b/umbraco-infoportal/CustomAuthentication/ConfigureMicrosoftEntraIdAuthenticationOptions.cs
@@ -59,17 +59,14 @@ public class ConfigureMicrosoftEntraIdAuthenticationOptions : IConfigureNamedOpt
         options.NonceCookie.SecurePolicy = CookieSecurePolicy.Always;
         options.CorrelationCookie.SecurePolicy = CookieSecurePolicy.Always;
 
-        var applicationUrl = _configuration["Umbraco:CMS:WebRouting:UmbracoApplicationUrl"];
+        var applicationUrl = _configuration["Umbraco:CMS:Security:BackOfficeHost"];
         if (!string.IsNullOrEmpty(applicationUrl))
         {
-            options.Events = new OpenIdConnectEvents
+            options.Events.OnRedirectToIdentityProvider = context =>
             {
-                OnRedirectToIdentityProvider = context =>
-                {
-                    context.ProtocolMessage.RedirectUri =
-                        $"{applicationUrl.TrimEnd('/')}{callbackPath}";
-                    return Task.CompletedTask;
-                }
+                context.ProtocolMessage.RedirectUri =
+                    $"{applicationUrl.TrimEnd('/')}{callbackPath}";
+                return Task.CompletedTask;
             };
         }
     }

--- a/umbraco-infoportal/appsettings.Production.json
+++ b/umbraco-infoportal/appsettings.Production.json
@@ -13,12 +13,6 @@
       "ModelsBuilder": {
         "ModelsMode": "Nothing"
       },
-      "WebRouting": {
-        "UmbracoApplicationUrl": "https://infoportal.at22.dis-core.altinn.cloud"
-      },
-      "Security": {
-	      "BackOfficeHost": "https://infoportal.at22.dis-core.altinn.cloud"    
-      },
       "HealthChecks": {
         "DisabledChecks": [
           {


### PR DESCRIPTION
Configure UmbracoApplicationUrl and BackOfficeHost environment variables for the Umbraco deployment across all environments (at22, at23, prod, tt02), while removing the hardcoded configuration from Production appsettings.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
