### PR TITLE
feat(umbraco): wire OpenTelemetry logs and traces for OTLP export

### DIFF
--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -1,6 +1,8 @@
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Trace;
 using umbraco_infoportal.Options;
 using Umbraco.Cms.Core.Composing;
 
@@ -37,6 +39,58 @@ if (keyVaultEnabled)
     }
 
     builder.Configuration.AddAzureKeyVault(keyVaultEndpoint, new DefaultAzureCredential());
+}
+
+// OpenTelemetry — only wire up if an OTLP endpoint is configured.
+// In Kubernetes, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME, and
+// OTEL_RESOURCE_ATTRIBUTES are provided as environment variables by the
+// deployment manifest. Locally these are typically unset, so OTEL is skipped.
+string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
+if (!string.IsNullOrWhiteSpace(otlpEndpoint))
+{
+    Uri otlpUri = new(otlpEndpoint);
+
+    builder.Logging.AddOpenTelemetry(log =>
+    {
+        log.IncludeScopes = true;
+        log.IncludeFormattedMessage = true;
+        log.ParseStateValues = true;
+        log.AddOtlpExporter(opt => opt.Endpoint = otlpUri);
+    });
+
+    builder.Services.AddOpenTelemetry()
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation(opt =>
+            {
+                opt.Filter = ctx =>
+                {
+                    PathString path = ctx.Request.Path;
+                    return !path.StartsWithSegments("/umbraco/backoffice")
+                        && !path.StartsWithSegments("/umbraco/management/api")
+                        && !path.StartsWithSegments("/umbraco/preview")
+                        && !path.StartsWithSegments("/css")
+                        && !path.StartsWithSegments("/scripts")
+                        && !path.StartsWithSegments("/media")
+                        && !path.StartsWithSegments("/lib");
+                };
+            })
+            .AddHttpClientInstrumentation(opt =>
+            {
+                opt.FilterHttpRequestMessage = req =>
+                {
+                    string? host = req.RequestUri?.Host;
+                    if (host is null) return true;
+                    return !host.EndsWith(".vault.azure.net", StringComparison.OrdinalIgnoreCase)
+                        && !host.EndsWith(".blob.core.windows.net", StringComparison.OrdinalIgnoreCase)
+                        && !host.EndsWith(".queue.core.windows.net", StringComparison.OrdinalIgnoreCase)
+                        && !host.EndsWith(".table.core.windows.net", StringComparison.OrdinalIgnoreCase)
+                        && !host.Equals("login.microsoftonline.com", StringComparison.OrdinalIgnoreCase)
+                        && !host.Equals("login.windows.net", StringComparison.OrdinalIgnoreCase)
+                        && !host.EndsWith("our.umbraco.com", StringComparison.OrdinalIgnoreCase)
+                        && !host.EndsWith("telemetry.umbraco.com", StringComparison.OrdinalIgnoreCase);
+                };
+            })
+            .AddOtlpExporter(opt => opt.Endpoint = otlpUri));
 }
 
 builder.CreateUmbracoBuilder()

--- a/umbraco-infoportal/umbraco-infoportal.csproj
+++ b/umbraco-infoportal/umbraco-infoportal.csproj
@@ -18,6 +18,10 @@
     <PackageReference Include="Umbraco.StorageProviders.AzureBlob.ImageSharp" Version="17.0.0" />
     <PackageReference Include="uSync" Version="17.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Add four OpenTelemetry NuGet packages (`Exporter.OpenTelemetryProtocol`, `Extensions.Hosting`, `Instrumentation.AspNetCore`, `Instrumentation.Http`) to `umbraco-infoportal.csproj`
- Register OTEL in `Program.cs` guarded by `OTEL_EXPORTER_OTLP_ENDPOINT` env var presence — no-op in local dev when the var is unset
- Configures logs (`IncludeScopes`, `IncludeFormattedMessage`, `ParseStateValues`) and traces (ASP.NET Core + HttpClient instrumentation) with OTLP gRPC export; filters out editor/static-asset paths and Azure infrastructure hosts from trace noise

## Test Plan

- [x] `dotnet build umbraco-infoportal/umbraco-infoportal.sln` passes with 0 errors, no new warnings
- [ ] Deploy to cluster and confirm pod starts cleanly (`kubectl logs`)
- [ ] In Application Insights, confirm `requests` and `traces` rows tagged `service.name=infoportal` appear after hitting a public page
- [ ] Verify filters: no `dependencies` rows for `*.vault.azure.net` / `*.blob.core.windows.net`, no `requests` rows for `/umbraco/backoffice/*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)