### PR TITLE
feat: implement contact form email backend with per-block routing

### DIFF
--- a/astro-infoportal/src/transformers/contactFormData.ts
+++ b/astro-infoportal/src/transformers/contactFormData.ts
@@ -5,11 +5,6 @@ import {
 } from "@api/umbraco/client";
 import { t, type Locale } from "@i18n/index";
 
-const CONTACT_FORM_SCHEMA_ID_BY_SUPPORT_EMAIL: Record<string, number> = {
-  "support@altinn.no": 31158,
-  "altinn.starteogdrive@brreg.no": 31157,
-};
-
 const defaultContactFormPageCache = new Map<Locale, Promise<any>>();
 
 function normalizeRichTextArea(value: any) {
@@ -131,8 +126,8 @@ async function hydrateContactFormBlock(
     useRecaptcha: startProps.useRecaptcha ?? props.useRecaptcha ?? false,
     recaptchaSiteKey:
       startProps.reCaptchaSiteKey ?? props.recaptchaSiteKey ?? undefined,
-    // Umbraco delivery omits the legacy numeric content id used by the submit endpoint.
-    schemaId: CONTACT_FORM_SCHEMA_ID_BY_SUPPORT_EMAIL[props.supportEmail ?? ""] ?? 0,
+    // Umbraco GUID of the contactFormBlock — backend looks up supportEmail from this.
+    schemaId: blockData?.id ?? rawBlock?.id ?? "",
     labels: buildContactFormLabels(locale),
     displayOptionId: rawBlock?.displayOptionId ?? "full",
     displayOptionName: rawBlock?.displayOptionName ?? "/displayoptions/full",

--- a/umbraco-infoportal/Controllers/ContactForm/ContactFormController.cs
+++ b/umbraco-infoportal/Controllers/ContactForm/ContactFormController.cs
@@ -1,0 +1,310 @@
+using System.Net.Mail;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Mail;
+using Umbraco.Cms.Core.Models.Email;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Extensions;
+using umbraco_infoportal.Options;
+
+namespace umbraco_infoportal.Controllers.ContactForm;
+
+[ApiController]
+[Route("api/contactform")]
+public sealed class ContactFormController(
+    IEmailSender emailSender,
+    IPublishedContentCache publishedContentCache,
+    IOptions<SupportEmailOptions> options,
+    ILogger<ContactFormController> logger) : ControllerBase
+{
+    private const long MaxAttachmentBytes = 15L * 1024 * 1024;
+    private const string ContactFormBlockAlias = "contactFormBlock";
+    private const string SupportEmailPropertyAlias = "supportEmail";
+    private const string GenericErrorMessage = "Unable to send contact form. Please try again later.";
+
+    // TODO: TEMP — remove before merging. Extra recipients for local testing visibility.
+    private static readonly string[] TempExtraRecipients = ["vu.quan@digdir.no", "quan.vu@knowit.no"];
+
+    private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".bmp", ".jpg", ".jpeg", ".png", ".gif",
+        ".txt", ".log", ".csv",
+        ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+        ".pdf", ".odt", ".ods", ".odp", ".rtf",
+        ".rar", ".zip", ".7z",
+        ".gdoc", ".gsheet", ".gslide",
+        ".htm", ".html",
+        ".eml", ".msg",
+    };
+
+    [HttpPost("send")]
+    [IgnoreAntiforgeryToken]
+    [Consumes("multipart/form-data")]
+    [RequestSizeLimit(20L * 1024 * 1024)]
+    public async Task<IActionResult> Send([FromForm] ContactFormModel model, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(model.Location))
+        {
+            logger.LogWarning("Contact form rejected: honeypot triggered.");
+            return BadRequest(new { success = false, errorMessage = GenericErrorMessage });
+        }
+
+        string? recipient = await ResolveRecipientAsync(model.SchemaId);
+        if (string.IsNullOrEmpty(recipient))
+        {
+            return BadRequest(new { success = false, errorMessage = GenericErrorMessage });
+        }
+
+        string[] recipients = BuildRecipientList(recipient, TempExtraRecipients);
+
+        if (!TryValidate(model, out CleanedFields fields, out string? validationError))
+        {
+            logger.LogWarning("Contact form rejected: {Reason}", validationError);
+            return BadRequest(new { success = false, errorMessage = validationError });
+        }
+
+        Stream? attachmentStream = null;
+        EmailMessageAttachment? emailAttachment = null;
+
+        try
+        {
+            if (model.Attachment is { Length: > 0 } file)
+            {
+                if (file.Length > MaxAttachmentBytes)
+                {
+                    logger.LogWarning("Contact form rejected: attachment too large ({Size} bytes).", file.Length);
+                    return BadRequest(new { success = false, errorMessage = "File is too large. Maximum size is 15 MB" });
+                }
+
+                string extension = Path.GetExtension(file.FileName);
+                if (string.IsNullOrEmpty(extension) || !AllowedExtensions.Contains(extension))
+                {
+                    logger.LogWarning("Contact form rejected: disallowed attachment extension {Extension}.", extension);
+                    return BadRequest(new
+                    {
+                        success = false,
+                        errorMessage = $"Invalid file type. Allowed types: {string.Join(", ", AllowedExtensions)}",
+                    });
+                }
+
+                attachmentStream = file.OpenReadStream();
+                emailAttachment = new EmailMessageAttachment(attachmentStream, file.FileName);
+            }
+
+            EmailMessage message = BuildMessage(fields, recipients, options.Value.FromAddress, emailAttachment);
+            await emailSender.SendAsync(message, emailType: "ContactForm", enableNotification: false, expires: null);
+            logger.LogInformation(
+                "Contact form sent to {Recipients} for schemaId {SchemaId}.",
+                string.Join(", ", recipients), model.SchemaId);
+            return Ok(new { success = true });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to send contact form email.");
+            return BadRequest(new { success = false, errorMessage = GenericErrorMessage });
+        }
+        finally
+        {
+            attachmentStream?.Dispose();
+        }
+    }
+
+    private string[] BuildRecipientList(string blockRecipient, string[] additionalRecipients)
+    {
+        List<string> list = [blockRecipient];
+
+        foreach (string candidate in additionalRecipients)
+        {
+            string trimmed = candidate?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            if (!MailAddress.TryCreate(trimmed, out _))
+            {
+                logger.LogWarning("Skipping invalid additional recipient: {Email}", trimmed);
+                continue;
+            }
+
+            if (list.Any(r => string.Equals(r, trimmed, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            list.Add(trimmed);
+        }
+
+        return [.. list];
+    }
+
+    private async Task<string?> ResolveRecipientAsync(string? schemaId)
+    {
+        if (string.IsNullOrWhiteSpace(schemaId))
+        {
+            logger.LogWarning("Contact form rejected: schemaId missing.");
+            return null;
+        }
+
+        if (!Guid.TryParse(schemaId.Trim(), out Guid blockKey))
+        {
+            logger.LogWarning("Contact form rejected: schemaId is not a GUID ({SchemaId}).", schemaId);
+            return null;
+        }
+
+        IPublishedContent? block = await publishedContentCache.GetByIdAsync(blockKey, preview: false);
+        if (block is null)
+        {
+            logger.LogWarning("Contact form rejected: no published content for {BlockKey}.", blockKey);
+            return null;
+        }
+
+        if (!string.Equals(block.ContentType.Alias, ContactFormBlockAlias, StringComparison.Ordinal))
+        {
+            logger.LogWarning(
+                "Contact form rejected: content {BlockKey} has alias '{Alias}', expected '{Expected}'.",
+                blockKey, block.ContentType.Alias, ContactFormBlockAlias);
+            return null;
+        }
+
+        string? email = block.Value<string>(SupportEmailPropertyAlias)?.Trim();
+        if (string.IsNullOrEmpty(email))
+        {
+            logger.LogWarning("Contact form rejected: block {BlockKey} has empty supportEmail.", blockKey);
+            return null;
+        }
+
+        if (!MailAddress.TryCreate(email, out _))
+        {
+            logger.LogWarning("Contact form rejected: block {BlockKey} supportEmail is not a valid email.", blockKey);
+            return null;
+        }
+
+        return email;
+    }
+
+    private static bool TryValidate(ContactFormModel model, out CleanedFields fields, out string? error)
+    {
+        string name = (model.Name ?? string.Empty).Trim();
+        if (name.Length < 2 || ContainsCrlf(name))
+        {
+            fields = default;
+            error = "Name is required.";
+            return false;
+        }
+
+        string email = (model.Email ?? string.Empty).Trim();
+        if (ContainsCrlf(email) || !TryParseEmail(email))
+        {
+            fields = default;
+            error = "A valid email address is required.";
+            return false;
+        }
+
+        string phone = (model.Phone ?? string.Empty).Trim();
+        if (phone.Length > 0 && !IsEightDigitPhone(phone))
+        {
+            fields = default;
+            error = "Phone must be 8 digits.";
+            return false;
+        }
+
+        string subject = (model.Subject ?? string.Empty).Trim();
+        if (subject.Length < 3 || ContainsCrlf(subject))
+        {
+            fields = default;
+            error = "Subject is required.";
+            return false;
+        }
+
+        string body = (model.Message ?? string.Empty).Trim();
+        if (body.Length < 1)
+        {
+            fields = default;
+            error = "Message is required.";
+            return false;
+        }
+
+        fields = new CleanedFields(name, email, phone, subject, body);
+        error = null;
+        return true;
+    }
+
+    private static EmailMessage BuildMessage(
+        CleanedFields fields,
+        string[] recipients,
+        string fromAddress,
+        EmailMessageAttachment? attachment)
+    {
+        HtmlEncoder encoder = HtmlEncoder.Default;
+
+        string body =
+            $"<p>Emne: {encoder.Encode(fields.Subject)}<br/>" +
+            $"Spørsmål: {encoder.Encode(fields.Message)}<br/>" +
+            $"Navn: {encoder.Encode(fields.Name)}<br/>" +
+            $"Telefon: {encoder.Encode(fields.Phone)}<br/>" +
+            $"E-post: <a href=\"mailto:{encoder.Encode(fields.Email)}\">{encoder.Encode(fields.Email)}</a></p>";
+
+        string?[] to = new string?[recipients.Length];
+        Array.Copy(recipients, to, recipients.Length);
+
+        return new EmailMessage(
+            from: fromAddress,
+            to: to,
+            cc: null,
+            bcc: null,
+            replyTo: new[] { fields.Email },
+            subject: fields.Subject,
+            body: body,
+            isBodyHtml: true,
+            attachments: attachment is null ? null : new[] { attachment });
+    }
+
+    private static bool TryParseEmail(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return false;
+        }
+
+        try
+        {
+            MailAddress address = new(value);
+            return string.Equals(address.Address, value, StringComparison.OrdinalIgnoreCase);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool ContainsCrlf(string value) =>
+        value.IndexOfAny(['\r', '\n']) >= 0;
+
+    private static bool IsEightDigitPhone(string value)
+    {
+        if (value.Length != 8)
+        {
+            return false;
+        }
+
+        foreach (char c in value)
+        {
+            if (!char.IsDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private readonly record struct CleanedFields(
+        string Name,
+        string Email,
+        string Phone,
+        string Subject,
+        string Message);
+}

--- a/umbraco-infoportal/Controllers/ContactForm/ContactFormController.cs
+++ b/umbraco-infoportal/Controllers/ContactForm/ContactFormController.cs
@@ -81,7 +81,7 @@ public sealed class ContactFormController(
                 string extension = Path.GetExtension(file.FileName);
                 if (string.IsNullOrEmpty(extension) || !AllowedExtensions.Contains(extension))
                 {
-                    logger.LogWarning("Contact form rejected: disallowed attachment extension {Extension}.", extension);
+                    logger.LogWarning("Contact form rejected: disallowed attachment extension {Extension}.", SanitizeForLog(extension));
                     return BadRequest(new
                     {
                         success = false,
@@ -97,7 +97,7 @@ public sealed class ContactFormController(
             await emailSender.SendAsync(message, emailType: "ContactForm", enableNotification: false, expires: null);
             logger.LogInformation(
                 "Contact form sent to {Recipients} for schemaId {SchemaId}.",
-                string.Join(", ", recipients), model.SchemaId);
+                string.Join(", ", recipients), SanitizeForLog(model.SchemaId));
             return Ok(new { success = true });
         }
         catch (Exception ex)
@@ -150,7 +150,7 @@ public sealed class ContactFormController(
 
         if (!Guid.TryParse(schemaId.Trim(), out Guid blockKey))
         {
-            logger.LogWarning("Contact form rejected: schemaId is not a GUID ({SchemaId}).", schemaId);
+            logger.LogWarning("Contact form rejected: schemaId is not a GUID ({SchemaId}).", SanitizeForLog(schemaId));
             return null;
         }
 
@@ -299,6 +299,19 @@ public sealed class ContactFormController(
         }
 
         return true;
+    }
+
+    // Strip control characters and cap length so user-supplied values cannot
+    // forge fake log lines (CRLF injection) or flood logs.
+    private static string SanitizeForLog(string? value, int maxLength = 64)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return "<empty>";
+        }
+
+        string trimmed = value.Length > maxLength ? value[..maxLength] : value;
+        return new string([.. trimmed.Where(c => !char.IsControl(c))]);
     }
 
     private readonly record struct CleanedFields(

--- a/umbraco-infoportal/Controllers/ContactForm/ContactFormModel.cs
+++ b/umbraco-infoportal/Controllers/ContactForm/ContactFormModel.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Http;
+
+namespace umbraco_infoportal.Controllers.ContactForm;
+
+public sealed class ContactFormModel
+{
+    public string? Name { get; set; }
+    public string? Email { get; set; }
+    public string? Phone { get; set; }
+    public string? Subject { get; set; }
+    public string? Message { get; set; }
+
+    public string? Location { get; set; }
+
+    public string? SchemaId { get; set; }
+    public string? Language { get; set; }
+    public string? RecaptchaToken { get; set; }
+
+    public IFormFile? Attachment { get; set; }
+}

--- a/umbraco-infoportal/Options/SupportEmailOptions.cs
+++ b/umbraco-infoportal/Options/SupportEmailOptions.cs
@@ -1,0 +1,8 @@
+namespace umbraco_infoportal.Options;
+
+public class SupportEmailOptions
+{
+    public const string SectionName = "Support";
+
+    public string FromAddress { get; set; } = "noreply@altinn.no";
+}

--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -18,6 +18,9 @@ builder.WebHost.ConfigureKestrel(options =>
 builder.Services.Configure<KeyVaultOptions>(
     builder.Configuration.GetSection(KeyVaultOptions.SectionName));
 
+builder.Services.Configure<SupportEmailOptions>(
+    builder.Configuration.GetSection(SupportEmailOptions.SectionName));
+
 KeyVaultOptions keyVaultOptions = builder.Configuration
     .GetSection(KeyVaultOptions.SectionName)
     .Get<KeyVaultOptions>() ?? new();

--- a/umbraco-infoportal/appsettings.json
+++ b/umbraco-infoportal/appsettings.json
@@ -15,7 +15,14 @@
       "Global": {
         "Id": "58292286-ad27-40c7-bc4b-76756cd62610",
         "SanitizeTinyMce": true,
-        "ReservedPaths": "~/app_plugins/,~/install/,~/mini-profiler-resources/,~/umbraco/,~/signin-entra"
+        "ReservedPaths": "~/app_plugins/,~/install/,~/mini-profiler-resources/,~/umbraco/,~/signin-entra",
+        "Smtp": {
+          "From": "noreply@altinn.no",
+          "Host": "smtp.ai-test.altinn.cloud",
+          "Port": 465,
+          "DeliveryMethod": "Network",
+          "SecureSocketOptions": "SslOnConnect"
+        }
       },
       "BasicAuth": {
         "RedirectToLoginPage": true
@@ -41,5 +48,8 @@
     "Endpoint": "http://localhost:9200",
     "IndexPrefix": "infoportal",
     "ApiKey": ""
+  },
+  "Support": {
+    "FromAddress": "noreply@altinn.no"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Architecture
- Backend (.NET) sends mail via Umbraco's IEmailSender, which uses MailKit and the Umbraco:CMS:Global:Smtp configuration. Cloudflare Workers cannot open raw SMTP sockets, so the email path stays in umbraco-infoportal, matching the legacy infrastructure.
- Recipient is resolved per-request from the Umbraco contactFormBlock content via IPublishedContentCache.GetByIdAsync(Guid). Editors can change supportEmail in the back office without a deploy.
- The frontend transformer (contactFormData.ts) now sends the Umbraco block GUID as schemaId, replacing the reverse-mapped legacy int CONTACT_FORM_SCHEMA_ID_BY_SUPPORT_EMAIL hack.
- Per-tab routing: each contactFormBlock in formTypeArea is hydrated with its own GUID. Selecting a radio tab in the modal carries that GUID through to submission, so each tab routes to its own inbox.

Configuration
- New SupportEmailOptions binds Support:FromAddress from config (default noreply@altinn.no).
- New Umbraco:CMS:Global:Smtp block in appsettings.json points at the shared test relay smtp.ai-test.altinn.cloud:465 (SslOnConnect / implicit TLS). Per-environment overrides can be added via kustomize env vars if prod requires a different relay.

Not yet verified
- Real SMTP delivery against smtp.ai-test.altinn.cloud has not been tested end-to-end. TCP timeout on port 465.

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/383
- https://github.com/Altinn/info.altinn.no/issues/387

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
