### PR TITLE
feat: Add kinorgeportal media storage infrastructure

### DIFF
--- a/.github/workflows/kinorgeportal-media-sa-prod.yml
+++ b/.github/workflows/kinorgeportal-media-sa-prod.yml
@@ -1,0 +1,88 @@
+name: kinorgeportal-media-sa-prod deploy
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/kinorgeportal-media-sa-prod.yml
+      - infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/**
+      - infrastructure/modules/infoportal-media-sa/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/kinorgeportal-media-sa-prod.yml
+      - infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/**
+      - infrastructure/modules/infoportal-media-sa/**
+  workflow_dispatch:
+    inputs:
+      log_level:
+        required: true
+        description: Terraform Log Level
+        default: ERROR
+        type: choice
+        options:
+          - TRACE
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+
+env:
+  TF_STATE_NAME: kinorgeportal-media-sa-prod.tfstate
+  WORKING_DIRECTORY: ./infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_PROD }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_PROD }}
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Plan
+    environment: prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Plan
+        uses: Altinn/altinn-platform/actions/terraform/plan@0f45b34649a70316b7a02daf9f283bbfbdf0ef74 # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: prod
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    environment: prod
+    if: github.ref == 'refs/heads/main'
+    needs: plan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Apply
+        uses: Altinn/altinn-platform/actions/terraform/apply@0f45b34649a70316b7a02daf9f283bbfbdf0ef74 # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: prod
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kinorgeportal-media-sa-tt02.yml
+++ b/.github/workflows/kinorgeportal-media-sa-tt02.yml
@@ -1,0 +1,88 @@
+name: kinorgeportal-media-sa-tt02 deploy
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/kinorgeportal-media-sa-tt02.yml
+      - infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/**
+      - infrastructure/modules/infoportal-media-sa/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/kinorgeportal-media-sa-tt02.yml
+      - infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/**
+      - infrastructure/modules/infoportal-media-sa/**
+  workflow_dispatch:
+    inputs:
+      log_level:
+        required: true
+        description: Terraform Log Level
+        default: ERROR
+        type: choice
+        options:
+          - TRACE
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+
+env:
+  TF_STATE_NAME: kinorgeportal-media-sa-tt02.tfstate
+  WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Plan
+    environment: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Plan
+        uses: Altinn/altinn-platform/actions/terraform/plan@0f45b34649a70316b7a02daf9f283bbfbdf0ef74 # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: test
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    environment: test
+    if: github.ref == 'refs/heads/main'
+    needs: plan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Apply
+        uses: Altinn/altinn-platform/actions/terraform/apply@0f45b34649a70316b7a02daf9f283bbfbdf0ef74 # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: test
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/main.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/main.tf
@@ -1,0 +1,28 @@
+resource "azurerm_resource_group" "main" {
+  name     = "kinorgeportal-media-sa-prod"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+locals {
+  tags = {
+    finops_environment = "prod"
+    finops_product     = "kinorgeportal"
+    repository         = "https://github.com/Altinn/info.altinn.no"
+    env                = "prod"
+    product            = "kinorgeportal"
+  }
+}
+
+module "media_sa" {
+  source = "../../modules/infoportal-media-sa"
+
+  environment                       = "prod"
+  location                          = azurerm_resource_group.main.location
+  resource_group_name               = azurerm_resource_group.main.name
+  storage_account_base_name         = "kinorgemediaprod"
+  umbraco_sp_object_id              = var.umbraco_sp_object_id
+  blob_reader_group_object_ids      = var.blob_reader_group_object_ids
+  blob_contributor_group_object_ids = var.blob_contributor_group_object_ids
+  tags                              = local.tags
+}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/outputs.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/outputs.tf
@@ -1,0 +1,14 @@
+output "storage_account_name" {
+  description = "Name of the media storage account"
+  value       = module.media_sa.storage_account_name
+}
+
+output "storage_account_id" {
+  description = "Resource ID of the media storage account"
+  value       = module.media_sa.storage_account_id
+}
+
+output "primary_blob_endpoint" {
+  description = "Primary blob service endpoint URL"
+  value       = module.media_sa.primary_blob_endpoint
+}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/providers.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.68.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.8.1"
+    }
+  }
+
+  backend "azurerm" {
+    use_azuread_auth     = true
+    storage_account_name = ""
+    container_name       = ""
+    key                  = ""
+  }
+}
+
+provider "azurerm" {
+  features {}
+  storage_use_azuread = true
+}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/terraform.tfvars
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/terraform.tfvars
@@ -1,4 +1,4 @@
-umbraco_sp_object_id = "" # TODO: set to kinorgeportal prod Umbraco managed identity object ID
+umbraco_sp_object_id = "4ded8119-6c31-45ab-8da4-cf751c4c63b8" # kin-prod-kgufhh-sql-uami
 
 blob_reader_group_object_ids = [
   "84e8286e-40cf-4aa9-a43c-2bc78b77c63d", # DIS AKS Reader Dev KIN

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/terraform.tfvars
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/terraform.tfvars
@@ -1,0 +1,9 @@
+umbraco_sp_object_id = "" # TODO: set to kinorgeportal prod Umbraco managed identity object ID
+
+blob_reader_group_object_ids = [
+  "84e8286e-40cf-4aa9-a43c-2bc78b77c63d", # DIS AKS Reader Dev KIN
+]
+
+blob_contributor_group_object_ids = [
+  "b5949ea9-f3dc-4fd8-9dca-37e997b60c63", # DIS AKS Admin Dev KIN
+]

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/variables.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/variables.tf
@@ -1,0 +1,17 @@
+variable "umbraco_sp_object_id" {
+  description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
+  type        = string
+  default     = ""
+}
+
+variable "blob_reader_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Reader on the storage account."
+  type        = list(string)
+  default     = []
+}
+
+variable "blob_contributor_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Contributor on the storage account."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/README.md
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/README.md
@@ -1,0 +1,78 @@
+# kinorgeportal-media-sa-tt02
+
+Provisions an Azure Storage Account for Umbraco CMS media file storage in the TT02 environment.
+
+## What this creates
+
+- **Azure Resource Group** `kinorgeportal-media-sa-tt02`
+- **Azure Storage Account** `kinorgemediatt02<random>` (Standard ZRS, Norway East)
+  - Shared key access disabled — workload identity only
+  - Blob versioning enabled
+- **Blob container** `umbraco` — holds Umbraco's `/media` and `/cache` folders
+- RBAC role assignment granting `Storage Blob Data Contributor` to the Umbraco service principal (optional, set `umbraco_sp_object_id` to enable)
+
+## Configuring Umbraco
+
+Umbraco connects to the storage account using AKS Workload Identity via `DefaultAzureCredential` — no connection strings or secrets required.
+
+### 1. Enable the role assignment
+
+Set `umbraco_sp_object_id` in `terraform.tfvars` to the object ID of the Umbraco pod's managed identity:
+
+```hcl
+umbraco_sp_object_id = "<object-id>"
+```
+
+### 2. Kustomization env var
+
+The blob service URI is injected as an environment variable via the kustomization patch. The storage account name is available in the Terraform output `storage_account_name`.
+
+```yaml
+- name: Umbraco__Storage__AzureBlob__Media__ConnectionString
+  value: https://<storage-account-name>.blob.core.windows.net
+```
+
+The container name defaults to `umbraco` and can be set similarly via `Umbraco__Storage__AzureBlob__Media__ContainerName` if needed.
+
+### 3. Composer
+
+Add a composer to configure `DefaultAzureCredential` instead of a connection string key:
+
+```csharp
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.StorageProviders.AzureBlob.IO;
+
+internal sealed class AzureBlobFileSystemComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+        => builder.AddAzureBlobMediaFileSystem(options =>
+        {
+            options.TryCreateBlobContainerClientUsingUri(uri =>
+                new BlobContainerClient(uri, new DefaultAzureCredential()));
+        })
+        .AddAzureBlobImageSharpCache();
+}
+```
+
+This replaces the `.AddAzureBlobMediaFileSystem()` call in `Program.cs` if already present.
+
+### 4. NuGet packages
+
+```
+Umbraco.StorageProviders.AzureBlob
+Azure.Identity
+```
+
+## Deploying
+
+Non-sensitive values are configured in `terraform.tfvars`. Run:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+To enable the role assignment for the Umbraco workload identity, set `umbraco_sp_object_id` in `terraform.tfvars` before applying.

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/main.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/main.tf
@@ -1,0 +1,28 @@
+resource "azurerm_resource_group" "main" {
+  name     = "kinorgeportal-media-sa-tt02"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+locals {
+  tags = {
+    finops_environment = "tt02"
+    finops_product     = "kinorgeportal"
+    repository         = "https://github.com/Altinn/info.altinn.no"
+    env                = "tt02"
+    product            = "kinorgeportal"
+  }
+}
+
+module "media_sa" {
+  source = "../../modules/infoportal-media-sa"
+
+  environment                       = "tt02"
+  location                          = azurerm_resource_group.main.location
+  resource_group_name               = azurerm_resource_group.main.name
+  storage_account_base_name         = "kinorgemediatt02"
+  umbraco_sp_object_id              = var.umbraco_sp_object_id
+  blob_reader_group_object_ids      = var.blob_reader_group_object_ids
+  blob_contributor_group_object_ids = var.blob_contributor_group_object_ids
+  tags                              = local.tags
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/outputs.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/outputs.tf
@@ -1,0 +1,14 @@
+output "storage_account_name" {
+  description = "Name of the media storage account"
+  value       = module.media_sa.storage_account_name
+}
+
+output "storage_account_id" {
+  description = "Resource ID of the media storage account"
+  value       = module.media_sa.storage_account_id
+}
+
+output "primary_blob_endpoint" {
+  description = "Primary blob service endpoint URL"
+  value       = module.media_sa.primary_blob_endpoint
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/providers.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/providers.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.68.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.8.1"
+    }
+  }
+
+  backend "azurerm" {
+    use_azuread_auth     = true
+    storage_account_name = ""
+    container_name       = ""
+    key                  = ""
+  }
+}
+
+provider "azurerm" {
+  features {}
+  storage_use_azuread = true
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/terraform.tfvars
@@ -1,4 +1,4 @@
-umbraco_sp_object_id = "" # TODO: set to kinorgeportal tt02 Umbraco managed identity object ID
+umbraco_sp_object_id = "d4ae7a16-8720-47b2-9bb1-10dd2833a684" # kin-tt02-sapxrr-sql-uami
 
 blob_reader_group_object_ids = [
   "84e8286e-40cf-4aa9-a43c-2bc78b77c63d", # DIS AKS Reader Dev KIN

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/terraform.tfvars
@@ -1,0 +1,9 @@
+umbraco_sp_object_id = "" # TODO: set to kinorgeportal tt02 Umbraco managed identity object ID
+
+blob_reader_group_object_ids = [
+  "84e8286e-40cf-4aa9-a43c-2bc78b77c63d", # DIS AKS Reader Dev KIN
+]
+
+blob_contributor_group_object_ids = [
+  "b5949ea9-f3dc-4fd8-9dca-37e997b60c63", # DIS AKS Admin Dev KIN
+]

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/variables.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/variables.tf
@@ -1,0 +1,17 @@
+variable "umbraco_sp_object_id" {
+  description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
+  type        = string
+  default     = ""
+}
+
+variable "blob_reader_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Reader on the storage account."
+  type        = list(string)
+  default     = []
+}
+
+variable "blob_contributor_group_object_ids" {
+  description = "List of Azure AD group object IDs granted Storage Blob Data Contributor on the storage account."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Add Terraform configurations for Azure Storage Account provisioning in both production and TT02 test environments to support Umbraco CMS media file storage using workload identity authentication.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
