### PR TITLE
Bugfix/urlblock mainbody rendering

### DIFF
--- a/astro-infoportal/src/Components/Blocks/TableBlock/TableBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/TableBlock/TableBlock.tsx
@@ -32,7 +32,7 @@ const TableBlock = ({
           </tr>
         </thead>
         <tbody>
-          {rows?.map((row: any, rowIndex: number) => {
+          {Array.isArray(rows) && rows.map((row: any, rowIndex: number) => {
             // Build array of column values in the same order as headers
             const columnValues = [
               row.column1,

--- a/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
+++ b/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
@@ -31,10 +31,17 @@ function toRichTextArea(value: any) {
   }
 
   return {
-    items: value.items.map((item: any) => ({
-      componentName: item.componentName ?? "RichText",
-      html: normalizeRichTextHtml(item.html),
-    })),
+    items: value.items.map((item: any) => {
+      const componentName = item.componentName ?? "RichText";
+      if (componentName === "RichText") {
+        return {
+          ...item,
+          componentName,
+          html: normalizeRichTextHtml(item.html),
+        };
+      }
+      return { ...item, componentName };
+    }),
   };
 }
 

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -24,9 +24,8 @@ export class SchemaPageTransformer implements IJSONTransformer {
     const mainBody = props.mainIntro?.items?.length
       ? {
           items: props.mainIntro.items.map((item: any) => ({
-            translatedHeading: item.name,
-            html: item.html,
-            componentName: "RichText",
+            ...item,
+            componentName: item.componentName ?? "RichText",
           })),
         }
       : props.mainIntro || undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`toRichTextArea` in `HeroArticlePageBaseTransformer` and the equivalent map in `SchemaPageTransformer` were collapsing every rich-text item to `{componentName, html}`, dropping the `linkText`/`url`/etc. props that `RichTextPropertyConverter` (C#) sets on inline picker blocks. `UrlBlock` then short-circuited at its `!url || !linkText` guard and rendered nothing. Affects `articlePage`, `sectionArticlePage`, `newsArticlePage`, and any future `schemaPage` that uses inline blocks in `mainIntro`.
 `/starte-og-drive/starte/valg-av-organisasjonsform/` had 3 inline UrlBlocks dropped from the article body.

 ### Regression history

- HeroArticlePageBase mapper: introduced in #160 (`a560960`, 2026-05-07) when the `/dokumentmaler/` URL rewrite was added.
- SchemaPage mapper: introduced in #54 (`559e97c`, 2026-04-07). Hard-coded `componentName: "RichText"` for every item, has been silently dropping inline blocks since day one. Latent because no current schemaPage` on at22 uses inline blocks in `mainIntro`.

## Related Issue(s)
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/549
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/622

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
