### PR TITLE
feat: Add backup vault configuration for media storage accounts

### DIFF
--- a/.github/workflows/infoportal-media-sa-at23.yml
+++ b/.github/workflows/infoportal-media-sa-at23.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/infoportal-media-sa-at23.yml
       - infrastructure/altinn-portaler-test/infoportal-media-sa-at23/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - .github/workflows/infoportal-media-sa-at23.yml
       - infrastructure/altinn-portaler-test/infoportal-media-sa-at23/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   workflow_dispatch:
     inputs:
       log_level:
@@ -38,6 +40,7 @@ env:
   WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/infoportal-media-sa-at23
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+  TF_VAR_backup_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
 
 permissions:
   id-token: write

--- a/.github/workflows/infoportal-media-sa-prod.yml
+++ b/.github/workflows/infoportal-media-sa-prod.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/infoportal-media-sa-prod.yml
       - infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - .github/workflows/infoportal-media-sa-prod.yml
       - infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   workflow_dispatch:
     inputs:
       log_level:
@@ -38,6 +40,7 @@ env:
   WORKING_DIRECTORY: ./infrastructure/altinn-portaler-prod/infoportal-media-sa-prod
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_PROD }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_PROD }}
+  TF_VAR_backup_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_PROD }}
 
 permissions:
   id-token: write

--- a/.github/workflows/infoportal-media-sa-tt02.yml
+++ b/.github/workflows/infoportal-media-sa-tt02.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/infoportal-media-sa-tt02.yml
       - infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - .github/workflows/infoportal-media-sa-tt02.yml
       - infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   workflow_dispatch:
     inputs:
       log_level:
@@ -38,6 +40,7 @@ env:
   WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/infoportal-media-sa-tt02
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+  TF_VAR_backup_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
 
 permissions:
   id-token: write

--- a/.github/workflows/kinorgeportal-media-sa-prod.yml
+++ b/.github/workflows/kinorgeportal-media-sa-prod.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/kinorgeportal-media-sa-prod.yml
       - infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - .github/workflows/kinorgeportal-media-sa-prod.yml
       - infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   workflow_dispatch:
     inputs:
       log_level:
@@ -38,6 +40,7 @@ env:
   WORKING_DIRECTORY: ./infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_PROD }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_PROD }}
+  TF_VAR_backup_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_PROD }}
 
 permissions:
   id-token: write

--- a/.github/workflows/kinorgeportal-media-sa-tt02.yml
+++ b/.github/workflows/kinorgeportal-media-sa-tt02.yml
@@ -12,6 +12,7 @@ on:
       - .github/workflows/kinorgeportal-media-sa-tt02.yml
       - infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - .github/workflows/kinorgeportal-media-sa-tt02.yml
       - infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/**
       - infrastructure/modules/infoportal-media-sa/**
+      - infrastructure/modules/infoportal-media-sa-backup/**
   workflow_dispatch:
     inputs:
       log_level:
@@ -38,6 +40,7 @@ env:
   WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02
   ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+  TF_VAR_backup_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
 
 permissions:
   id-token: write

--- a/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/backup.tf
+++ b/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/backup.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "backup" {
+  provider = azurerm.backup
+  name     = "infoportal-media-sa-backup-prod"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+module "media_sa_backup" {
+  source = "../../modules/infoportal-media-sa-backup"
+
+  providers = {
+    azurerm        = azurerm.backup
+    azurerm.source = azurerm
+  }
+
+  storage_account_id    = module.media_sa.storage_account_id
+  resource_group_name   = azurerm_resource_group.backup.name
+  location              = azurerm_resource_group.backup.location
+  backup_vault_name     = "infoportal-media-bvault-prod"
+  backup_retention_days = 30
+  tags                  = local.tags
+}

--- a/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/outputs.tf
+++ b/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/outputs.tf
@@ -12,3 +12,8 @@ output "primary_blob_endpoint" {
   description = "Primary blob service endpoint URL"
   value       = module.media_sa.primary_blob_endpoint
 }
+
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = module.media_sa_backup.backup_vault_id
+}

--- a/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/providers.tf
+++ b/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/providers.tf
@@ -24,3 +24,9 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
+
+provider "azurerm" {
+  alias           = "backup"
+  subscription_id = var.backup_subscription_id
+  features {}
+}

--- a/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/variables.tf
+++ b/infrastructure/altinn-portaler-prod/infoportal-media-sa-prod/variables.tf
@@ -1,3 +1,8 @@
+variable "backup_subscription_id" {
+  description = "Azure subscription ID where the backup vault will be created (separate from the storage account subscription)"
+  type        = string
+}
+
 variable "umbraco_sp_object_id" {
   description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
   type        = string

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/backup.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/backup.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "backup" {
+  provider = azurerm.backup
+  name     = "kinorgeportal-media-sa-backup-prod"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+module "media_sa_backup" {
+  source = "../../modules/infoportal-media-sa-backup"
+
+  providers = {
+    azurerm        = azurerm.backup
+    azurerm.source = azurerm
+  }
+
+  storage_account_id    = module.media_sa.storage_account_id
+  resource_group_name   = azurerm_resource_group.backup.name
+  location              = azurerm_resource_group.backup.location
+  backup_vault_name     = "kinorge-media-bvault-prod"
+  backup_retention_days = 30
+  tags                  = local.tags
+}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/outputs.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/outputs.tf
@@ -12,3 +12,8 @@ output "primary_blob_endpoint" {
   description = "Primary blob service endpoint URL"
   value       = module.media_sa.primary_blob_endpoint
 }
+
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = module.media_sa_backup.backup_vault_id
+}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/providers.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/providers.tf
@@ -24,3 +24,9 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
+
+provider "azurerm" {
+  alias           = "backup"
+  subscription_id = var.backup_subscription_id
+  features {}
+}

--- a/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/variables.tf
+++ b/infrastructure/altinn-portaler-prod/kinorgeportal-media-sa-prod/variables.tf
@@ -1,3 +1,8 @@
+variable "backup_subscription_id" {
+  description = "Azure subscription ID where the backup vault will be created (separate from the storage account subscription)"
+  type        = string
+}
+
 variable "umbraco_sp_object_id" {
   description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
   type        = string

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/backup.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/backup.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "backup" {
+  provider = azurerm.backup
+  name     = "infoportal-media-sa-backup-at23"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+module "media_sa_backup" {
+  source = "../../modules/infoportal-media-sa-backup"
+
+  providers = {
+    azurerm        = azurerm.backup
+    azurerm.source = azurerm
+  }
+
+  storage_account_id    = module.media_sa.storage_account_id
+  resource_group_name   = azurerm_resource_group.backup.name
+  location              = azurerm_resource_group.backup.location
+  backup_vault_name     = "infoportal-media-bvault-at23"
+  backup_retention_days = 30
+  tags                  = local.tags
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/outputs.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/outputs.tf
@@ -12,3 +12,8 @@ output "primary_blob_endpoint" {
   description = "Primary blob service endpoint URL"
   value       = module.media_sa.primary_blob_endpoint
 }
+
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = module.media_sa_backup.backup_vault_id
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/providers.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/providers.tf
@@ -24,3 +24,9 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
+
+provider "azurerm" {
+  alias           = "backup"
+  subscription_id = var.backup_subscription_id
+  features {}
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-at23/variables.tf
@@ -1,3 +1,8 @@
+variable "backup_subscription_id" {
+  description = "Azure subscription ID where the backup vault will be created (separate from the storage account subscription)"
+  type        = string
+}
+
 variable "umbraco_sp_object_id" {
   description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
   type        = string

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/backup.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/backup.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "backup" {
+  provider = azurerm.backup
+  name     = "infoportal-media-sa-backup-tt02"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+module "media_sa_backup" {
+  source = "../../modules/infoportal-media-sa-backup"
+
+  providers = {
+    azurerm        = azurerm.backup
+    azurerm.source = azurerm
+  }
+
+  storage_account_id    = module.media_sa.storage_account_id
+  resource_group_name   = azurerm_resource_group.backup.name
+  location              = azurerm_resource_group.backup.location
+  backup_vault_name     = "infoportal-media-bvault-tt02"
+  backup_retention_days = 30
+  tags                  = local.tags
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/outputs.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/outputs.tf
@@ -12,3 +12,8 @@ output "primary_blob_endpoint" {
   description = "Primary blob service endpoint URL"
   value       = module.media_sa.primary_blob_endpoint
 }
+
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = module.media_sa_backup.backup_vault_id
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/providers.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/providers.tf
@@ -24,3 +24,9 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
+
+provider "azurerm" {
+  alias           = "backup"
+  subscription_id = var.backup_subscription_id
+  features {}
+}

--- a/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/variables.tf
+++ b/infrastructure/altinn-portaler-test/infoportal-media-sa-tt02/variables.tf
@@ -1,3 +1,8 @@
+variable "backup_subscription_id" {
+  description = "Azure subscription ID where the backup vault will be created (separate from the storage account subscription)"
+  type        = string
+}
+
 variable "umbraco_sp_object_id" {
   description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
   type        = string

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/backup.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/backup.tf
@@ -1,0 +1,22 @@
+resource "azurerm_resource_group" "backup" {
+  provider = azurerm.backup
+  name     = "kinorgeportal-media-sa-backup-tt02"
+  location = "Norway East"
+  tags     = local.tags
+}
+
+module "media_sa_backup" {
+  source = "../../modules/infoportal-media-sa-backup"
+
+  providers = {
+    azurerm        = azurerm.backup
+    azurerm.source = azurerm
+  }
+
+  storage_account_id    = module.media_sa.storage_account_id
+  resource_group_name   = azurerm_resource_group.backup.name
+  location              = azurerm_resource_group.backup.location
+  backup_vault_name     = "kinorge-media-bvault-tt02"
+  backup_retention_days = 30
+  tags                  = local.tags
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/outputs.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/outputs.tf
@@ -12,3 +12,8 @@ output "primary_blob_endpoint" {
   description = "Primary blob service endpoint URL"
   value       = module.media_sa.primary_blob_endpoint
 }
+
+output "backup_vault_id" {
+  description = "Resource ID of the backup vault"
+  value       = module.media_sa_backup.backup_vault_id
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/providers.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/providers.tf
@@ -24,3 +24,9 @@ provider "azurerm" {
   features {}
   storage_use_azuread = true
 }
+
+provider "azurerm" {
+  alias           = "backup"
+  subscription_id = var.backup_subscription_id
+  features {}
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/variables.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-media-sa-tt02/variables.tf
@@ -1,3 +1,8 @@
+variable "backup_subscription_id" {
+  description = "Azure subscription ID where the backup vault will be created (separate from the storage account subscription)"
+  type        = string
+}
+
 variable "umbraco_sp_object_id" {
   description = "Object ID of the Umbraco managed identity that reads/writes media files in the storage account. Leave empty to skip the role assignment."
   type        = string


### PR DESCRIPTION
Add backup vault support across all media storage account environments (prod and test). This includes:

- New backup module deployments in separate subscriptions
- Backup provider configuration with subscription ID variable
- Workflow triggers for backup module changes
- Backup vault outputs for all environments

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
