### PR TITLE
chore(umbraco): add OpenTelemetry env vars

### DIFF
--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -40,6 +40,19 @@ spec:
               value: "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True"
             - name: ConnectionStrings__umbracoDbDSN_ProviderName
               value: "Microsoft.Data.Sqlite"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://otel-collector.monitoring.svc.cluster.local:4317
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: grpc
+            - name: OTEL_SERVICE_NAME
+              value: infoportal
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
## Summary
- Add `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_SERVICE_NAME` so the umbraco container exports OTLP/gRPC to `otel-collector.monitoring.svc.cluster.local:4317`.
- Add `POD_UID` (downward API) and `OTEL_RESOURCE_ATTRIBUTES=k8s.pod.uid=$(POD_UID)` to tag telemetry with pod UID.

## Test plan
- [ ] Roll out deployment and verify env vars are set on the umbraco pod (`kubectl describe pod`).
- [ ] Confirm traces/metrics arrive at the `otel-collector` in the `monitoring` namespace.
- [ ] Confirm `k8s.pod.uid` resource attribute is present on exported telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)