### PR TITLE
fix(breadcrumbs): use content id for ancestors lookup so non-default …

### DIFF
--- a/astro-infoportal/src/transformers/CategoryPageTransformer.ts
+++ b/astro-infoportal/src/transformers/CategoryPageTransformer.ts
@@ -32,10 +32,11 @@ async function fetchSchemaCountsByUrl(): Promise<Record<string, string>> {
 }
 
 export class CategoryPageTransformer implements IJSONTransformer {
-  public async Transform(cmsPageData: any): Promise<any> {
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData.properties ?? {};
+    const locale = globalData?.locale ?? "nb";
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     // Subcategories: direct children of this category page

--- a/astro-infoportal/src/transformers/HelpProcessArticlePageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpProcessArticlePageTransformer.ts
@@ -16,7 +16,7 @@ export class HelpProcessArticlePageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData?.properties ?? {};
     const locale: Locale = globalData?.locale ?? "nb";
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const lastUpdatedDateString = formatDate(cmsPageData?.updateDate ?? "");

--- a/astro-infoportal/src/transformers/HelpQuestionPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpQuestionPageTransformer.ts
@@ -3,8 +3,8 @@ import { fetchUmbracoAncestors } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 
 export class HelpQuestionPageTransformer implements IJSONTransformer {
-  public async Transform(cmsPageData: any): Promise<any> {
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+  public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, globalData?.locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     return {

--- a/astro-infoportal/src/transformers/HelpSearchPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpSearchPageTransformer.ts
@@ -4,7 +4,7 @@ import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 
 export class HelpSearchPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, globalData?.locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     return {

--- a/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
@@ -62,7 +62,7 @@ export class HelpStartPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData?.properties ?? {};
     const locale: Locale = globalData?.locale || "nb";
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route?.path ?? cmsPageData.id);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     // Drilldown/question/contact picker refs arrive with `properties: {}`;

--- a/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
+++ b/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
@@ -71,7 +71,7 @@ export class HeroArticlePageBaseTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const locale: Locale = globalData?.locale || "nb";
     const props = cmsPageData.properties ?? {};
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path, locale);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
     const mainBody = toRichTextArea(props.mainBody);
     const bottomContentArea = props.bottomContentArea

--- a/astro-infoportal/src/transformers/NewsArchivePageTransformer.ts
+++ b/astro-infoportal/src/transformers/NewsArchivePageTransformer.ts
@@ -31,7 +31,7 @@ export class NewsArchivePageTransformer implements IJSONTransformer {
     const startIndex = (currentPageNumber - 1) * PAGE_SIZE;
     const paginatedArticles = newsChildren.slice(startIndex, startIndex + PAGE_SIZE);
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path, locale);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const newsArticles = paginatedArticles.map((child: any) => {

--- a/astro-infoportal/src/transformers/ProviderPageTransformer.ts
+++ b/astro-infoportal/src/transformers/ProviderPageTransformer.ts
@@ -15,7 +15,7 @@ export class ProviderPageTransformer implements IJSONTransformer {
     const locale: Locale = globalData?.locale || "nb";
     const resolver = await ProviderResolver.create();
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const providerImageUrl = resolver.resolveImageUrl(

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -24,7 +24,7 @@ export class SchemaPageTransformer implements IJSONTransformer {
     const locale: Locale = globalData?.locale || "nb";
     const resolver = await ProviderResolver.create();
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const mainBody = props.mainIntro?.items?.length

--- a/astro-infoportal/src/transformers/SubCategoryPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SubCategoryPageTransformer.ts
@@ -20,7 +20,7 @@ export class SubCategoryPageTransformer implements IJSONTransformer {
     const locale: Locale = globalData?.locale || "nb";
     const resolver = await ProviderResolver.create();
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const boxBlocks = props.boxBlocks

--- a/astro-infoportal/src/transformers/SubsidyOverviewPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SubsidyOverviewPageTransformer.ts
@@ -7,7 +7,7 @@ import { t, type Locale } from "@i18n/index";
 export class SubsidyOverviewPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<SubsidyOverviewPageProps> {
     const locale: Locale = globalData?.locale || "nb";
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path, locale);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     return {

--- a/astro-infoportal/src/transformers/SubsidyPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SubsidyPageTransformer.ts
@@ -20,7 +20,7 @@ export class SubsidyPageTransformer implements IJSONTransformer {
     const props = cmsPageData.properties ?? {};
     const locale: Locale = globalData?.locale ?? "nb";
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const mainBody = props.mainBody;

--- a/astro-infoportal/src/transformers/ThemePageTransformer.ts
+++ b/astro-infoportal/src/transformers/ThemePageTransformer.ts
@@ -81,7 +81,7 @@ export class ThemePageTransformer implements IJSONTransformer {
     const props = cmsPageData.properties ?? {};
     const locale: Locale = globalData?.locale || "nb";
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.route.path, locale);
+    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, locale);
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
     const allChildren = await fetchUmbracoChildrenInEditorOrder(cmsPageData.route.path, 100, locale);


### PR DESCRIPTION
Issue: [#547](https://github.com/Altinn/altinn-infoportal-optimizely/issues/547)

Breadcrumbs on nynorsk and english pages were collapsing to `Start > <page name>` because `fetchUmbracoAncestors` was being called with the page's path. Umbraco's path-based ancestors query returns 0 items for non-default locales (verified against the Delivery API: NN ancestors of any path return `total: 0`, while the same lookup by content id returns the full localized chain).            
                                                                                              
  Switched every active transformer in `src/transformers/` to pass `cmsPageData.id` and `locale` to `fetchUmbracoAncestors`. Several Help* transformers were already using the id as a fallback but weren't passing the locale, so their NN/EN breadcrumbs came back in NB — they now do both.