### PR TITLE
fix: render block content correctly across affected pages

### DIFF
--- a/astro-infoportal/src/Components/Blocks/AccordianCollectionBlock/AccordianCollectionBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/AccordianCollectionBlock/AccordianCollectionBlock.tsx
@@ -1,10 +1,12 @@
 import { ContentArea } from "/App.Components";
 
-const AccordianCollectionBlock = ({
-    accordianArea,
-}: any) => {
-    return <>
-        {accordianArea && <ContentArea {...accordianArea} />}
-    </>;
+// Umbraco's RichTextPropertyConverter delivers `accordianArea` as a raw array of
+// pre-rendered block items, whereas Optimizely supplied a {componentName, items}
+// shape. Accept both and normalise so ContentArea sees its expected `items` prop.
+const AccordianCollectionBlock = ({ accordianArea }: any) => {
+    const data = Array.isArray(accordianArea)
+        ? { items: accordianArea }
+        : accordianArea;
+    return data ? <ContentArea {...data} /> : null;
 };
 export default AccordianCollectionBlock;

--- a/astro-infoportal/src/Components/Blocks/LinkBlock/LinkBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/LinkBlock/LinkBlock.tsx
@@ -6,8 +6,14 @@ const LinkBlock = ({
   // icon,
   extraTitle,
   link,
+  urlBlock,
 }: any) => {
-  if (!link?.linkText || !link?.url) {
+  // Legacy Optimizely shape supplied a built `link` view-model. Umbraco's
+  // RichTextPropertyConverter instead exposes the raw picker as `urlBlock`
+  // (array). Accept either; pick the first populated item.
+  const resolved =
+    link ?? (Array.isArray(urlBlock) ? urlBlock[0] : urlBlock);
+  if (!resolved?.linkText || !resolved?.url) {
     return null;
   }
 
@@ -35,12 +41,12 @@ const LinkBlock = ({
             <p className="a-iconText-text-small">{extraTitle}</p>
           )}
           <a
-            href={link.url}
+            href={resolved.url}
             className="a-linkFeatured"
-            target={link.openInNewWindow ? "_blank" : undefined}
-            rel={link.openInNewWindow ? "noopener noreferrer" : undefined}
+            target={resolved.openInNewWindow ? "_blank" : undefined}
+            rel={resolved.openInNewWindow ? "noopener noreferrer" : undefined}
           >
-            {link.linkText}
+            {resolved.linkText}
           </a>
         </div>
       </div>

--- a/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
@@ -1,7 +1,8 @@
 import type { IJSONTransformer } from "./IJSONTransformer";
-import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import { fetchUmbracoAncestors, resolveBlockReferences } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import { BlockTransformer } from "./BlockTransformer";
+import { type Locale, t } from "@i18n/index";
 
 function mapDrilldownPage(item: any) {
   const props = item?.properties ?? {};
@@ -28,24 +29,70 @@ function mapQuestionAreaItem(item: any) {
   return null;
 }
 
+// Mirrors the legacy Optimizely ContactListBlockViewModelBuilder shape: i18n labels
+// for contactNumberText, and contactFormLocation reshaped from a picker array into
+// a LinkItem-ish object. contactFormPageData is attached by
+// hydrateNestedContactFormPageData in JSONTransformer.
+function mapContactListBlock(props: any, locale: Locale) {
+  const locationRefs = Array.isArray(props.contactFormLocation)
+    ? props.contactFormLocation
+    : [];
+  const firstLocation = locationRefs[0];
+  const contactFormLocation = firstLocation
+    ? {
+        text: t("support.contactForm", locale),
+        url: firstLocation?.route?.path,
+        route: firstLocation?.route,
+      }
+    : undefined;
+
+  return {
+    componentName: "ContactListBlock",
+    contactHeading: props.contactHeading ?? undefined,
+    text: props.text ?? undefined,
+    useContactNumberButton: props.useContactNumberButton ?? false,
+    contactNumber: props.contactNumber ?? "",
+    contactNumberText: t("support.contactTelephone", locale),
+    useContactFormButton: props.useContactFormButton ?? false,
+    contactFormLocation,
+  };
+}
+
 export class HelpStartPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData?.properties ?? {};
+    const locale: Locale = globalData?.locale || "nb";
     const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
-    const newDrilldownPages = Array.isArray(props.newDrilldownPages)
-      ? props.newDrilldownPages.map(mapDrilldownPage)
-      : [];
-    const oldDrilldownPages = Array.isArray(props.oldDrilldownPages)
-      ? props.oldDrilldownPages.map(mapDrilldownPage)
-      : [];
-    const questionArea = Array.isArray(props.questionArea)
-      ? props.questionArea.map(mapQuestionAreaItem).filter(Boolean)
-      : [];
+    // Drilldown/question/contact picker refs arrive with `properties: {}`;
+    // hydrate each ref so the mappers below have access to inline properties
+    // (icon, triggerWords, mainBody, contact fields).
+    const [
+      newDrilldownRefs,
+      oldDrilldownRefs,
+      questionAreaRefs,
+      helpContentRefs,
+    ] = await Promise.all([
+      resolveBlockReferences(props.newDrilldownPages, locale),
+      resolveBlockReferences(props.oldDrilldownPages, locale),
+      resolveBlockReferences(props.questionArea, locale),
+      resolveBlockReferences(props.helpContentArea, locale),
+    ]);
 
-    const helpContentArea = props.helpContentArea
-      ? BlockTransformer.TransformBlocks(props.helpContentArea)
+    const newDrilldownPages = newDrilldownRefs.map(mapDrilldownPage);
+    const oldDrilldownPages = oldDrilldownRefs.map(mapDrilldownPage);
+    const questionArea = questionAreaRefs.map(mapQuestionAreaItem).filter(Boolean);
+
+    const helpContentItems = helpContentRefs.map((item: any) => {
+      const blockProps = item?.properties ?? {};
+      if (item?.contentType === "contactListBlock") {
+        return mapContactListBlock(blockProps, locale);
+      }
+      return BlockTransformer.TransformBlocks([item]).items[0];
+    });
+    const helpContentArea = helpContentItems.length
+      ? { componentName: "ContentArea", items: helpContentItems }
       : undefined;
 
     const helpSearchPageUrl =

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -78,38 +78,41 @@ export class SchemaPageTransformer implements IJSONTransformer {
       };
     });
 
-    // `promoArea` (editor label "Faglig brukerstøtte") is a Content Picker, so refs
-    // arrive with `properties: {}` and must be hydrated. `providerContactInformationBlock`
-    // gets an explicit field mapping (mirrors ProviderPageTransformer.contactInfo);
-    // other block types fall back to BlockTransformer.
-    const resolvedPromoItems = await resolveBlockReferences(
-      props.promoArea,
-      locale,
-    );
-    const defaultProviderIcon = providerPages[0]?.providerIcon;
-    const promoItems = resolvedPromoItems.map((item: any) => {
-      if (item?.contentType === "providerContactInformationBlock") {
-        const bp = item.properties ?? {};
-        return {
-          componentName: "ProviderContactInformationBlock",
-          body: bp.body ?? undefined,
-          bottomText: bp.bottomText ?? undefined,
-          webpageLink: bp.webpageLink ?? undefined,
-          telephone: bp.telephone ?? "",
-          telephoneLabel: bp.telephoneLabel ?? "",
-          email: bp.email ?? "",
-          emailTitle: bp.emailTitle ?? "",
-          pageName: item.name,
-          providerIcon: defaultProviderIcon
-            ? {
-                name: defaultProviderIcon.name,
-                imageUrl: defaultProviderIcon.imageUrl,
-              }
-            : undefined,
-        };
-      }
-      return BlockTransformer.TransformBlocks([item]).items[0];
-    });
+    // `promoArea` (editor label "Faglig brukerstøtte") is a Block List. Items wrap
+    // each block as `{ content: { contentType, id, properties }, settings }`, with
+    // properties inline (no picker hydration needed). The `formElementContactFreetext`
+    // element type maps to ProviderContactInformationBlock; other block types fall
+    // back to BlockTransformer's contentType-keyed registry.
+    const promoBlockItems: any[] = Array.isArray(props.promoArea?.items)
+      ? props.promoArea.items
+      : [];
+    const defaultProvider = providerPages[0];
+    const promoItems = promoBlockItems
+      .map((wrapper: any) => {
+        const content = wrapper?.content ?? wrapper;
+        const blockProps = content?.properties ?? {};
+        if (content?.contentType === "formElementContactFreetext") {
+          return {
+            componentName: "ProviderContactInformationBlock",
+            body: blockProps.body ?? undefined,
+            bottomText: blockProps.bottomText ?? undefined,
+            webpageLink: blockProps.webpageLink ?? undefined,
+            telephone: blockProps.telephone ?? "",
+            telephoneLabel: blockProps.telephoneLabel ?? "",
+            email: blockProps.email ?? "",
+            emailTitle: blockProps.emailTitle ?? "",
+            pageName: defaultProvider?.name ?? "",
+            providerIcon: defaultProvider?.providerIcon
+              ? {
+                  name: defaultProvider.providerIcon.name,
+                  imageUrl: defaultProvider.providerIcon.imageUrl,
+                }
+              : undefined,
+          };
+        }
+        return BlockTransformer.TransformBlocks([content]).items[0];
+      })
+      .filter(Boolean);
     const promoArea = promoItems.length
       ? { componentName: "ContentArea", items: promoItems }
       : undefined;

--- a/astro-infoportal/src/transformers/ThemePageTransformer.ts
+++ b/astro-infoportal/src/transformers/ThemePageTransformer.ts
@@ -1,8 +1,61 @@
 import type { IJSONTransformer } from "./IJSONTransformer";
-import { fetchUmbracoAncestors, fetchUmbracoChildrenInEditorOrder, fetchUmbracoContent } from "../api/umbraco/client";
+import {
+  fetchUmbracoAncestors,
+  fetchUmbracoChildrenInEditorOrder,
+  fetchUmbracoContent,
+  resolveBlockReferences,
+} from "../api/umbraco/client";
 import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
-import type { Locale } from "@i18n/index";
+import { type Locale, t } from "@i18n/index";
+
+// Mirrors the legacy Optimizely CampaignBlockViewModelBuilder. Umbraco's link
+// editor stores a plain URL string, but the component expects { url, text }.
+// Use the block's content name as heading text (the picked node's name).
+function mapCampaignBlock(item: any) {
+  const props = item?.properties ?? {};
+  const rawLink = props.link;
+  const linkUrl =
+    typeof rawLink === "string" ? rawLink : rawLink?.url ?? undefined;
+  const linkText =
+    typeof rawLink === "string"
+      ? item?.name ?? ""
+      : rawLink?.text ?? item?.name ?? "";
+  return {
+    componentName: "CampaignBlock",
+    link: linkUrl ? { url: linkUrl, text: linkText } : null,
+    description: props.description ?? null,
+  };
+}
+
+// Mirrors the legacy Optimizely ContactListBlockViewModelBuilder: contactNumberText
+// always comes from i18n, and the contactFormLocation MNTP ref is reshaped into a
+// LinkItem-ish object with localized link text. contactFormPageData is attached
+// later by hydrateNestedContactFormPageData in JSONTransformer.
+function mapContactListBlock(props: any, locale: Locale) {
+  const locationRefs = Array.isArray(props.contactFormLocation)
+    ? props.contactFormLocation
+    : [];
+  const firstLocation = locationRefs[0];
+  const contactFormLocation = firstLocation
+    ? {
+        text: t("support.contactForm", locale),
+        url: firstLocation?.route?.path,
+        route: firstLocation?.route,
+      }
+    : undefined;
+
+  return {
+    componentName: "ContactListBlock",
+    contactHeading: props.contactHeading ?? undefined,
+    text: props.text ?? undefined,
+    useContactNumberButton: props.useContactNumberButton ?? false,
+    contactNumber: props.contactNumber ?? "",
+    contactNumberText: t("support.contactTelephone", locale),
+    useContactFormButton: props.useContactFormButton ?? false,
+    contactFormLocation,
+  };
+}
 
 const articleContentTypes = new Set([
   "articlePage",
@@ -77,8 +130,26 @@ export class ThemePageTransformer implements IJSONTransformer {
       }),
     );
 
-    const bottomContentArea = props.bottomContentArea
-      ? BlockTransformer.TransformBlocks(props.bottomContentArea)
+    // `bottomContentArea` (editor label "Faglig brukerstøtte") is a Content Picker.
+    // Refs arrive with `properties: {}`; hydrate them, then map known block types
+    // (mirroring legacy Optimizely ViewModelBuilders) so the React components receive
+    // the shape they expect. Unknown types fall through to BlockTransformer.
+    const hydratedBottomItems = await resolveBlockReferences(
+      props.bottomContentArea,
+      locale,
+    );
+    const bottomItems = hydratedBottomItems.map((item: any) => {
+      const blockProps = item?.properties ?? {};
+      if (item?.contentType === "contactListBlock") {
+        return mapContactListBlock(blockProps, locale);
+      }
+      if (item?.contentType === "campaignBlock") {
+        return mapCampaignBlock(item);
+      }
+      return BlockTransformer.TransformBlocks([item]).items[0];
+    });
+    const bottomContentArea = bottomItems.length
+      ? { componentName: "ContentArea", items: bottomItems }
       : undefined;
 
     return {

--- a/umbraco-infoportal/BlockListPropertyConverter.cs
+++ b/umbraco-infoportal/BlockListPropertyConverter.cs
@@ -28,9 +28,13 @@ public class BlockListPropertyConverter : IPropertyValueConverter
         _publishedContentCache = publishedContentCache;
     }
 
-    // Make sure the Property Value Converter only applies to the Content Picker property editor
+    // This converter pre-renders schemaAccordianBlock content into a ContentArea shape
+    // (see ConvertIntermediateToObject). Apply it only to `accordianList` so other
+    // BlockList properties (e.g. `promoArea` on schemaPage) return raw Delivery API
+    // output and are mapped in TypeScript via BlockTransformer.
     public bool IsConverter(IPublishedPropertyType propertyType)
-        => propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.BlockList);
+        => propertyType.EditorAlias.Equals(Constants.PropertyEditors.Aliases.BlockList)
+           && "accordianList".Equals(propertyType.Alias);
 
 
     public bool? IsValue(object? value, PropertyValueLevel level)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- **BlockListPropertyConverter**: scope to `accordianList` only (mirrors ContentPickerConverter pattern). It was firing on every BlockList property and force-mapping each block to SchemaAccordianBlock, mangling non-accordion content like promoArea on **schemaPage**.
- **SchemaPageTransformer**: handle promoArea as a raw Umbraco BlockList; map formElementContactFreetext to **ProviderContactInformationBlock**.
- **ThemePageTransformer**: hydrate bottomContentArea picker refs; map contactListBlock and campaignBlock with i18n labels and link reshape (parity with the legacy Optimizely ViewModelBuilders).
- **HelpStartPageTransformer**: hydrate all four picker arrays (newDrilldownPages, oldDrilldownPages, questionArea, helpContentArea) so drilldown icons, question bodies, and contact cards render.
- **AccordianCollectionBlock**: accept either an array or {items} shape — the C# RichTextPropertyConverter emits a raw array but ContentArea needs {items}.
- **LinkBlock**: accept either \`link\` (legacy) or \`urlBlock\` (new alias) since RichTextPropertyConverter exposes the raw picker property without renaming or building it.

Required editor data for other blocks to appear:
- themePage CampaignBlock: requires a populated \`link\` to render (component returns null otherwise — matches Optimizely behavior).
- LinkBlock: the inner \`urlBlock\` field must contain a UrlBlock entry with linkText + url; an empty array means no link, no render.
- providerPage Faglig brukerstøtte picker: currently has a broken reference; needs a new contact node created and re-picked.

## Related Issue(s)
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/576
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/625
- 
## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
