### PR TITLE
feat: Add blob storage backup for infoportal media SA

### DIFF
--- a/.github/workflows/infoportal-media-sa-at22.yml
+++ b/.github/workflows/infoportal-media-sa-at22.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/infoportal-media-sa-at22.yml
       - infrastructure/altinn-portaler-test/infoportal-media-sa-at22/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - .github/workflows/infoportal-media-sa-at22.yml
       - infrastructure/altinn-portaler-test/infoportal-media-sa-at22/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   workflow_dispatch:
     inputs:
       log_level:
@@ -38,6 +40,7 @@ env:
   WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/infoportal-media-sa-at22
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+  TF_VAR_backup_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
 
 permissions:
   id-token: write

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/backup.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/backup.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "backup" {
+  provider = azurerm.backup
+  name     = "infoportal-media-sa-backup-at22"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+module "media_sa_backup" {
+  source = "../../modules/infoportal-media-sa-backup"
+
+  providers = {
+    azurerm        = azurerm.backup
+    azurerm.source = azurerm
+  }
+
+  storage_account_id    = module.media_sa.storage_account_id
+  resource_group_name   = azurerm_resource_group.backup.name
+  location              = azurerm_resource_group.backup.location
+  backup_vault_name     = "infoportal-media-bvault-at22"
+  backup_retention_days = 30
+  tags                  = local.tags
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/main.tf
@@ -26,3 +26,4 @@ module "media_sa" {
   blob_contributor_group_object_ids = var.blob_contributor_group_object_ids
   tags                              = local.tags
 }
+

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/outputs.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/outputs.tf
@@ -12,3 +12,8 @@ output "primary_blob_endpoint" {
   description = "Primary blob service endpoint URL"
   value       = module.media_sa.primary_blob_endpoint
 }
+
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = module.media_sa_backup.backup_vault_id
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/providers.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/providers.tf
@@ -24,3 +24,9 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
+
+provider "azurerm" {
+  alias           = "backup"
+  subscription_id = var.backup_subscription_id
+  features {}
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at22/variables.tf
@@ -1,3 +1,8 @@
+variable "backup_subscription_id" {
+  description = "Azure subscription ID where the backup vault will be created (separate from the storage account subscription)"
+  type        = string
+}
+
 variable "umbraco_sp_object_id" {
   description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
   type        = string

--- a/infrastructure/modules/infoportal-media-sa-backup/main.tf
+++ b/infrastructure/modules/infoportal-media-sa-backup/main.tf
@@ -37,6 +37,12 @@ resource "azurerm_role_assignment" "backup_vault_sa_contributor" {
   principal_id         = azurerm_data_protection_backup_vault.media.identity[0].principal_id
 }
 
+resource "azurerm_management_lock" "backup_vault" {
+  name       = "${var.backup_vault_name}-lock"
+  scope      = azurerm_data_protection_backup_vault.media.id
+  lock_level = "CanNotDelete"
+}
+
 # Backup instance is created in the vault subscription but references the cross-subscription storage account
 resource "azurerm_data_protection_backup_instance_blob_storage" "media" {
   name               = "${var.backup_vault_name}-instance"

--- a/infrastructure/modules/infoportal-media-sa-backup/main.tf
+++ b/infrastructure/modules/infoportal-media-sa-backup/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source                = "hashicorp/azurerm"
+      configuration_aliases = [azurerm.source]
+    }
+  }
+}
+
+# Vault and policy live in the backup subscription (default provider)
+resource "azurerm_data_protection_backup_vault" "media" {
+  name                = var.backup_vault_name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  datastore_type      = "OperationalStore"
+  redundancy          = "ZoneRedundant"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_data_protection_backup_policy_blob_storage" "media" {
+  name     = "blob-backup-policy"
+  vault_id = azurerm_data_protection_backup_vault.media.id
+
+  operational_default_retention_duration = "P${var.backup_retention_days}D"
+}
+
+# Role assignment scoped to the storage account in the source subscription
+resource "azurerm_role_assignment" "backup_vault_sa_contributor" {
+  provider             = azurerm.source
+  scope                = var.storage_account_id
+  role_definition_name = "Storage Account Backup Contributor"
+  principal_id         = azurerm_data_protection_backup_vault.media.identity[0].principal_id
+}
+
+# Backup instance is created in the vault subscription but references the cross-subscription storage account
+resource "azurerm_data_protection_backup_instance_blob_storage" "media" {
+  name               = "${var.backup_vault_name}-instance"
+  location           = var.location
+  vault_id           = azurerm_data_protection_backup_vault.media.id
+  storage_account_id = var.storage_account_id
+  backup_policy_id   = azurerm_data_protection_backup_policy_blob_storage.media.id
+
+  depends_on = [azurerm_role_assignment.backup_vault_sa_contributor]
+}

--- a/infrastructure/modules/infoportal-media-sa-backup/outputs.tf
+++ b/infrastructure/modules/infoportal-media-sa-backup/outputs.tf
@@ -1,0 +1,9 @@
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = azurerm_data_protection_backup_vault.media.id
+}
+
+output "backup_vault_principal_id" {
+  description = "Principal ID of the backup vault's system-assigned managed identity"
+  value       = azurerm_data_protection_backup_vault.media.identity[0].principal_id
+}

--- a/infrastructure/modules/infoportal-media-sa-backup/variables.tf
+++ b/infrastructure/modules/infoportal-media-sa-backup/variables.tf
@@ -1,0 +1,31 @@
+variable "storage_account_id" {
+  description = "Resource ID of the storage account to protect (in the source subscription)"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group in the backup subscription where the vault will be created"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region — must match the storage account's region"
+  type        = string
+}
+
+variable "backup_vault_name" {
+  description = "Name for the backup vault"
+  type        = string
+}
+
+variable "backup_retention_days" {
+  description = "Number of days to retain operational blob backups (1–360)"
+  type        = number
+  default     = 30
+}
+
+variable "tags" {
+  description = "Tags to apply to all taggable resources"
+  type        = map(string)
+  default     = {}
+}

--- a/infrastructure/modules/infoportal-media-sa/main.tf
+++ b/infrastructure/modules/infoportal-media-sa/main.tf
@@ -14,7 +14,8 @@ resource "azurerm_storage_account" "media" {
   shared_access_key_enabled = false
 
   blob_properties {
-    versioning_enabled = true
+    versioning_enabled  = true
+    change_feed_enabled = true
   }
 
   tags = var.tags


### PR DESCRIPTION
Add a new backup module that creates a data protection vault in a separate subscription and configures cross-subscription backup for the infoportal media storage account, with 30-day retention policy.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
