### PR TITLE
fix(umbraco): bridge Serilog to OTLP so logs reach Log Analytics

### DIFF
--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -1,7 +1,7 @@
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using OpenTelemetry.Logs;
+using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 using umbraco_infoportal.Options;
 using Umbraco.Cms.Core.Composing;
@@ -41,27 +41,23 @@ if (keyVaultEnabled)
     builder.Configuration.AddAzureKeyVault(keyVaultEndpoint, new DefaultAzureCredential());
 }
 
-// OpenTelemetry — only wire up if an OTLP endpoint is configured.
+// OpenTelemetry tracing — only wire up if an OTLP endpoint is configured.
 // In Kubernetes, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME, and
 // OTEL_RESOURCE_ATTRIBUTES are provided as environment variables by the
 // deployment manifest. Locally these are typically unset, so OTEL is skipped.
+// Logs are bridged from Umbraco's Serilog pipeline via Serilog.Sinks.OpenTelemetry
+// configured in appsettings.Production.json — registering an OTel log provider
+// here would be wiped out by Umbraco's ClearProviders() in CreateUmbracoBuilder.
 string? otlpEndpoint = builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"];
 if (!string.IsNullOrWhiteSpace(otlpEndpoint))
 {
     Uri otlpUri = new(otlpEndpoint);
 
-    builder.Logging.AddOpenTelemetry(log =>
-    {
-        log.IncludeScopes = true;
-        log.IncludeFormattedMessage = true;
-        log.ParseStateValues = true;
-        log.AddOtlpExporter(opt => opt.Endpoint = otlpUri);
-    });
-
     builder.Services.AddOpenTelemetry()
         .WithTracing(tracing => tracing
             .AddAspNetCoreInstrumentation(opt =>
             {
+                opt.RecordException = true;
                 opt.Filter = ctx =>
                 {
                     PathString path = ctx.Request.Path;
@@ -76,6 +72,7 @@ if (!string.IsNullOrWhiteSpace(otlpEndpoint))
             })
             .AddHttpClientInstrumentation(opt =>
             {
+                opt.RecordException = true;
                 opt.FilterHttpRequestMessage = req =>
                 {
                     string? host = req.RequestUri?.Host;
@@ -90,7 +87,11 @@ if (!string.IsNullOrWhiteSpace(otlpEndpoint))
                         && !host.EndsWith("telemetry.umbraco.com", StringComparison.OrdinalIgnoreCase);
                 };
             })
-            .AddOtlpExporter(opt => opt.Endpoint = otlpUri));
+            .AddOtlpExporter(opt =>
+            {
+                opt.Endpoint = otlpUri;
+                opt.Protocol = OtlpExportProtocol.Grpc;
+            }));
 }
 
 builder.CreateUmbracoBuilder()

--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -1,7 +1,6 @@
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using OpenTelemetry.Exporter;
 using OpenTelemetry.Trace;
 using umbraco_infoportal.Options;
 using Umbraco.Cms.Core.Composing;
@@ -57,7 +56,6 @@ if (!string.IsNullOrWhiteSpace(otlpEndpoint))
         .WithTracing(tracing => tracing
             .AddAspNetCoreInstrumentation(opt =>
             {
-                opt.RecordException = true;
                 opt.Filter = ctx =>
                 {
                     PathString path = ctx.Request.Path;
@@ -72,7 +70,6 @@ if (!string.IsNullOrWhiteSpace(otlpEndpoint))
             })
             .AddHttpClientInstrumentation(opt =>
             {
-                opt.RecordException = true;
                 opt.FilterHttpRequestMessage = req =>
                 {
                     string? host = req.RequestUri?.Host;
@@ -87,11 +84,7 @@ if (!string.IsNullOrWhiteSpace(otlpEndpoint))
                         && !host.EndsWith("telemetry.umbraco.com", StringComparison.OrdinalIgnoreCase);
                 };
             })
-            .AddOtlpExporter(opt =>
-            {
-                opt.Endpoint = otlpUri;
-                opt.Protocol = OtlpExportProtocol.Grpc;
-            }));
+            .AddOtlpExporter(opt => opt.Endpoint = otlpUri));
 }
 
 builder.CreateUmbracoBuilder()

--- a/umbraco-infoportal/appsettings.Production.json
+++ b/umbraco-infoportal/appsettings.Production.json
@@ -1,4 +1,18 @@
 {
+  "Serilog": {
+    "WriteTo": [
+      {
+        "Name": "OpenTelemetry",
+        "Args": {
+          "Endpoint": "http://otel-collector.monitoring.svc.cluster.local:4317",
+          "Protocol": "Grpc",
+          "ResourceAttributes": {
+            "service.name": "infoportal"
+          }
+        }
+      }
+    ]
+  },
   "Umbraco": {
     "CMS": {
       "Runtime": {

--- a/umbraco-infoportal/appsettings.Production.json
+++ b/umbraco-infoportal/appsettings.Production.json
@@ -1,16 +1,7 @@
 {
   "Serilog": {
     "WriteTo": [
-      {
-        "Name": "OpenTelemetry",
-        "Args": {
-          "Endpoint": "http://otel-collector.monitoring.svc.cluster.local:4317",
-          "Protocol": "Grpc",
-          "ResourceAttributes": {
-            "service.name": "infoportal"
-          }
-        }
-      }
+      { "Name": "OpenTelemetry" }
     ]
   },
   "Umbraco": {

--- a/umbraco-infoportal/umbraco-infoportal.csproj
+++ b/umbraco-infoportal/umbraco-infoportal.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Umbraco's `CreateUmbracoBuilder` calls `ClearProviders()` and registers `SerilogLoggerFactory` as the singleton `ILoggerFactory`, which silently wiped the `OpenTelemetryLoggerProvider` added in #195 via `builder.Logging.AddOpenTelemetry`. Logs were only landing in `/app/umbraco/Logs` (the emptyDir mount) while traces continued working, because tracing lives in DI + `ActivityListener` and is unaffected by Umbraco's logger reset.
- Drop the dead `builder.Logging.AddOpenTelemetry(...)` block and register the `Serilog.Sinks.OpenTelemetry` sink via `appsettings.Production.json`. Umbraco's Serilog pipeline now forwards log records (including `LogError(ex, …)`) to the cluster otel-collector.
- The sink's config has no hardcoded values — `Serilog.Sinks.OpenTelemetry` natively reads `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_SERVICE_NAME`, and `OTEL_RESOURCE_ATTRIBUTES` via `OpenTelemetryEnvironment.Configure`. Those env vars are already set on the umbraco deployment, so per-environment endpoint/service name flows through the deployment manifest alone.
- `appsettings.Production.json` is loaded in **all four cluster environments** (at22, at23, tt02, prod). The Dockerfile uses `mcr.microsoft.com/dotnet/aspnet:10.0`, which does not set `ASPNETCORE_ENVIRONMENT`, so .NET defaults to `Production`. None of the kustomize overlays patch in `ASPNETCORE_ENVIRONMENT` either, matching the existing `KeyVault.Enabled` pattern.

## Test plan

- [ ] Deploy and confirm the pod's Serilog self-log shows no OpenTelemetry sink errors
- [ ] Trigger an `ILogger.LogError` (or throw) and confirm rows appear in Log Analytics `AppTraces` / `AppExceptions` filtered to `AppRoleName == "infoportal"`
- [ ] Confirm local `dotnet run` (Development env) is unaffected — the Production overlay is the only place the OTel sink is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)
