### PR TITLE
feat: add sidebar to SchemaPage from subCategories property

### DIFF
--- a/astro-infoportal/src/Components/Pages/SchemaPage/SchemaPage.types.ts
+++ b/astro-infoportal/src/Components/Pages/SchemaPage/SchemaPage.types.ts
@@ -31,4 +31,5 @@ export interface SchemaPageProps {
   noHitText?: string;
   orangeMessage?: any;
   orangeMessageTitle?: string;
+  pageSidebarViewModel?: any;
 }

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -78,6 +78,7 @@ globalData = {
   ...globalData,
   startPageData,
   query: Object.fromEntries(Astro.url.searchParams.entries()),
+  referer: Astro.request.headers.get("referer") || undefined,
 };
 
 const pageData = await new JSONTransformer().Transform(umbracoPageData, globalData);

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -3,6 +3,8 @@ import { type Locale, t } from "@i18n/index";
 import { ProviderResolver } from "@services/Providers/ProviderResolver";
 import {
   fetchUmbracoAncestors,
+  fetchUmbracoChildren,
+  fetchUmbracoContent,
   resolveBlockReferences,
 } from "../api/umbraco/client";
 import { BlockTransformer } from "./BlockTransformer";
@@ -77,6 +79,88 @@ export class SchemaPageTransformer implements IJSONTransformer {
       };
     });
 
+    // Sidebar: schema's tree parent is a providerPage (URL: /skjemaoversikt/<provider>/<schema>/),
+    // so the category/subcategory comes from the `subCategories` Content Picker property.
+    // Schemas can belong to multiple subcategories; prefer the one the user came from
+    // (server-side Referer header), falling back to subCategories[0] (editorial primary).
+    // Subcategory URLs look like /skjemaoversikt/kategori/<categorySlug>/<subCategorySlug>/,
+    // so the parent category is segments.slice(0, 3) of the subcategory's route.path.
+    const subCategoryRefs = Array.isArray(props.subCategories)
+      ? props.subCategories
+      : [];
+
+    const normalizePath = (p: string | undefined) =>
+      (p || "").replace(/\/+$/, "").toLowerCase();
+
+    let refererPath: string | undefined;
+    if (globalData?.referer) {
+      try {
+        refererPath = normalizePath(new URL(globalData.referer).pathname);
+      } catch {
+        // Invalid referer — ignore.
+      }
+    }
+
+    const primarySubCategory =
+      (refererPath
+        ? subCategoryRefs.find(
+            (s: any) => normalizePath(s?.route?.path) === refererPath,
+          )
+        : undefined) ?? subCategoryRefs[0];
+
+    let pageSidebarViewModel: any;
+    if (primarySubCategory?.route?.path) {
+      const subSegments = primarySubCategory.route.path
+        .split("/")
+        .filter(Boolean);
+      const parentCategoryPath = `/${subSegments.slice(0, 3).join("/")}/`;
+
+      let parentCategory: any;
+      try {
+        parentCategory = await fetchUmbracoContent(parentCategoryPath, locale);
+      } catch {
+        // Category fetch failed — render no sidebar rather than a broken one.
+      }
+
+      if (parentCategory) {
+        const categoryPrefix = parentCategory.name
+          ? `${parentCategory.name} - `
+          : "";
+        const stripPrefix = (name: string) =>
+          categoryPrefix && name.startsWith(categoryPrefix)
+            ? name.slice(categoryPrefix.length)
+            : name;
+
+        const siblings = await fetchUmbracoChildren(parentCategory.route.path);
+        const subItems = siblings
+          .filter((sub: any) => sub.contentType === "subCategoryPage")
+          .map((sub: any) => ({
+            label: stripPrefix(sub.name),
+            url: sub.route?.path,
+            current: sub.id === primarySubCategory.id,
+          }))
+          .sort((a: any, b: any) => a.label.localeCompare(b.label, locale));
+
+        pageSidebarViewModel = {
+          titleItem: {
+            label: t("schemaOverview.allServices", locale),
+            url: "/skjemaoversikt",
+            icon: "MenuGridIcon",
+          },
+          mainItems: [
+            {
+              label:
+                parentCategory.name || t("schema.accordions.category", locale),
+              url: parentCategory.route?.path,
+              icon: parentCategory.properties?.icon,
+              current: false,
+              subItems,
+            },
+          ],
+        };
+      }
+    }
+
     return {
       componentName: "SchemaPage",
       schemaPageNameText: cmsPageData.name,
@@ -119,6 +203,7 @@ export class SchemaPageTransformer implements IJSONTransformer {
       noHitText: t("schema.noHit", locale),
       orangeMessage: props.orangeMessage || undefined,
       orangeMessageTitle: props.orangeMessageTitle || undefined,
+      pageSidebarViewModel,
     };
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The schema's tree parent is a providerPage, so category/subcategory context comes from the subCategories Content Picker. For schemas tagged into multiple subcategories, prefer the one matching the Referer header; fall back to subCategories[0] (editorial primary).

## Related Issue(s)
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/624

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
