### PR TITLE
feat: migrate About Altinn pages (#614)

### DIFF
--- a/astro-infoportal/src/Components/Pages/AboutPage/AboutPage.tsx
+++ b/astro-infoportal/src/Components/Pages/AboutPage/AboutPage.tsx
@@ -7,6 +7,7 @@ import {
   SearchItem,
   Section,
 } from "@altinn/altinn-components";
+import { Fragment } from "react";
 import ContentArea from "../../Shared/ContentArea/ContentArea";
 import "./AboutPage.scss";
 
@@ -24,7 +25,7 @@ const AboutPage = ({ pageName, linkArea, contactArea }: any) => {
           {linkArea
             .filter((link: any) => !!link?.url)
             .map((link: any, index: number) => (
-              <React.Fragment key={link.url || index}>
+              <Fragment key={link.url || index}>
                 <SearchItem
                   as="a"
                   href={link.url || "#"}
@@ -32,7 +33,7 @@ const AboutPage = ({ pageName, linkArea, contactArea }: any) => {
                   summary={link.preamble}
                 />
                 <Divider as="li" />
-              </React.Fragment>
+              </Fragment>
             ))}
         </List>
       )}

--- a/astro-infoportal/src/transformers/AboutPageTransformer.ts
+++ b/astro-infoportal/src/transformers/AboutPageTransformer.ts
@@ -1,46 +1,27 @@
 import type { IJSONTransformer } from "./IJSONTransformer";
+import { resolveBlockReferences } from "../api/umbraco/client";
+import { BlockTransformer } from "./BlockTransformer";
 
 export class AboutPageTransformer implements IJSONTransformer {
-  public async Transform(cmsPageData: any): Promise<any> {
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
+    const props = cmsPageData?.properties ?? {};
 
-    /* C# logic (TS-ish++):
-    const culture: CultureInfo.CurrentCulture.NormalizeCulture();
-    
-                const linkitems: currentPage.LinkArea?.Items?
-                    .map(item: > item.LoadContent())
-                    .OfType<SitePageData>()
-                    .map(page: >
-                    {
-                        const url: urlResolver.GetUrl(page.ContentLink, culture.Name, { contextMode: ContextMode.Default });
-    
-                        string preamble: null;
-                        if isHeroArticlePageBase((page) heroArticlePage)
-                            preamble: heroArticlePage.MainIntro;
-    
-                        return {
-                            text: page.Name,
-                            url: url,
-                            preamble: preamble,
-                            
-                        };
-                    })
-                     ?? new();
-    
-                return {
-                    pageName: currentPage.PageName,
-                    linkArea: linkItems,
-                    contactArea: contentAreaPropsBuilder.Build({
-                        contentArea: currentPage.ContactArea,
-                        propertyName: "currentPage.ContactArea"
-                    }, withOnPageEdit),
-                    ope: withOnPageEdit ? {} : null
-                }
-    */
+    const resolvedLinks = await resolveBlockReferences(props.linkArea, globalData?.locale);
+    const linkArea = resolvedLinks.map((item: any) => ({
+      text: item?.name,
+      url: item?.route?.path,
+      preamble: item?.properties?.mainIntro,
+    }));
+
+    const contactArea = props.contactArea
+      ? BlockTransformer.TransformBlocks(props.contactArea)
+      : undefined;
 
     return {
       componentName: "AboutPage",
-      pageName: cmsPageData.name,
-      ...cmsPageData.properties,
+      pageName: cmsPageData?.name,
+      linkArea,
+      contactArea,
       isUserLoggedIn: false,
     };
   }

--- a/astro-infoportal/src/transformers/JSONTransformer.ts
+++ b/astro-infoportal/src/transformers/JSONTransformer.ts
@@ -3,6 +3,7 @@ import { t } from "@i18n/index";
 import { SectionPageTransformer } from "./SectionPageTransformer";
 import { HeroArticlePageBaseTransformer } from "./HeroArticlePageBaseTransformer";
 import { ThemePageTransformer } from "./ThemePageTransformer";
+import { AboutPageTransformer } from "./AboutPageTransformer";
 import { CategoryPageTransformer } from "./CategoryPageTransformer";
 import { HelpDrilldownPageTransformer } from "./HelpDrilldownPageTransformer";
 import { HelpLandingPageTransformer } from "./HelpLandingPageTransformer";
@@ -65,6 +66,8 @@ export class JSONTransformer implements IJSONTransformer {
     switch (umbracoContentType) {
       case "startPage":
         return new StartPageTransformer();
+      case "aboutPage":
+        return new AboutPageTransformer();
       case "categoryPage":
         return new CategoryPageTransformer();
       case "helpDrilldownPage":

--- a/astro-infoportal/wrangler.jsonc
+++ b/astro-infoportal/wrangler.jsonc
@@ -18,7 +18,7 @@
 		"UMBRACO_API_URL": "https://infoportal.at22.dis-core.altinn.cloud/",
 		"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 		"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-		"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+		"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
         "OLD_PORTAL": "https://inte.info.altinn.no"
       },
   "env": {
@@ -28,7 +28,7 @@
 				"UMBRACO_API_URL": "https://infoportal.prod.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
         "OLD_PORTAL": "https://prod.info.altinn.no"
       }
 		},
@@ -38,7 +38,7 @@
 				"UMBRACO_API_URL": "https://infoportal.at22.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
         "OLD_PORTAL": "https://inte.info.altinn.no"
       }
 		},
@@ -48,7 +48,7 @@
 				"UMBRACO_API_URL": "https://infoportal.at23.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui",
+				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
         "OLD_PORTAL": "https://inte.info.altinn.no"
 			}
 		},
@@ -58,7 +58,7 @@
 				"UMBRACO_API_URL": "https://infoportal.tt02.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-tt02-ec939c.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"PAGES_FROM_OLD_PORTAL": "/om-altinn,/en/about-altinn,/nn/om-altinn,/inforportalapi/,/ui,/skjemaoversikt,/en/forms-overview/,/nn/skjemaoversikt",
+				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui,/skjemaoversikt,/en/forms-overview/,/nn/skjemaoversikt",
         "OLD_PORTAL": "https://prep.info.altinn.no"
 			}
 		}


### PR DESCRIPTION
Replaces the AboutPage transformer spread-stub with explicit linkArea/contactArea mapping (uses resolveBlockReferences to get article preambles), registers aboutPage in JSONTransformer, fixes a latent React.Fragment import bug in AboutPage.tsx, and drops /om-altinn from PAGES_FROM_OLD_PORTAL.

Tested /om-altinn/ and child article pages render against at22 with correct link list + previews.