### PR TITLE
fix: Migrate to Elastic serverless traffic filter

### DIFF
--- a/infrastructure/modules/infoportal-elasticsearch/main.tf
+++ b/infrastructure/modules/infoportal-elasticsearch/main.tf
@@ -42,16 +42,16 @@ resource "azurerm_elastic_cloud_elasticsearch" "search" {
   }
 }
 
-resource "ec_deployment_traffic_filter" "allowed_sources" {
+resource "ec_serverless_traffic_filter" "allowed_sources" {
   count  = length(var.allowed_cidr_blocks) > 0 ? 1 : 0
   name   = "infoportal-${var.environment}-allowed-sources"
   region = "azure-germanywestcentral"
   type   = "ip"
 
-  dynamic "rule" {
+  dynamic "rules" {
     for_each = var.allowed_cidr_blocks
     content {
-      source = rule.value
+      source = rules.value
     }
   }
 }
@@ -59,7 +59,7 @@ resource "ec_deployment_traffic_filter" "allowed_sources" {
 resource "ec_elasticsearch_project" "search" {
   name               = "infoportal-search-${var.environment}"
   region_id          = "azure-germanywestcentral"
-  traffic_filter_ids = length(var.allowed_cidr_blocks) > 0 ? [ec_deployment_traffic_filter.allowed_sources[0].id] : []
+  traffic_filter_ids = length(var.allowed_cidr_blocks) > 0 ? [ec_serverless_traffic_filter.allowed_sources[0].id] : []
 }
 
 resource "azurerm_key_vault_secret" "es_endpoint" {

--- a/infrastructure/modules/infoportal-elasticsearch/main.tf
+++ b/infrastructure/modules/infoportal-elasticsearch/main.tf
@@ -48,12 +48,7 @@ resource "ec_serverless_traffic_filter" "allowed_sources" {
   region = "azure-germanywestcentral"
   type   = "ip"
 
-  dynamic "rules" {
-    for_each = var.allowed_cidr_blocks
-    content {
-      source = rules.value
-    }
-  }
+  rules = [for cidr in var.allowed_cidr_blocks : { source = cidr }]
 }
 
 resource "ec_elasticsearch_project" "search" {


### PR DESCRIPTION
Update the Elasticsearch traffic filter resource from the deprecated deployment-based API to the serverless API, including the corresponding rule iteration variable rename.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
