### PR TITLE
feat: support `heading` field on Faglig brukerstøtte contact block

### DIFF
--- a/astro-infoportal/src/transformers/ProviderPageTransformer.ts
+++ b/astro-infoportal/src/transformers/ProviderPageTransformer.ts
@@ -3,7 +3,6 @@ import { ProviderResolver } from "@services/Providers/ProviderResolver";
 import {
   fetchUmbracoAncestors,
   fetchUmbracoChildren,
-  fetchUmbracoContent,
   resolveBlockReferences,
 } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
@@ -66,34 +65,36 @@ export class ProviderPageTransformer implements IJSONTransformer {
     );
     schemas.sort((a: any, b: any) => a.title.localeCompare(b.title, locale));
 
+    // `promoArea` (editor label "Faglig brukerstøtte") is a Block List. Items
+    // wrap each block as `{ content: { contentType, properties }, settings }`
+    // with inline properties (no picker hydration needed). We map the first
+    // `formElementContactFreetext` block to a ProviderContactInformationBlock
+    // view-model — same shape as on schemaPage.
+    const promoBlockItems: any[] = Array.isArray(props.promoArea?.items)
+      ? props.promoArea.items
+      : [];
     let contactInfo: any;
-    const contactBlock = (props.promoArea || []).find(
-      (b: any) => b.contentType === "providerContactInformationBlock",
-    );
-    
-    if (contactBlock?.route?.path) {
-      try {
-        const blockPath = contactBlock.route.path.replace(/^\/+/, "");
-        const blockData = await fetchUmbracoContent(blockPath, locale);
-        const bp = blockData.properties ?? {};
-        contactInfo = {
-          componentName: "ProviderContactInformationBlock",
-          body: bp.body ?? undefined,
-          bottomText: bp.bottomText ?? undefined,
-          webpageLink: bp.webpageLink ?? undefined,
-          telephone: bp.telephone ?? "",
-          telephoneLabel: bp.telephoneLabel ?? "",
-          email: bp.email ?? "",
-          emailTitle: bp.emailTitle ?? "",
-          pageName: cmsPageData.name,
-          providerIcon: {
-            name: cmsPageData.name,
-            imageUrl: providerIcon.imageUrl,
-          },
-        };
-      } catch {
-        // Block fetch failed, skip contact info
-      }
+    for (const wrapper of promoBlockItems) {
+      const content = wrapper?.content ?? wrapper;
+      if (content?.contentType !== "formElementContactFreetext") continue;
+      const bp = content.properties ?? {};
+      contactInfo = {
+        componentName: "ProviderContactInformationBlock",
+        body: bp.body ?? undefined,
+        bottomText: bp.bottomText ?? undefined,
+        webpageLink: bp.webpageLink ?? undefined,
+        telephone: bp.telephone ?? "",
+        telephoneLabel: bp.telephoneLabel ?? "",
+        email: bp.email ?? "",
+        emailTitle: bp.emailTitle ?? "",
+        // Editor-supplied heading wins; provider name is the fallback. The
+        // emblem only shows when the heading isn't set (matches schemaPage).
+        pageName: bp.heading || cmsPageData.name,
+        providerIcon: !bp.heading
+          ? { name: cmsPageData.name, imageUrl: providerIcon.imageUrl }
+          : undefined,
+      };
+      break;
     }
 
     const pageSidebarViewModel = {

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -101,13 +101,17 @@ export class SchemaPageTransformer implements IJSONTransformer {
             telephoneLabel: blockProps.telephoneLabel ?? "",
             email: blockProps.email ?? "",
             emailTitle: blockProps.emailTitle ?? "",
-            pageName: defaultProvider?.name ?? "",
-            providerIcon: defaultProvider?.providerIcon
-              ? {
-                  name: defaultProvider.providerIcon.name,
-                  imageUrl: defaultProvider.providerIcon.imageUrl,
-                }
-              : undefined,
+            pageName: blockProps.heading || defaultProvider?.name || "",
+            // Only show the provider emblem when we fell back to the provider
+            // name as the heading. If the editor supplied a `heading`, the
+            // card stands on its own without the org logo.
+            providerIcon:
+              !blockProps.heading && defaultProvider?.providerIcon
+                ? {
+                    name: defaultProvider.providerIcon.name,
+                    imageUrl: defaultProvider.providerIcon.imageUrl,
+                  }
+                : undefined,
           };
         }
         return BlockTransformer.TransformBlocks([content]).items[0];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- SchemaPageTransformer / ProviderPageTransformer: read `blockProps.heading` as the card title; fall back to the provider / page name if it's empty.
- The provider emblem (org logo) now renders only when the title falls back to the page name. When the editor supplies a `heading`, the card stands on its own without the emblem.
- ProviderPageTransformer: rewrite `promoArea` handling to match the new BlockList shape (`{items: [{content, settings}]}`) and read inline properties directly. Previously expected the old MNTP shape with `providerContactInformationBlock` refs and a separate Umbraco fetch.

## Related Issue(s)
- https://github.com/Altinn/altinn-infoportal-optimizely/issues/576

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
