### PR TITLE
bokmål fallback

### DIFF
--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -20,6 +20,7 @@ export function getGlobalData(
   cultures: CultureRoutes = {},
   startPage?: { properties?: Record<string, unknown> },
   currentPageContentType?: string,
+  currentPath?: string,
 ) {
   const afBase = endpoints.afBaseUrl.replace(/\/$/, "");
   const amUiBase = endpoints.amUiBaseUrl.replace(/\/$/, "");
@@ -60,7 +61,7 @@ export function getGlobalData(
       loggedInAsText: t("header.loggedInAs", locale),
       backButtonText: t("header.back", locale),
       chooseLanguageText: t("header.chooseLanguage", locale),
-      menuLanguageList: buildMenuLanguageList(locale, cultures),
+      menuLanguageList: buildMenuLanguageList(locale, cultures, currentPath),
       shortcutText: t("header.shortcuts", locale),
       menuText: t("header.menu", locale),
       searchTextPlaceholder: t("header.searchPlaceholder", locale),

--- a/astro-infoportal/src/Constants/languages.ts
+++ b/astro-infoportal/src/Constants/languages.ts
@@ -39,12 +39,49 @@ const LOCALE_HOME: Record<Locale, string> = {
 export type CultureRoute = { path: string };
 export type CultureRoutes = Partial<Record<Locale, CultureRoute>>;
 
+const LOCALE_PREFIXES: Record<Locale, string> = {
+  nb: "",
+  nn: "/nn",
+  en: "/en",
+};
+
+function stripLocalePrefix(path: string): string {
+  const match = path.match(/^\/(nn|en)(?=\/|$)/);
+  const stripped = match ? path.slice(match[0].length) : path;
+  if (!stripped) return "/";
+  return stripped.startsWith("/") ? stripped : `/${stripped}`;
+}
+
+/**
+ * Derive the equivalent URL for `targetLocale` from the page's bokmål
+ * pathname, so the locale switcher keeps the user on the same page when the
+ * target locale isn't an official translation. Combined with the
+ * Accept-Language fallback in `fetchUmbracoContentWithLocaleFallback`, the
+ * resulting URL will render the bokmål content under the chosen locale's
+ * chrome. The bokmål path is preferred as the base because nb is the
+ * editorial source of truth — translated locales may use entirely different
+ * slugs (e.g. `/en/help` vs `/hjelp`), so the current URL alone isn't
+ * reliable when switching away from a translated page.
+ */
+function deriveLocaleUrl(nbPath: string, targetLocale: Locale): string {
+  if (!nbPath) return LOCALE_HOME[targetLocale];
+  const path = nbPath.startsWith("/") ? nbPath : `/${nbPath}`;
+  const derived = `${LOCALE_PREFIXES[targetLocale]}${path}`;
+  return derived || LOCALE_HOME[targetLocale];
+}
+
 export function buildMenuLanguageList(
   currentLocale: Locale,
   cultures: CultureRoutes = {},
+  currentPath?: string,
 ) {
+  const nbPath =
+    cultures.nb?.path ?? (currentPath ? stripLocalePrefix(currentPath) : undefined);
+
   return SUPPORTED_LOCALES.map((l) => ({
-    pageUrl: cultures[l.locale]?.path ?? LOCALE_HOME[l.locale],
+    pageUrl:
+      cultures[l.locale]?.path ??
+      (nbPath ? deriveLocaleUrl(nbPath, l.locale) : LOCALE_HOME[l.locale]),
     languageTeaser: l.languageTeaser,
     languageImage: l.languageImage,
     languageName: l.languageName,

--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -70,6 +70,33 @@ export async function fetchUmbracoContent(path: string, culture?: string) {
   return await response.json();
 }
 
+/**
+ * Fetch a content item with locale fallback to bokmål.
+ *
+ * If a request for /{nn|en}/... 404s, retry once with the locale prefix
+ * stripped and Accept-Language: nb. This matches the editorial expectation
+ * that untranslated pages render their NB content while the surrounding
+ * chrome stays in the requested locale.
+ */
+export async function fetchUmbracoContentWithLocaleFallback(
+  path: string,
+  culture?: string,
+) {
+  try {
+    return await fetchUmbracoContent(path, culture);
+  } catch (error) {
+    if (culture && culture !== "nb") {
+      const normalized = normalizeItemPath(path);
+      const prefix = `/${culture}/`;
+      if (normalized.startsWith(prefix)) {
+        const fallbackPath = normalized.slice(prefix.length - 1) || "/";
+        return await fetchUmbracoContent(fallbackPath, "nb");
+      }
+    }
+    throw error;
+  }
+}
+
 export async function fetchUmbracoContentById(id: string, culture?: string) {
   const url = deliveryUrl(
     `/umbraco/delivery/api/v2/content/item/${encodeURIComponent(id)}`,

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 
-import { fetchUmbracoContent, fetchUmbracoErrorPage, fetchUmbracoStartPage } from '@api/umbraco/client';
+import { fetchUmbracoContentWithLocaleFallback, fetchUmbracoErrorPage, fetchUmbracoStartPage } from '@api/umbraco/client';
 import { fetchFromOldPortal } from '@api/oldportal/client';
 import { shouldFetchFromOldPortal } from '@api/oldportal/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
@@ -51,7 +51,7 @@ if (redirectTarget && redirectTarget !== path) {
 const isLocaleRoot = isNorwegianStartRoot || /^\/(nn|en)\/?$/.test(path);
 const umbracoPath = isNorwegianStartRoot ? "/" : path;
 
-const pagePromise = fetchUmbracoContent(umbracoPath, locale);
+const pagePromise = fetchUmbracoContentWithLocaleFallback(umbracoPath, locale);
 const startPagePromise = isLocaleRoot ? pagePromise : fetchUmbracoStartPage(locale);
 
 const [pageResult, startPageResult] = await Promise.allSettled([

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -73,7 +73,7 @@ if (pageResult.status === 'rejected') {
 
 const startPageData = startPageResult.status === 'fulfilled' ? startPageResult.value : null;
 
-let globalData: any = getGlobalData(locale, "/sok/", altinnEndpoints, umbracoPageData?.cultures, startPageData, umbracoPageData?.contentType);
+let globalData: any = getGlobalData(locale, "/sok/", altinnEndpoints, umbracoPageData?.cultures, startPageData, umbracoPageData?.contentType, path);
 globalData = {
   ...globalData,
   startPageData,

--- a/astro-infoportal/src/transformers/generatedTransformers/Blocks/AdvisorStartBlockTransformer.ts
+++ b/astro-infoportal/src/transformers/generatedTransformers/Blocks/AdvisorStartBlockTransformer.ts
@@ -1,45 +1,142 @@
 import type { IJSONTransformer } from "../IJSONTransformer";
 
+// Image lookup keyed by block heading. Heading text varies per locale and even
+// within a locale (definite vs indefinite Norwegian forms, editor typos with
+// trailing spaces), so every observed variant is enumerated here. Lookup is
+// normalized (trim + lowercase) before matching. Note: nynorsk collapses the
+// definite/indefinite bokmål forms to one heading; where that happens the nynorsk
+// entry mirrors the definite form's image.
 const ADVISOR_START_BLOCK_IMAGE_MAP_RAW: Record<string, { src: string; alt: string }> = {
+    // valg av organisasjonsform
     "Veileder for valg av organisasjonsform": {
         src: "/assets/img/illustrasjon_arbeidsforhold_sirkel.svg",
         alt: "Illustrasjon for veileder organisasjonsform",
     },
+    "Rettleiar for val av organisasjonsform": {
+        src: "/assets/img/illustrasjon_arbeidsforhold_sirkel.svg",
+        alt: "Illustrasjon for rettleiar organisasjonsform",
+    },
+    "Tutorial for choosing legal structure": {
+        src: "/assets/img/illustrasjon_arbeidsforhold_sirkel.svg",
+        alt: "Illustration for choosing legal structure",
+    },
+
+    // enkeltpersonforetak — indefinite NB form
     "Oppstartsveileder for enkeltpersonforetak": {
         src: "/assets/img/altinn-veileder-sirkel.svg",
         alt: "Illustrasjon for veileder enkeltpersonforetak",
     },
+    "Startup tutorial for sole proprietorships": {
+        src: "/assets/img/altinn-veileder-sirkel.svg",
+        alt: "Illustration for sole proprietorship tutorial",
+    },
+
+    // enkeltpersonforetak — definite NB form (used on the "oppstartsveileder-for-enkeltpersonforetak" page)
     "Oppstartsveilederen for enkeltpersonforetak": {
         src: "/assets/img/illustrasjon_loginn_sirkel_2.svg",
         alt: "Illustrasjon for veileder enkeltpersonforetak",
     },
+    "Oppstartsrettleiar for enkeltpersonføretak": {
+        src: "/assets/img/illustrasjon_loginn_sirkel_2.svg",
+        alt: "Illustrasjon for rettleiar enkeltpersonføretak",
+    },
+    "Start-up tutorial for sole proprietorship": {
+        src: "/assets/img/illustrasjon_loginn_sirkel_2.svg",
+        alt: "Illustration for sole proprietorship tutorial",
+    },
+
+    // aksjeselskap — indefinite NB form
     "Oppstartsveileder for aksjeselskap": {
         src: "/assets/img/illustrasjon_regnskap_og_revisjon_sirkel.svg",
         alt: "Illustrasjon for veileder aksjeselskap",
     },
+    "Startup tutorial for private limited company": {
+        src: "/assets/img/illustrasjon_regnskap_og_revisjon_sirkel.svg",
+        alt: "Illustration for private limited company tutorial",
+    },
+
+    // aksjeselskap — definite NB form (used on the "oppstartsveileder-for-enkeltpersonforetak" page)
     "Oppstartsveilederen for aksjeselskap": {
         src: "/assets/img/illustrasjon_loginn_sirkel_1.svg",
         alt: "Illustrasjon for veileder aksjeselskap",
     },
+    "Oppstartsrettleiar for aksjeselskap": {
+        src: "/assets/img/illustrasjon_loginn_sirkel_1.svg",
+        alt: "Illustrasjon for rettleiar aksjeselskap",
+    },
+    "Start-up tutorial for private limited company": {
+        src: "/assets/img/illustrasjon_loginn_sirkel_1.svg",
+        alt: "Illustration for private limited company tutorial",
+    },
+
+    // serveringsbransjen
     "Veileder for serveringsbransjen": {
         src: "/assets/img/illustrasjon_hjelp_sirkel_1.svg",
         alt: "Illustrasjon for veileder serveringsbransjen",
     },
+    "Rettleiar for serveringsbransjen": {
+        src: "/assets/img/illustrasjon_hjelp_sirkel_1.svg",
+        alt: "Illustrasjon for rettleiar serveringsbransjen",
+    },
+    "Tutorial for the food and beverage services sector": {
+        src: "/assets/img/illustrasjon_hjelp_sirkel_1.svg",
+        alt: "Illustration for the food and beverage services sector",
+    },
+
+    // renholdsbransjen / reinhaldsbransjen
     "Veileder for renholdsbransjen": {
         src: "/assets/img/illustrasjon_skatt_og_avgift_sirkel.svg",
         alt: "Veileder for renholdsbransjen",
     },
+    "Rettleiar for reinhaldsbransjen": {
+        src: "/assets/img/illustrasjon_skatt_og_avgift_sirkel.svg",
+        alt: "Rettleiar for reinhaldsbransjen",
+    },
+    "Guide for the cleaning industry": {
+        src: "/assets/img/illustrasjon_skatt_og_avgift_sirkel.svg",
+        alt: "Guide for the cleaning industry",
+    },
+
+    // frisørbransjen
     "Veiledning for frisørbransjen": {
         src: "/assets/img/illustrasjon_loginn_sirkel_1.svg",
         alt: "Illustrasjon for veileder frisør",
     },
+    "Rettleiing for frisørbransjen": {
+        src: "/assets/img/illustrasjon_loginn_sirkel_1.svg",
+        alt: "Illustrasjon for rettleiar frisør",
+    },
+    "Guidance for the hairdressing industry": {
+        src: "/assets/img/illustrasjon_loginn_sirkel_1.svg",
+        alt: "Guidance for the hairdressing industry",
+    },
+
+    // byggebransjen
     "Veiledning for byggebransjen": {
         src: "/assets/img/illustrasjon_starte_og_drive_sirkel.svg",
         alt: "Illustrasjon for veileder elektriker og rørlegger",
     },
+    "Rettleiing for byggebransjen": {
+        src: "/assets/img/illustrasjon_starte_og_drive_sirkel.svg",
+        alt: "Illustrasjon for rettleiar elektrikar og røyrleggjar",
+    },
+    "Guidance for the construction industry": {
+        src: "/assets/img/illustrasjon_starte_og_drive_sirkel.svg",
+        alt: "Guidance for the construction industry",
+    },
+
+    // varebransjen
     "Veiledning for varebransjen": {
         src: "/assets/img/illustrasjon_arbeidsforhold_sirkel.svg",
         alt: "Illustrasjon for veileder varebransjen",
+    },
+    "Rettleiing for varebransjen": {
+        src: "/assets/img/illustrasjon_arbeidsforhold_sirkel.svg",
+        alt: "Illustrasjon for rettleiar varebransjen",
+    },
+    "Guidance for the retail industry": {
+        src: "/assets/img/illustrasjon_arbeidsforhold_sirkel.svg",
+        alt: "Guidance for the retail industry",
     },
 };
 


### PR DESCRIPTION
 Fixes these issues:
  - [610](https://github.com/Altinn/altinn-infoportal-optimizely/issues/610)
  - [603](https://github.com/Altinn/info.altinn.no/issues/381)

                                                                                                                            
  ## Implements bokmål fallback for untranslated pages and fills in missing illustrations for `AdvisorStartBlock` across all locales.
                                                                                                                                     
  ### Locale fallback for Umbraco content fetching                                
  Adds `fetchUmbracoContentWithLocaleFallback` in `astro-infoportal/src/api/umbraco/client.ts`. When a request for `/nn/…` or `/en/…` returns 404, it retries once with the locale prefix stripped and `Accept-Language: nb`. The catch-all `[...slug].astro` now uses this helper, so untranslated pages render their NB content while the surrounding chrome stays in the requested locale.
                                                                                                                                     
  ### Language switcher preserves the current page                                                                       
  Previously, switching language on an untranslated page sent the user to the locale home (`/nn/` or `/en/`) because
  `cultures[targetLocale]` was undefined. `buildMenuLanguageList` now derives a fallback URL from `cultures.nb.path` (the editorial source of truth) by prepending the target locale's prefix, with the current pathname as a last-resort backup. The current pathname is threaded through `getGlobalData → buildMenuLanguageList` from `[...slug].astro`. Combined with the fetch-side fallback above, the user stays on the same page when switching languages, and the page renders NB content under the chosen locale's chrome.
                                         
  ### Localized illustrations for `AdvisorStartBlock`                                                                    
  Heading-based image lookup in `AdvisorStartBlockTransformer` only covered NB variants, so cards rendered without illustrations in NN and EN. The map now enumerates every observed NB/NN/EN heading (gathered from the Umbraco API) grouped by editorial concept. The existing `normalizeHeadingKey` (trim + lowercase) handles trailing whitespace and casing.  
                                                                                              
  ### Test plan                          
  - [ ] Visit `/en/<nb-only-path>` and `/nn/<nb-only-path>` — page renders NB content with localized chrome. Example: [/nyheter/ki-sok/](https://info.at22.altinn.cloud/nyheter/ki-sok/)
  - [ ] Switch language via the header on a NB-only page — URL becomes `/en/<same-slug>/` (or `/nn/<same-slug>/`) and renders, instead of redirecting to the locale home.                                                                                         
  - [ ] Switch from a translated EN page to NN where NN isn't translated — lands on `/nn/<nb-slug>/` and renders NB content.         
  - [ ] Open `oppstartsveileder-for-enkeltpersonforetak/` in `nb`, `nn`, `en` — both cards show illustrations matching prod.  