### PR TITLE
feat: real transformers for Help pages (#613)

### DIFF
--- a/astro-infoportal/src/transformers/HelpProcessArticlePageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpProcessArticlePageTransformer.ts
@@ -1,0 +1,45 @@
+import { type Locale, t } from "@i18n/index";
+import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
+import { BlockTransformer } from "./BlockTransformer";
+import type { IJSONTransformer } from "./IJSONTransformer";
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return "";
+  const day = String(d.getDate()).padStart(2, "0");
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  return `${day}.${month}.${d.getFullYear()}`;
+}
+
+export class HelpProcessArticlePageTransformer implements IJSONTransformer {
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
+    const props = cmsPageData?.properties ?? {};
+    const locale: Locale = globalData?.locale ?? "nb";
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+
+    const lastUpdatedDateString = formatDate(cmsPageData?.updateDate ?? "");
+    const lastUpdatedDateText = lastUpdatedDateString
+      ? t("common.lastUpdated", locale)
+      : undefined;
+
+    const bottomContentArea = props.bottomContentArea
+      ? BlockTransformer.TransformBlocks(props.bottomContentArea)
+      : undefined;
+
+    return {
+      componentName: "HelpProcessArticlePage",
+      pageName: cmsPageData?.name,
+      mainIntro: props.mainIntro,
+      mainBody: props.mainBody,
+      timeline: props.timeline ?? [],
+      bottomContentArea,
+      linkToPortalProcess: props.linkToPortalProcess,
+      lastUpdatedDateString: lastUpdatedDateString || undefined,
+      lastUpdatedDateText,
+      breadcrumb,
+      isUserLoggedIn: false,
+    };
+  }
+}

--- a/astro-infoportal/src/transformers/HelpQuestionPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpQuestionPageTransformer.ts
@@ -1,0 +1,18 @@
+import type { IJSONTransformer } from "./IJSONTransformer";
+import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
+
+export class HelpQuestionPageTransformer implements IJSONTransformer {
+  public async Transform(cmsPageData: any): Promise<any> {
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+
+    return {
+      componentName: "HelpQuestionPage",
+      pageName: cmsPageData?.name,
+      ...cmsPageData?.properties,
+      breadcrumb,
+      isUserLoggedIn: false,
+    };
+  }
+}

--- a/astro-infoportal/src/transformers/HelpSearchPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpSearchPageTransformer.ts
@@ -1,0 +1,20 @@
+import type { IJSONTransformer } from "./IJSONTransformer";
+import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
+
+export class HelpSearchPageTransformer implements IJSONTransformer {
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+
+    return {
+      componentName: "HelpSearchPage",
+      pageName: cmsPageData?.name,
+      ...cmsPageData?.properties,
+      helpSearchPageUrl: cmsPageData?.route?.path,
+      searchPageUrl: globalData?.headerViewModel?.searchPageUrl,
+      breadcrumb,
+      isUserLoggedIn: false,
+    };
+  }
+}

--- a/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
@@ -1,0 +1,72 @@
+import type { IJSONTransformer } from "./IJSONTransformer";
+import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
+import { BlockTransformer } from "./BlockTransformer";
+
+function mapDrilldownPage(item: any) {
+  const props = item?.properties ?? {};
+  return {
+    pageName: item?.name,
+    url: item?.route?.path,
+    akselIcon: props.akselIcon,
+    triggerWords: props.triggerWords,
+    altImage: props.altImage,
+  };
+}
+
+function mapQuestionAreaItem(item: any) {
+  const props = item?.properties ?? {};
+  const ct = item?.contentType;
+  if (ct === "helpQuestionPage" || ct === "helpProcessArticlePage") {
+    return {
+      pageName: item?.name,
+      pageType: ct === "helpQuestionPage" ? "HelpQuestionPage" : "HelpProcessArticlePage",
+      url: item?.route?.path,
+      body: props.mainBody,
+    };
+  }
+  return null;
+}
+
+export class HelpStartPageTransformer implements IJSONTransformer {
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
+    const props = cmsPageData?.properties ?? {};
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
+
+    const newDrilldownPages = Array.isArray(props.newDrilldownPages)
+      ? props.newDrilldownPages.map(mapDrilldownPage)
+      : [];
+    const oldDrilldownPages = Array.isArray(props.oldDrilldownPages)
+      ? props.oldDrilldownPages.map(mapDrilldownPage)
+      : [];
+    const questionArea = Array.isArray(props.questionArea)
+      ? props.questionArea.map(mapQuestionAreaItem).filter(Boolean)
+      : [];
+
+    const helpContentArea = props.helpContentArea
+      ? BlockTransformer.TransformBlocks(props.helpContentArea)
+      : undefined;
+
+    const helpSearchPageUrl =
+      globalData?.headerViewModel?.searchPageUrl ?? "";
+
+    return {
+      componentName: "HelpStartPage",
+      breadcrumb,
+      pageName: cmsPageData?.name,
+      mainIntro: props.mainIntro,
+      newVersionHeading: props.newDrillDownTitle,
+      newDrilldownPages,
+      currentVersionHeading: props.oldDrillDownTitle,
+      oldDrilldownPages,
+      questionAreaHeading: props.questionAreaTitle,
+      questionArea,
+      helpContentAreaHeading: props.helpContentAreaTitle,
+      helpContentArea,
+      searchPlaceholder: props.searchPageTitle,
+      helpSearchPageUrl,
+      isUserLoggedIn: false,
+    };
+  }
+}

--- a/astro-infoportal/src/transformers/JSONTransformer.ts
+++ b/astro-infoportal/src/transformers/JSONTransformer.ts
@@ -6,6 +6,10 @@ import { ThemePageTransformer } from "./ThemePageTransformer";
 import { CategoryPageTransformer } from "./CategoryPageTransformer";
 import { HelpDrilldownPageTransformer } from "./HelpDrilldownPageTransformer";
 import { HelpLandingPageTransformer } from "./HelpLandingPageTransformer";
+import { HelpProcessArticlePageTransformer } from "./HelpProcessArticlePageTransformer";
+import { HelpQuestionPageTransformer } from "./HelpQuestionPageTransformer";
+import { HelpSearchPageTransformer } from "./HelpSearchPageTransformer";
+import { HelpStartPageTransformer } from "./HelpStartPageTransformer";
 import { StartPageTransformer } from "./StartPageTransformer";
 import { Error404PageTransformer } from "./Error404PageTransformer";
 import { SchemaPageTransformer } from "./SchemaPageTransformer";
@@ -19,7 +23,6 @@ import { NewsArchivePageTransformer } from "./NewsArchivePageTransformer";
 import { OperationalMessageArticlePageTransformer } from "./OperationalMessageArticlePageTransformer";
 import { OperationalMessageArchivePageTransformer } from "./OperationalMessageArchivePageTransformer";
 import { SchemaAttachmentPageTransformer } from "./SchemaAttachmentPageTransformer";
-import { HelpStartPageTransformer } from "./generatedTransformers/Pages/HelpStartPageTransformer";
 import { ContactFormPageTransformer } from "./generatedTransformers/Pages/ContactFormPageTransformer";
 import { hydrateNestedContactFormPageData } from "./contactFormData";
 
@@ -68,6 +71,12 @@ export class JSONTransformer implements IJSONTransformer {
         return new HelpDrilldownPageTransformer();
       case "helpLandingPage":
         return new HelpLandingPageTransformer();
+      case "helpProcessArticlePage":
+        return new HelpProcessArticlePageTransformer();
+      case "helpQuestionPage":
+        return new HelpQuestionPageTransformer();
+      case "helpSearchPage":
+        return new HelpSearchPageTransformer();
       case "helpStartPage":
         return new HelpStartPageTransformer();
       case "error404Page":
@@ -89,7 +98,7 @@ export class JSONTransformer implements IJSONTransformer {
       case "providerPage":
         return new ProviderPageTransformer();
       case "newsArchivePage":
-        return new NewsArchivePageTransformer();        
+        return new NewsArchivePageTransformer();
       case "operationalMessageArticlePage":
         return new OperationalMessageArticlePageTransformer();
       case "operationalMessageArchivePage":

--- a/astro-infoportal/wrangler.jsonc
+++ b/astro-infoportal/wrangler.jsonc
@@ -18,7 +18,7 @@
 		"UMBRACO_API_URL": "https://infoportal.at22.dis-core.altinn.cloud/",
 		"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 		"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-		"PAGES_FROM_OLD_PORTAL": "/hjelp,/nn/hjelp,/en/help,/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+		"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
         "OLD_PORTAL": "https://inte.info.altinn.no"
       },
   "env": {
@@ -28,7 +28,7 @@
 				"UMBRACO_API_URL": "https://infoportal.prod.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/hjelp,/nn/hjelp,/en/help,/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
         "OLD_PORTAL": "https://prod.info.altinn.no"
       }
 		},
@@ -38,7 +38,7 @@
 				"UMBRACO_API_URL": "https://infoportal.at22.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/hjelp,/nn/hjelp,/en/help,/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
         "OLD_PORTAL": "https://inte.info.altinn.no"
       }
 		},
@@ -48,7 +48,7 @@
 				"UMBRACO_API_URL": "https://infoportal.at23.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/hjelp,/nn/hjelp,/en/help,/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
         "OLD_PORTAL": "https://inte.info.altinn.no"
 			}
 		},
@@ -58,7 +58,7 @@
 				"UMBRACO_API_URL": "https://infoportal.tt02.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-tt02-ec939c.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/hjelp,/nn/hjelp,/en/help,/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui,/skjemaoversikt,/en/forms-overview/,/nn/skjemaoversikt",
+				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui,/skjemaoversikt,/en/forms-overview/,/nn/skjemaoversikt",
         "OLD_PORTAL": "https://prep.info.altinn.no"
 			}
 		}


### PR DESCRIPTION
Replaces the helpStartPage stub from #160 with real mappings, adds real transformers for the three other help types (HelpProcessArticle, HelpQuestion, HelpSearch), and drops /hjelp from PAGES_FROM_OLD_PORTAL.

Two gaps: drilldown card icons on HelpStartPage need ?expand=properties on the picker fetch, and HelpSearchPage transformer doesn't pull Elasticsearch results.