### PR TITLE
feat: Add Elasticsearch traffic filtering with Cloudflare IPs

### DIFF
--- a/.github/workflows/update-cloudflare-ips-elasticsearch.yml
+++ b/.github/workflows/update-cloudflare-ips-elasticsearch.yml
@@ -1,0 +1,76 @@
+name: Update Cloudflare IP ranges (Elasticsearch)
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays at 06:00 UTC
+    - cron: '0 6 * * 4'  # Thursdays at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Fetch and update Cloudflare IP ranges
+        id: update
+        run: |
+          python3 - <<'EOF'
+          import urllib.request, re
+
+          v4 = urllib.request.urlopen('https://www.cloudflare.com/ips-v4').read().decode().strip().splitlines()
+          v6 = urllib.request.urlopen('https://www.cloudflare.com/ips-v6').read().decode().strip().splitlines()
+          new_ips = v4 + v6
+
+          paths = [
+            'infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/terraform.tfvars',
+            'infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/terraform.tfvars',
+            'infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/terraform.tfvars',
+          ]
+
+          items = ''.join(f'  "{ip}",\n' for ip in new_ips)
+
+          for path in paths:
+              with open(path) as f:
+                  content = f.read()
+
+              new_content = re.sub(
+                  r'(  # BEGIN CLOUDFLARE\n)(?:  ".+",\n)+(  # END CLOUDFLARE\n)',
+                  r'\g<1>' + items + r'\g<2>',
+                  content,
+              )
+
+              with open(path, 'w') as f:
+                  f.write(new_content)
+          EOF
+
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open pull request
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          BRANCH="chore/update-cloudflare-ips-elasticsearch-$(date +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/terraform.tfvars
+          git add infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/terraform.tfvars
+          git add infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/terraform.tfvars
+          git commit -m "chore(elasticsearch): update Cloudflare IP ranges"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(elasticsearch): update Cloudflare IP ranges" \
+            --body "Automated update of Cloudflare IP ranges for Elasticsearch traffic filters." \
+            --base main \
+            --head "$BRANCH"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/main.tf
+++ b/infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/main.tf
@@ -29,5 +29,6 @@ module "elasticsearch" {
   elastic_cloud_email_address = var.elastic_cloud_email_address
   sku_name                    = var.sku_name
   elasticsearch_api_key       = var.elasticsearch_api_key
+  allowed_cidr_blocks         = var.allowed_cidr_blocks
   tags                        = local.tags
 }

--- a/infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/terraform.tfvars
+++ b/infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/terraform.tfvars
@@ -2,3 +2,34 @@ elastic_cloud_email_address = "aas-bfred-prod@ai-dev.no"
 sku_name                    = "ess-consumption-2024_Monthly@TIDn7ja87drquhy"
 elasticsearch_endpoint      = "https://infoportal-search-prod-adac85.es.germanywestcentral.azure.elastic.cloud"
 eso_object_id               = "8b43f887-3962-4cc4-ad7b-fba8ebf3b70b" # infop-prod-hxhapc-sql-uami
+
+allowed_cidr_blocks = [
+  # BEGIN CLOUDFLARE
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+  "2400:cb00::/32",
+  "2606:4700::/32",
+  "2803:f800::/32",
+  "2405:b500::/32",
+  "2405:8100::/32",
+  "2a06:98c0::/29",
+  "2c0f:f248::/32",
+  # END CLOUDFLARE
+
+  # dis-core-prod AKS egress prefixes
+  "20.251.69.80/28",
+  "2603:1020:e01:4:3a0/124",
+]

--- a/infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/variables.tf
+++ b/infrastructure/altinn-portaler-prod/infoportal-elasticsearch-prod/variables.tf
@@ -30,3 +30,9 @@ variable "eso_object_id" {
   type        = string
   default     = ""
 }
+
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the Elasticsearch project. Empty list allows all traffic."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/main.tf
@@ -29,5 +29,6 @@ module "elasticsearch" {
   elastic_cloud_email_address = var.elastic_cloud_email_address
   sku_name                    = var.sku_name
   elasticsearch_api_key       = var.elasticsearch_api_key
+  allowed_cidr_blocks         = var.allowed_cidr_blocks
   tags                        = local.tags
 }

--- a/infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/terraform.tfvars
@@ -2,3 +2,34 @@ elastic_cloud_email_address = "aas-bfred-prod@ai-dev.no"
 sku_name                    = "ess-consumption-2024_Monthly@TIDn7ja87drquhy"
 elasticsearch_endpoint      = "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud"
 eso_object_id               = "37bad695-20a0-4b9c-8374-bd182c5cdad4"
+
+allowed_cidr_blocks = [
+  # BEGIN CLOUDFLARE
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+  "2400:cb00::/32",
+  "2606:4700::/32",
+  "2803:f800::/32",
+  "2405:b500::/32",
+  "2405:8100::/32",
+  "2a06:98c0::/29",
+  "2c0f:f248::/32",
+  # END CLOUDFLARE
+
+  # dis-core-at22 AKS egress prefixes
+  "4.177.14.48/28",
+  "2603:1020:e01:4::350/124",
+]

--- a/infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-elasticsearch-at22/variables.tf
@@ -30,3 +30,9 @@ variable "eso_object_id" {
   type        = string
   default     = ""
 }
+
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the Elasticsearch project. Empty list allows all traffic."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/main.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/main.tf
@@ -29,5 +29,6 @@ module "elasticsearch" {
   elastic_cloud_email_address = var.elastic_cloud_email_address
   sku_name                    = var.sku_name
   elasticsearch_api_key       = var.elasticsearch_api_key
+  allowed_cidr_blocks         = var.allowed_cidr_blocks
   tags                        = local.tags
 }

--- a/infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/terraform.tfvars
@@ -2,3 +2,34 @@ elastic_cloud_email_address = "aas-bfred-prod@ai-dev.no"
 sku_name                    = "ess-consumption-2024_Monthly@TIDn7ja87drquhy"
 elasticsearch_endpoint      = "https://infoportal-search-tt02-b375ed.es.germanywestcentral.azure.elastic.cloud"
 eso_object_id               = "4e20a3a6-2c50-4a23-a02b-23fc8597d3a7"
+
+allowed_cidr_blocks = [
+  # BEGIN CLOUDFLARE
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+  "2400:cb00::/32",
+  "2606:4700::/32",
+  "2803:f800::/32",
+  "2405:b500::/32",
+  "2405:8100::/32",
+  "2a06:98c0::/29",
+  "2c0f:f248::/32",
+  # END CLOUDFLARE
+
+  # dis-core-tt02 AKS egress prefixes
+  "4.177.18.112/28",
+  "2603:1020:e01:c::1e0/124",
+]

--- a/infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-elasticsearch-test/variables.tf
@@ -30,3 +30,9 @@ variable "eso_object_id" {
   type        = string
   default     = ""
 }
+
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the Elasticsearch project. Empty list allows all traffic."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/modules/infoportal-elasticsearch/main.tf
+++ b/infrastructure/modules/infoportal-elasticsearch/main.tf
@@ -42,9 +42,24 @@ resource "azurerm_elastic_cloud_elasticsearch" "search" {
   }
 }
 
+resource "ec_deployment_traffic_filter" "allowed_sources" {
+  count  = length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  name   = "infoportal-${var.environment}-allowed-sources"
+  region = "azure-germanywestcentral"
+  type   = "ip"
+
+  dynamic "rule" {
+    for_each = var.allowed_cidr_blocks
+    content {
+      source = rule.value
+    }
+  }
+}
+
 resource "ec_elasticsearch_project" "search" {
-  name      = "infoportal-search-${var.environment}"
-  region_id = "azure-germanywestcentral"
+  name               = "infoportal-search-${var.environment}"
+  region_id          = "azure-germanywestcentral"
+  traffic_filter_ids = length(var.allowed_cidr_blocks) > 0 ? [ec_deployment_traffic_filter.allowed_sources[0].id] : []
 }
 
 resource "azurerm_key_vault_secret" "es_endpoint" {

--- a/infrastructure/modules/infoportal-elasticsearch/variables.tf
+++ b/infrastructure/modules/infoportal-elasticsearch/variables.tf
@@ -51,6 +51,12 @@ variable "elastic_cloud_api_key" {
   sensitive   = true
 }
 
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the Elasticsearch project. Empty list allows all traffic."
+  type        = list(string)
+  default     = []
+}
+
 variable "tags" {
   description = "Tags to apply to all taggable resources"
   type        = map(string)


### PR DESCRIPTION
Add support for restricting Elasticsearch access to specific CIDR blocks, with Cloudflare IP ranges as the primary use case. Includes a GitHub Actions workflow to automatically update Cloudflare IPs on a weekly schedule via pull requests.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
