### PR TITLE
feat: render related schemas on Vedleggsskjema (#626)

### DIFF
--- a/astro-infoportal/src/Components/Pages/SchemaAttachmentPage/SchemaAttachmentPage.tsx
+++ b/astro-infoportal/src/Components/Pages/SchemaAttachmentPage/SchemaAttachmentPage.tsx
@@ -9,6 +9,7 @@ import {
   Section,
   Typography,
 } from "@altinn/altinn-components";
+import { Fragment } from "react";
 import { ContentArea, OperationalMessage, RichTextArea } from "/App.Components";
 import BreadcrumbsView from "../../Layout/Breadcrumbs/BreadcrumbsView";
 import ProvidersInline from "../../Shared/ProvidersInline/ProvidersInline";
@@ -106,10 +107,9 @@ const SchemaAttachmentPage = ({
                 }));
 
               return (
-                <>
+                <Fragment key={id ?? idx}>
                   <SearchItem
                     className="search-item__item"
-                    key={id ?? idx}
                     as="a"
                     href={url}
                     title={title}
@@ -122,8 +122,8 @@ const SchemaAttachmentPage = ({
                       ) : undefined
                     }
                   />
-                  <Divider as="li" key={`div-${id ?? idx}`} />
-                </>
+                  <Divider as="li" />
+                </Fragment>
               );
             })}
           </List>

--- a/astro-infoportal/src/transformers/BreadcrumbsTransformer.ts
+++ b/astro-infoportal/src/transformers/BreadcrumbsTransformer.ts
@@ -40,10 +40,15 @@ export class BreadcrumbsTransformer {
     }];
 
     ancestors.forEach((item:any) => {
+      // providerPage-noder har `showInNavigation: false` i CMS for å skjules
+      // i meny og drilldowns, men de skal være med i brødsmulestien
+      // (`Start > Skjemaoversikt > Skatteetaten > Avskrivning`).
       const isBreadcrumbVisible =
         item.contentType !== "startPage" &&
         item.contentType !== "themeContainerPage" &&
-        (item.properties?.showInNavigation !== false || item.contentType === "themePage");
+        (item.properties?.showInNavigation !== false ||
+          item.contentType === "themePage" ||
+          item.contentType === "providerPage");
 
       if (isBreadcrumbVisible) {
         breadcrumbs.push({

--- a/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
@@ -3,7 +3,10 @@ import {
   type ProviderInfo,
   ProviderResolver,
 } from "@services/Providers/ProviderResolver";
-import { fetchUmbracoAncestors } from "../api/umbraco/client";
+import {
+  fetchUmbracoAncestors,
+  resolveBlockReferences,
+} from "../api/umbraco/client";
 import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
@@ -42,15 +45,33 @@ export class SchemaAttachmentPageTransformer implements IJSONTransformer {
       ? BlockTransformer.TransformBlocks(props.promoArea)
       : undefined;
 
-    // Related schemas: legacy used IRelationsDataProvider.GetRelatedSchemas.
-    // Until we have an equivalent Umbraco wiring for relation-based lookups,
-    // emit an empty list so the section is hidden gracefully.
-    const relatedSchemas: Array<{
-      id: string;
-      title: string;
-      url: string;
-      providers: ProviderInfo[];
-    }> = [];
+    const resolvedSchemas = await resolveBlockReferences(props.schemas, locale);
+    const relatedSchemas = await Promise.all(
+      resolvedSchemas.map(async (schema: any) => {
+        const schemaPath = schema?.route?.path;
+        const schemaAncestors = schemaPath
+          ? await fetchUmbracoAncestors(schemaPath, locale)
+          : [];
+        const providers: ProviderInfo[] = schemaAncestors
+          .filter((a: any) => a.contentType === "providerPage")
+          .map((a: any) => ({
+            name: a.name,
+            imageUrl: resolver.resolveImageUrl(
+              a.properties?.providerAcronym,
+              a.properties?.providerOrgNr,
+              a.name ?? "",
+              locale,
+            ),
+            url: a.route?.path ?? "",
+          }));
+        return {
+          id: schema?.id,
+          title: schema?.name,
+          url: schemaPath ?? "",
+          providers,
+        };
+      }),
+    );
 
     return {
       componentName: "SchemaAttachmentPage",

--- a/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
@@ -64,9 +64,13 @@ export class SchemaAttachmentPageTransformer implements IJSONTransformer {
             ),
             url: a.route?.path ?? "",
           }));
+        const schemaCode = schema?.properties?.schemaCode;
+        const title = schemaCode
+          ? `${schema?.name} (${schemaCode})`
+          : schema?.name;
         return {
           id: schema?.id,
-          title: schema?.name,
+          title,
           url: schemaPath ?? "",
           providers,
         };

--- a/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
@@ -38,9 +38,17 @@ export class SchemaAttachmentPageTransformer implements IJSONTransformer {
       });
     }
 
-    const accordianList = props.accordianList
-      ? BlockTransformer.TransformBlocks(props.accordianList)
-      : undefined;
+    // `accordianList` kommer fra CMS allerede i ContentArea-formen
+    // (`{componentName: "ContentArea", items: [{componentName: "SchemaAccordianBlock",
+    //   description, displayOption..., translatedHeading: "schema.importAccordions.b"}]}`).
+    // Skal IKKE gå gjennom BlockTransformer (som forventer
+    // `{content: {contentType, properties}}`). Vi muterer kun `translatedHeading`,
+    // identisk med SchemaPageTransformer.
+    props.accordianList?.items?.forEach((item: any) => {
+      item.translatedHeading = t(item.translatedHeading, locale);
+    });
+    const accordianList = props.accordianList || undefined;
+
     const promoArea = props.promoArea
       ? BlockTransformer.TransformBlocks(props.promoArea)
       : undefined;


### PR DESCRIPTION
Migrerer Vedleggsskjema. Rendrer brødsmuler, akkordioner og related schemas med RF-koder.

Mangler kontaktskjemafeltet ("Faglig brukerstøtte") på f.eks. https://info.altinn.no/skjemaoversikt/skatteetaten/avskrivning/.