### PR TITLE
fix(SchemaPage): render Faglig brukerstøtte and metadata fields

### DIFF
--- a/astro-infoportal/src/Components/Shared/RichTextMetadata/RichTextMetadata.tsx
+++ b/astro-infoportal/src/Components/Shared/RichTextMetadata/RichTextMetadata.tsx
@@ -23,7 +23,11 @@ export const RichTextMetadata = ({ items }: RichTextMetadataProps) => {
             <IconComponent aria-hidden="true" className="rich-text-metadata__icon" />
             <dt className="rich-text-metadata__label">{item.label}:</dt>
             <dd className="rich-text-metadata__content">
-              <RichTextArea {...item.content} />
+              {typeof item.content === "string" ? (
+                item.content
+              ) : (
+                <RichTextArea {...item.content} />
+              )}
             </dd>
           </div>
         );

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -11,6 +11,10 @@ import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
 
+// Prefer rich text when an editor has populated it; fall back to the legacy plain-text field.
+const richTextOrText = (rich: any, text: any) =>
+  rich?.items?.length ? rich : text || undefined;
+
 export class SchemaPageTransformer implements IJSONTransformer {
   public async Transform(
     cmsPageData: any,
@@ -32,10 +36,6 @@ export class SchemaPageTransformer implements IJSONTransformer {
         }
       : props.mainIntro || undefined;
 
-    const promoArea = props.promoArea
-      ? BlockTransformer.TransformBlocks(props.promoArea)
-      : undefined;
-
     let shallowLinkText: string | undefined;
     if (props.shallowLink) {
       try {
@@ -47,7 +47,7 @@ export class SchemaPageTransformer implements IJSONTransformer {
       }
     }
 
-    props.accordianList.items.forEach((item: any) => {
+    props.accordianList?.items?.forEach((item: any) => {
       item.translatedHeading = t(item.translatedHeading, locale);
     });
 
@@ -77,6 +77,42 @@ export class SchemaPageTransformer implements IJSONTransformer {
         url: ref?.route?.path,
       };
     });
+
+    // `promoArea` (editor label "Faglig brukerstøtte") is a Content Picker, so refs
+    // arrive with `properties: {}` and must be hydrated. `providerContactInformationBlock`
+    // gets an explicit field mapping (mirrors ProviderPageTransformer.contactInfo);
+    // other block types fall back to BlockTransformer.
+    const resolvedPromoItems = await resolveBlockReferences(
+      props.promoArea,
+      locale,
+    );
+    const defaultProviderIcon = providerPages[0]?.providerIcon;
+    const promoItems = resolvedPromoItems.map((item: any) => {
+      if (item?.contentType === "providerContactInformationBlock") {
+        const bp = item.properties ?? {};
+        return {
+          componentName: "ProviderContactInformationBlock",
+          body: bp.body ?? undefined,
+          bottomText: bp.bottomText ?? undefined,
+          webpageLink: bp.webpageLink ?? undefined,
+          telephone: bp.telephone ?? "",
+          telephoneLabel: bp.telephoneLabel ?? "",
+          email: bp.email ?? "",
+          emailTitle: bp.emailTitle ?? "",
+          pageName: item.name,
+          providerIcon: defaultProviderIcon
+            ? {
+                name: defaultProviderIcon.name,
+                imageUrl: defaultProviderIcon.imageUrl,
+              }
+            : undefined,
+        };
+      }
+      return BlockTransformer.TransformBlocks([item]).items[0];
+    });
+    const promoArea = promoItems.length
+      ? { componentName: "ContentArea", items: promoItems }
+      : undefined;
 
     // Sidebar: schema's tree parent is a providerPage (URL: /skjemaoversikt/<provider>/<schema>/),
     // so the category/subcategory comes from the `subCategories` Content Picker property.
@@ -174,11 +210,11 @@ export class SchemaPageTransformer implements IJSONTransformer {
       preInstansiated: props.preInstansiated || false,
       schemaNotInUse: props.schemaNotInUse || false,
       deactivateButton: props.deactivateButton || false,
-      deadline: props.deadline || undefined,
+      deadline: richTextOrText(props.deadlineRichText, props.deadline),
       deadlineText: t("schema.deadline", locale),
-      processTime: props.processTime || undefined,
+      processTime: richTextOrText(props.processTimeRichText, props.processTime),
       processTimeText: t("schema.processTime", locale),
-      fee: props.fee || undefined,
+      fee: richTextOrText(props.feeRichText, props.fee),
       feeText: t("schema.fee", locale),
       securityLevelInfo: props.securityLevelInfo || undefined,
       shallowLink: props.shallowLink || undefined,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- promoArea (editor label "Faglig brukerstøtte") is a Content Picker; hydrate refs via resolveBlockReferences and map providerContactInformationBlock explicitly so the contact card renders with body/phone/email instead of an empty component shell.
- Prefer rich-text variants (deadlineRichText, processTimeRichText, feeRichText) with fallback to the legacy plain-text fields, so both shapes render during the rich-text migration.
- RichTextMetadata: render plain strings directly instead of spreading them into RichTextArea, which produced empty <dd> rows.
- Add null-safety to accordianList iteration so schemas without accordions don't throw during transform.
 
## Related Issue(s)
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/577

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
