### PR TITLE
Activated UseForwardHeaders in program.cs

### DIFF
--- a/umbraco-infoportal/CustomAuthentication/MicrosoftEntraIdBackOfficeExternalLoginProviderOptions.cs
+++ b/umbraco-infoportal/CustomAuthentication/MicrosoftEntraIdBackOfficeExternalLoginProviderOptions.cs
@@ -100,7 +100,7 @@ public class MicrosoftEntraIdBackOfficeExternalLoginProviderOptions : IConfigure
                 if (roles.Contains("umbraco-tad"))
                     mappedGroups.Add("tjenesterTad");
 
-                // Writer rolle om ingen andre er spesifisert
+                // Deny om ingen andre er roller er spesifisert
                 if (!mappedGroups.Any())
                 {
                     return false;

--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -1,5 +1,6 @@
 using Azure.Extensions.AspNetCore.Configuration.Secrets;
 using Azure.Identity;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using OpenTelemetry.Trace;
 using umbraco_infoportal.Options;
@@ -13,6 +14,15 @@ builder.WebHost.ConfigureKestrel(options =>
     options.Limits.MaxRequestHeadersTotalSize = 65536;
 });
 
+// Honor X-Forwarded-Proto/For from the cluster ingress (Traefik) so Request.Scheme
+// reflects the original https scheme. Required for OIDC correlation cookies set
+// with SecurePolicy.Always to round-trip correctly.
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.KnownIPNetworks.Clear();
+    options.KnownProxies.Clear();
+});
 
 builder.Services.Configure<KeyVaultOptions>(
     builder.Configuration.GetSection(KeyVaultOptions.SectionName));
@@ -102,6 +112,8 @@ builder.CreateUmbracoBuilder()
 WebApplication app = builder.Build();
 
 await app.BootUmbracoAsync();
+
+app.UseForwardedHeaders();
 
 app.UseUmbraco()
     .WithMiddleware(u =>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fikser HTTP 500 ved Entra ID-innlogging til Umbraco backoffice (POST /signin-entra) ved å aktivere UseForwardedHeaders så .NET respekterer X-Forwarded-Proto fra Traefik.