### PR TITLE
feat: Altinn 3 platform API alignment + profile language

### DIFF
--- a/astro-infoportal/src/Components/Layout/Header/hooks/useCurrentUser.ts
+++ b/astro-infoportal/src/Components/Layout/Header/hooks/useCurrentUser.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { isBrowser } from "../utils/browserUtils";
+
+export interface CurrentUser {
+  selfAccountUuid?: string | null;
+  currentAccountUuid?: string | null;
+  showDeletedEntities?: boolean | null;
+  language?: string | null;
+}
+
+// Shared cache: header + language hook reuse one /api/users/current request.
+let currentUserPromise: Promise<CurrentUser> | null = null;
+
+export function fetchCurrentUserOnce(): Promise<CurrentUser> {
+  if (!currentUserPromise) {
+    currentUserPromise = fetch("/api/users/current", {
+      credentials: "include",
+      cache: "no-store",
+    })
+      .then((response) =>
+        response.ok ? (response.json() as Promise<CurrentUser>) : {},
+      )
+      .catch(() => ({}) as CurrentUser);
+  }
+  return currentUserPromise;
+}
+
+export function useCurrentUser(): {
+  user: CurrentUser | null;
+  isLoading: boolean;
+} {
+  const [user, setUser] = useState<CurrentUser | null>(null);
+  const [isLoading, setIsLoading] = useState(isBrowser);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      setIsLoading(false);
+      return;
+    }
+    let active = true;
+    fetchCurrentUserOnce().then((value) => {
+      if (active) {
+        setUser(value);
+        setIsLoading(false);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { user, isLoading };
+}

--- a/astro-infoportal/src/Components/Layout/Header/hooks/useLanguagePreference.ts
+++ b/astro-infoportal/src/Components/Layout/Header/hooks/useLanguagePreference.ts
@@ -1,0 +1,38 @@
+import {
+  detectLocaleFromPath,
+  navigateToLocale,
+  resolveLocale,
+} from "@constants/languages";
+import type { Locale } from "@i18n/index";
+import { useEffect } from "react";
+import { isBrowser } from "../utils/browserUtils";
+import { fetchCurrentUserOnce } from "./useCurrentUser";
+
+type LocaleMenuEntry = { locale: Locale; pageUrl: string };
+
+const REDIRECT_GUARD = "langPrefRedirected";
+
+// Stop the auto-redirect for this session after an explicit language choice.
+export function suppressLanguageRedirect(): void {
+  if (isBrowser) sessionStorage.setItem(REDIRECT_GUARD, "1");
+}
+
+// Auto-select locale from the profile. Client-side only: the page is edge-cached
+// per URL, so SSR must never vary by this.
+export function useLanguagePreference(
+  menuLanguageList: LocaleMenuEntry[] | undefined,
+): void {
+  useEffect(() => {
+    if (!isBrowser) return;
+    if (sessionStorage.getItem(REDIRECT_GUARD)) return;
+
+    fetchCurrentUserOnce().then((user) => {
+      if (!user?.language) return;
+      const preferred = resolveLocale(user.language);
+      const current = detectLocaleFromPath(window.location.pathname);
+      if (preferred === current) return;
+      suppressLanguageRedirect();
+      navigateToLocale(preferred, menuLanguageList, window.location.pathname);
+    });
+  }, [menuLanguageList]);
+}

--- a/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
+++ b/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
@@ -1,15 +1,25 @@
 import type {
-  AuthorizedParty as LibAuthorizedParty,
   GlobalHeaderProps,
+  AuthorizedParty as LibAuthorizedParty,
 } from "@altinn/altinn-components";
 import { useAccountSelector } from "@altinn/altinn-components";
 import "@altinn/altinn-components/dist/global.css";
+import { isLocale, navigateToLocale } from "@constants/languages";
+import type { Locale } from "@i18n/index";
 import { useEffect, useMemo, useState } from "react";
 // import { useSearchSuggestions } from "./hooks/useSearchSuggestions";
 import { buildDesktopMenu } from "./builders/menuBuilder";
+import { fetchCurrentUserOnce } from "./hooks/useCurrentUser";
 import { useFavorites } from "./hooks/useFavorites";
+import { suppressLanguageRedirect } from "./hooks/useLanguagePreference";
 import type { MenuPages } from "./types/headerTypes";
 import { isBrowser } from "./utils/browserUtils";
+
+// Local UUID guard — can't import from api/altinn/client (it pulls in
+// cloudflare:workers, which must not enter the browser bundle). Hardening only.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const isValidUuid = (value: string): boolean => UUID_RE.test(value);
 
 // Determines the visual theme for the header and layout
 const getAccountColor = (
@@ -56,27 +66,39 @@ const useHeaderConfig = (
     searchTextPlaceholder,
     menuLanguageList,
     chooseLanguageText,
-    hostBaseUrl,
     backButtonText,
     logOutPage,
     aboutNewAltinnPage,
     profilePage,
     loggedInAsText,
-    startPage
+    startPage,
     // useSearchSuggestions: useSuggestionsEnabled,
   }: any,
   languageCode: "nb" | "nn" | "en" = "nb",
 ): { headerProps: GlobalHeaderProps; color: "person" | "company" } => {
   // State management for user session data
-  const [currentAccountUuid, setCurrentAccountUuid] = useState<string | undefined>(undefined);
-  const [selfAccountUuid, setSelfAccountUuid] = useState<string | undefined>(undefined);
-  const [authorizedParties, setAuthorizedParties] = useState<AuthorizedPartyData[]>([]);
+  const [currentAccountUuid, setCurrentAccountUuid] = useState<
+    string | undefined
+  >(undefined);
+  const [selfAccountUuid, setSelfAccountUuid] = useState<string | undefined>(
+    undefined,
+  );
+  const [authorizedParties, setAuthorizedParties] = useState<
+    AuthorizedPartyData[]
+  >([]);
   const [currentPath, setCurrentPath] = useState<string>("");
-  const [shouldShowDeletedUnits, setShouldShowDeletedUnits] = useState<boolean | undefined>(undefined);
+  const [shouldShowDeletedUnits, setShouldShowDeletedUnits] = useState<
+    boolean | undefined
+  >(undefined);
   const [isDataLoading, setIsDataLoading] = useState(isBrowser);
 
   // Custom hooks
-  const { favorites, isLoading: isFavoritesLoading, addFavorite, removeFavorite } = useFavorites();
+  const {
+    favorites,
+    isLoading: isFavoritesLoading,
+    addFavorite,
+    removeFavorite,
+  } = useFavorites();
 
   // Fetch user data and authorized parties on mount
   useEffect(() => {
@@ -90,30 +112,25 @@ const useHeaderConfig = (
 
     const fetchUserData = async () => {
       try {
-        // Fetch both user data and authorized parties in parallel
-        const [userResponse, partiesResponse] = await Promise.all([
-          fetch("/api/users/current", {
-            credentials: "include",
-            cache: "no-store",
-          }),
+        // Current-user fetch is shared with useLanguagePreference (one request).
+        const [userData, partiesResponse] = await Promise.all([
+          fetchCurrentUserOnce(),
           fetch("/api/users/authorized-parties", {
             credentials: "include",
             cache: "no-store",
           }),
         ]);
 
-        // Only update if both requests succeeded
-        if (userResponse.ok && partiesResponse.ok) {
-          const userData = await userResponse.json();
+        if (partiesResponse.ok) {
           const partiesData = await partiesResponse.json();
-
-          // Update state with user session data
-          setSelfAccountUuid(userData.selfAccountUuid);
-          setCurrentAccountUuid(userData.currentAccountUuid);
+          setSelfAccountUuid(userData.selfAccountUuid ?? undefined);
+          setCurrentAccountUuid(userData.currentAccountUuid ?? undefined);
           setAuthorizedParties(partiesData);
 
-          // Update show deleted units preference
-          if (userData.showDeletedEntities !== undefined) {
+          if (
+            userData.showDeletedEntities !== undefined &&
+            userData.showDeletedEntities !== null
+          ) {
             setShouldShowDeletedUnits(userData.showDeletedEntities);
           }
         }
@@ -147,15 +164,16 @@ const useHeaderConfig = (
   };
 
   // Find the main user and build menu - memoized to avoid recalculation
-  const currentUser = useMemo(() =>
-    authorizedParties.find(p => p.partyUuid === currentAccountUuid),
-    [authorizedParties, currentAccountUuid]
+  const currentUser = useMemo(
+    () => authorizedParties.find((p) => p.partyUuid === currentAccountUuid),
+    [authorizedParties, currentAccountUuid],
   );
 
   const userType = useMemo(() => {
-    if (!currentUser)
-      return "person";
-    return currentUser.type === 1 || currentUser.type === "Person" ? "person" : "company";
+    if (!currentUser) return "person";
+    return currentUser.type === 1 || currentUser.type === "Person"
+      ? "person"
+      : "company";
   }, [currentUser]);
 
   const accountColor = useMemo(
@@ -163,16 +181,24 @@ const useHeaderConfig = (
     [currentUser?.type, isLoggedIn],
   );
 
-  const desktopMenu = useMemo(() =>
-    buildDesktopMenu(
+  const desktopMenu = useMemo(
+    () =>
+      buildDesktopMenu(
+        pages,
+        isLoggedIn,
+        loggedInAsText || "",
+        currentUser?.name || "",
+        userType,
+        currentPath,
+      ),
+    [
       pages,
       isLoggedIn,
-      loggedInAsText || "",
-      currentUser?.name || "",
+      loggedInAsText,
+      currentUser?.name,
       userType,
       currentPath,
-    ),
-    [pages, isLoggedIn, loggedInAsText, currentUser?.name, userType, currentPath]
+    ],
   );
 
   const transformParty = (party: AuthorizedPartyData): LibAuthorizedParty => {
@@ -187,8 +213,12 @@ const useHeaderConfig = (
       onlyHierarchyElementWithNoAccess: party.onlyHierarchyElementWithNoAccess,
       authorizedResources: party.authorizedResources,
       authorizedRoles: party.authorizedRoles,
-      ...(party.dateOfBirth && isPerson ? { dateOfBirth: party.dateOfBirth } : {}),
-      ...(party.organizationNumber && !isPerson ? { organizationNumber: party.organizationNumber } : {}),
+      ...(party.dateOfBirth && isPerson
+        ? { dateOfBirth: party.dateOfBirth }
+        : {}),
+      ...(party.organizationNumber && !isPerson
+        ? { organizationNumber: party.organizationNumber }
+        : {}),
       ...(party.unitType ? { unitType: party.unitType } : {}),
       subunits: party.subunits?.map(transformParty) || [],
     };
@@ -199,12 +229,15 @@ const useHeaderConfig = (
   // Callback to update show deleted units preference
   const onShowDeletedUnitsChange = async (shouldShowDeleted: boolean) => {
     try {
-      const response = await fetch("/api/users/preferences/show-deleted-entities", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify(shouldShowDeleted),
-      });
+      const response = await fetch(
+        "/api/users/preferences/show-deleted-entities",
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(shouldShowDeleted),
+        },
+      );
       if (response.ok) {
         const data = await response.json();
         setShouldShowDeletedUnits(data.shouldShowDeletedEntities);
@@ -232,13 +265,15 @@ const useHeaderConfig = (
       }
     },
     onSelectAccount: (accountId: string) => {
+      if (!isBrowser || !isValidUuid(accountId)) return;
       setCurrentAccountUuid(accountId);
-      const redirectUrl = window.location.href;
+      // Altinn 3 reportee switch via our own Worker route.
       const changeUrl = new URL(
-        `${hostBaseUrl}ui/Reportee/ChangeReporteeAndRedirect/`,
+        "/api/users/change-party",
+        window.location.origin,
       );
-      changeUrl.searchParams.set("P", accountId);
-      changeUrl.searchParams.set("goTo", redirectUrl);
+      changeUrl.searchParams.set("partyUuid", accountId);
+      changeUrl.searchParams.set("goTo", window.location.href);
       (window as Window).open(changeUrl.toString(), "_self");
     },
   });
@@ -255,53 +290,43 @@ const useHeaderConfig = (
 
   const currentLangCode = detectCurrentLang();
 
-  const langCodeMap: Record<string, string> = {
-    "Bokmål": "nb",
-    "Nynorsk": "nn",
-    "English": "en",
-  };
-
-  const localeSwitcher = menuLanguageList && menuLanguageList.length > 0
-    ? {
-        title: chooseLanguageText || "Språk/language",
-        options: menuLanguageList.map((lang: any) => {
-          const code = lang.languageCode || langCodeMap[lang.languageName] || lang.languageName;
-          return {
-            id: lang.languageName,
-            title: lang.languageName,
-            value: code,
-            checked: code === currentLangCode,
-          };
-        }),
-        onSelect: (value: string) => {
-          if (!isBrowser) return;
-          const lang = menuLanguageList.find((l: any) =>
-            (l.languageCode || langCodeMap[l.languageName] || l.languageName) === value
-          );
-          if (!lang) return;
-
-          // Search pages have different slugs per language — handle them explicitly
-          const searchSlugMap: Record<string, string> = {
-            nb: "/sok/",
-            nn: "/nn/sok/",
-            en: "/en/search/",
-          };
-          const searchSlugs = new Set(Object.values(searchSlugMap).flatMap(s => [s, s.replace(/\/$/, "")]));
-          const currentPath = window.location.pathname;
-          const targetLangCode = value;
-
-          if (searchSlugs.has(currentPath) && searchSlugMap[targetLangCode]) {
-            window.location.assign(searchSlugMap[targetLangCode]);
-            return;
-          }
-
-          // For Umbraco pages, use the CMS-provided pageUrl
-          if (lang.pageUrl) {
-            window.location.assign(lang.pageUrl);
-          }
-        },
-      }
-    : undefined;
+  const localeSwitcher =
+    menuLanguageList && menuLanguageList.length > 0
+      ? {
+          title: chooseLanguageText || "Språk/language",
+          options: menuLanguageList.map(
+            (lang: { locale: Locale; languageName: string }) => ({
+              id: lang.languageName,
+              title: lang.languageName,
+              value: lang.locale,
+              checked: lang.locale === currentLangCode,
+            }),
+          ),
+          onSelect: async (value: string) => {
+            if (!isBrowser || !isLocale(value)) return;
+            const locale = value;
+            suppressLanguageRedirect();
+            // Persist the choice to the profile (logged-in only).
+            if (isLoggedIn) {
+              try {
+                await fetch("/api/users/preferences/language", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  credentials: "include",
+                  body: JSON.stringify({ languageCode: locale }),
+                });
+              } catch {
+                // Non-blocking — still navigate.
+              }
+            }
+            navigateToLocale(
+              locale,
+              menuLanguageList,
+              window.location.pathname,
+            );
+          },
+        }
+      : undefined;
 
   const globalHeaderProps: GlobalHeaderProps = {
     globalMenu: {
@@ -311,16 +336,17 @@ const useHeaderConfig = (
       ...(isLoggedIn && {
         backLabel: backButtonText,
       }),
-      ...(isLoggedIn && logOutPage && {
-        logoutButton: {
-          label: logOutPage.text || "",
-          onClick: () => {
-            if (isBrowser && logOutPage.url) {
-              location.assign(logOutPage.url);
-            }
+      ...(isLoggedIn &&
+        logOutPage && {
+          logoutButton: {
+            label: logOutPage.text || "",
+            onClick: () => {
+              if (isBrowser && logOutPage.url) {
+                location.assign(logOutPage.url);
+              }
+            },
           },
-        },
-      }),
+        }),
     },
     ...(startPage?.url && {
       logo: { href: startPage.url },
@@ -333,8 +359,8 @@ const useHeaderConfig = (
     },
     onLoginClick: !isLoggedIn
       ? () => {
-        if (isBrowser) location.assign(loginPage?.url ?? "#");
-      }
+          if (isBrowser) location.assign(loginPage?.url ?? "#");
+        }
       : undefined,
   };
 

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
@@ -7,6 +7,7 @@ import type {SiteLayoutProps} from './SiteLayout.types';
 import useSidebarConfig from '../../Shared/PageSidebar/useSidebarConfig';
 import useFooterConfig from '../Footer/useFooterConfig';
 import useHeaderConfig from '../Header/useHeaderConfig';
+import {useLanguagePreference} from '../Header/hooks/useLanguagePreference';
 import './SiteLayout.scss';
 import {SkipLink} from '@digdir/designsystemet-react';
 import BannerBlock from '../../../Components/Blocks/BannerBlock/BannerBlock';
@@ -62,6 +63,9 @@ const SiteLayout = ({
     headerViewModel || ({} as any),
     languageCode,
   );
+
+  // Client-side locale auto-select from the profile (never SSR — cached per URL).
+  useLanguagePreference(headerViewModel?.menuLanguageList);
   const footerProps = useFooterConfig(footerViewModel || ({} as any));
   const sidebarConfig = useSidebarConfig(pageSidebarViewModel);
 

--- a/astro-infoportal/src/Constants/languages.ts
+++ b/astro-infoportal/src/Constants/languages.ts
@@ -76,9 +76,11 @@ export function buildMenuLanguageList(
   currentPath?: string,
 ) {
   const nbPath =
-    cultures.nb?.path ?? (currentPath ? stripLocalePrefix(currentPath) : undefined);
+    cultures.nb?.path ??
+    (currentPath ? stripLocalePrefix(currentPath) : undefined);
 
   return SUPPORTED_LOCALES.map((l) => ({
+    locale: l.locale,
     pageUrl:
       cultures[l.locale]?.path ??
       (nbPath ? deriveLocaleUrl(nbPath, l.locale) : LOCALE_HOME[l.locale]),
@@ -87,4 +89,58 @@ export function buildMenuLanguageList(
     languageName: l.languageName,
     selected: l.locale === currentLocale,
   }));
+}
+
+// Cross-Altinn UI-language cookie value per locale (read by other Altinn apps).
+export const LOCALE_TO_PERSISTENT_CONTEXT: Record<Locale, string> = {
+  nb: "UL=1044",
+  nn: "UL=2068",
+  en: "UL=1033",
+};
+
+// Type guard for the locale literal union (narrow after validation).
+export function isLocale(value: unknown): value is Locale {
+  return value === "nb" || value === "nn" || value === "en";
+}
+
+// Profile language → site locale (profile stores nb/nn/en; fallback nb).
+export function resolveLocale(value?: string | null): Locale {
+  return isLocale(value) ? value : "nb";
+}
+
+export function detectLocaleFromPath(path: string): Locale {
+  if (path === "/nn" || path.startsWith("/nn/")) return "nn";
+  if (path === "/en" || path.startsWith("/en/")) return "en";
+  return "nb";
+}
+
+const SEARCH_SLUGS: Record<Locale, string> = {
+  nb: "/sok/",
+  nn: "/nn/sok/",
+  en: "/en/search/",
+};
+
+type LocaleMenuEntry = { locale: Locale; pageUrl: string };
+
+// Navigate to the same page in another locale (CMS pageUrls + search slugs).
+export function navigateToLocale(
+  targetLocale: Locale,
+  menuLanguageList: LocaleMenuEntry[] | undefined,
+  currentPath: string,
+): boolean {
+  const searchSlugSet = new Set(
+    Object.values(SEARCH_SLUGS).flatMap((s) => [s, s.replace(/\/$/, "")]),
+  );
+  const target = searchSlugSet.has(currentPath)
+    ? SEARCH_SLUGS[targetLocale]
+    : menuLanguageList?.find((l) => l.locale === targetLocale)?.pageUrl;
+
+  // Relative same-origin only (open-redirect guard).
+  if (!target || /^[a-z]+:/i.test(target) || target.startsWith("//")) {
+    return false;
+  }
+  if (typeof window !== "undefined") {
+    window.location.assign(target);
+  }
+  return true;
 }

--- a/astro-infoportal/src/api/altinn/config.ts
+++ b/astro-infoportal/src/api/altinn/config.ts
@@ -8,6 +8,10 @@ export interface AltinnPlatformConfig {
   subscriptionKeyHeaderName: string;
   jwtCookieName: string;
   partyUuidCookieName: string;
+  // Feature flags, set via wrangler/env vars (mirror AM UI's per-env FeatureFlags).
+  useNewActorList: boolean;
+  // Turn off after the Altinn 2 shutdown (2026-06-19).
+  routeChangeReporteeViaAltinn2: boolean;
 }
 
 export function getAltinnPlatformConfig(
@@ -21,6 +25,9 @@ export function getAltinnPlatformConfig(
       env.ALTINN_SUBSCRIPTION_KEY_HEADER_NAME || "Ocp-Apim-Subscription-Key",
     jwtCookieName: env.ALTINN_JWT_COOKIE_NAME || "AltinnStudioRuntime",
     partyUuidCookieName: env.ALTINN_PARTY_UUID_COOKIE_NAME || "AltinnPartyUuid",
+    useNewActorList: env.USE_NEW_ACTOR_LIST === "true",
+    routeChangeReporteeViaAltinn2:
+      env.ROUTE_CHANGE_REPORTEE_VIA_ALTINN2 !== "false",
   };
 }
 

--- a/astro-infoportal/src/api/altinn/types.ts
+++ b/astro-infoportal/src/api/altinn/types.ts
@@ -58,4 +58,35 @@ export interface CurrentUserResponse {
   selfAccountUuid: string | null;
   currentAccountUuid: string | null;
   showDeletedEntities?: boolean | null;
+  language?: string | null;
+}
+
+// Altinn 3 `enduser/connections` shapes (new actor list, behind USE_NEW_ACTOR_LIST).
+export interface ConnectionEntity {
+  id: string;
+  name: string;
+  type: string;
+  variant?: string | null;
+  parent?: ConnectionEntity | null;
+  children?: ConnectionEntity[] | null;
+  partyId?: number | null;
+  organizationIdentifier?: string | null;
+  dateOfBirth?: string | null;
+  isDeleted: boolean;
+}
+
+export interface ConnectionRoleInfo {
+  id: string;
+  code?: string | null;
+}
+
+export interface Connection {
+  party: ConnectionEntity;
+  roles: ConnectionRoleInfo[];
+  connections: Connection[];
+}
+
+export interface PaginatedResult<T> {
+  links?: { next?: string | null } | null;
+  items: T[];
 }

--- a/astro-infoportal/src/pages/api/users/authorized-parties.ts
+++ b/astro-infoportal/src/pages/api/users/authorized-parties.ts
@@ -1,13 +1,117 @@
 import type { APIRoute } from "astro";
 import {
+  type AuthContext,
   altinnPlatformFetch,
   getAuthContext,
   jsonResponse,
 } from "../../../api/altinn/client";
-import { getAccessManagementApiBaseUrl } from "../../../api/altinn/config";
-import type { AuthorizedParty } from "../../../api/altinn/types";
+import {
+  getAccessManagementApiBaseUrl,
+  getProfileApiBaseUrl,
+} from "../../../api/altinn/config";
+import type {
+  AuthorizedParty,
+  Connection,
+  ConnectionEntity,
+  ConnectionRoleInfo,
+  PaginatedResult,
+  UserProfile,
+} from "../../../api/altinn/types";
 
 export const prerender = false;
+
+// Actor list (parties the user can represent). Default: authorizedparties (what AM
+// ships); USE_NEW_ACTOR_LIST: enduser/connections. Both mapped to AuthorizedParty[].
+
+function buildAuthorizedPartiesUrl(base: string): string {
+  const url = new URL(`${base}/authorizedparties`);
+  url.searchParams.set("includeAltinn2", "true");
+  url.searchParams.set("includeRoles", "false");
+  url.searchParams.set("includeAccessPackages", "false");
+  url.searchParams.set("includeResources", "false");
+  url.searchParams.set("includeInstances", "false");
+  return url.toString();
+}
+
+async function fetchAuthorizedParties(
+  auth: AuthContext,
+): Promise<AuthorizedParty[]> {
+  const response = await altinnPlatformFetch(
+    auth,
+    buildAuthorizedPartiesUrl(getAccessManagementApiBaseUrl(auth.config)),
+  );
+  if (!response || !response.ok) {
+    throw new Error("authorizedparties request failed");
+  }
+  const parties = (await response.json()) as AuthorizedParty[] | null;
+  return parties ?? [];
+}
+
+// PROVISIONAL (USE_NEW_ACTOR_LIST only): connections lacks
+// onlyHierarchyElementWithNoAccess / authorizedResources — defaulted. Verify against
+// AM's final mapping before enabling.
+function entityToAuthorizedParty(
+  entity: ConnectionEntity,
+  roles: ConnectionRoleInfo[] = [],
+): AuthorizedParty {
+  const isPerson = entity.type === "Person";
+  return {
+    partyUuid: entity.id,
+    name: entity.name,
+    organizationNumber: isPerson
+      ? null
+      : (entity.organizationIdentifier ?? null),
+    dateOfBirth: isPerson ? (entity.dateOfBirth ?? null) : null,
+    partyId: entity.partyId ?? 0,
+    type: isPerson ? "Person" : "Organization",
+    unitType: entity.variant ?? null,
+    isDeleted: entity.isDeleted,
+    onlyHierarchyElementWithNoAccess: false,
+    authorizedResources: [],
+    authorizedRoles: roles
+      .map((role) => role.code)
+      .filter((code): code is string => !!code),
+    subunits: (entity.children ?? []).map((child) =>
+      entityToAuthorizedParty(child),
+    ),
+  };
+}
+
+// The user's OWN party uuid (not the active-reportee cookie) — keys the actor list,
+// mirroring AM's GetUserPartyUuid.
+async function resolveUserPartyUuid(auth: AuthContext): Promise<string | null> {
+  const response = await altinnPlatformFetch(
+    auth,
+    `${getProfileApiBaseUrl(auth.config)}/users/current`,
+  );
+  if (!response || !response.ok) return null;
+  const profile = (await response.json()) as UserProfile | null;
+  return profile?.party?.partyUuid ?? null;
+}
+
+async function fetchNewActorList(
+  auth: AuthContext,
+): Promise<AuthorizedParty[]> {
+  const userPartyUuid = await resolveUserPartyUuid(auth);
+  if (!userPartyUuid) return [];
+  const url = new URL(
+    `${getAccessManagementApiBaseUrl(auth.config)}/enduser/connections`,
+  );
+  url.searchParams.set("party", userPartyUuid);
+  url.searchParams.set("from", "");
+  url.searchParams.set("to", userPartyUuid);
+  url.searchParams.set("includeClientDelegations", "true");
+  url.searchParams.set("includeAgentConnections", "true");
+
+  const response = await altinnPlatformFetch(auth, url.toString());
+  if (!response || !response.ok) {
+    throw new Error("connections request failed");
+  }
+  const data = (await response.json()) as PaginatedResult<Connection> | null;
+  return (data?.items ?? []).map((connection) =>
+    entityToAuthorizedParty(connection.party, connection.roles),
+  );
+}
 
 export const GET: APIRoute = async ({ request }) => {
   const auth = getAuthContext(request);
@@ -17,20 +121,10 @@ export const GET: APIRoute = async ({ request }) => {
   }
 
   try {
-    const response = await altinnPlatformFetch(
-      auth,
-      `${getAccessManagementApiBaseUrl(auth.config)}/authorizedparties?includeAltinn2=true`,
-    );
-
-    if (!response || !response.ok) {
-      return jsonResponse(
-        { error: "Failed to retrieve authorized parties" },
-        500,
-      );
-    }
-
-    const parties = (await response.json()) as AuthorizedParty[] | null;
-    return jsonResponse(parties ?? []);
+    const parties = auth.config.useNewActorList
+      ? await fetchNewActorList(auth)
+      : await fetchAuthorizedParties(auth);
+    return jsonResponse(parties);
   } catch {
     return jsonResponse(
       { error: "Failed to retrieve authorized parties" },

--- a/astro-infoportal/src/pages/api/users/change-party.ts
+++ b/astro-infoportal/src/pages/api/users/change-party.ts
@@ -1,0 +1,119 @@
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  getAuthContext,
+  isValidUuid,
+} from "../../../api/altinn/client";
+import { getAccessManagementApiBaseUrl } from "../../../api/altinn/config";
+import type { AuthorizedParty } from "../../../api/altinn/types";
+
+export const prerender = false;
+
+// Altinn 3 reportee switch: no platform endpoint exists, so replicate AM's
+// ReporteeController (PR #2167) — validate via authorizedparties, set cookies here.
+
+// Redirect allowlist (mirrors PR #2167): host equals or ends with one of these.
+const ALLOWED_REDIRECT_DOMAINS = ["altinn.no", "altinn.cloud", "localhost"];
+
+function isAllowedRedirect(target: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") return false;
+  const host = url.hostname.toLowerCase();
+  return ALLOWED_REDIRECT_DOMAINS.some(
+    (domain) => host === domain || host.endsWith(`.${domain}`),
+  );
+}
+
+function findParty(
+  parties: AuthorizedParty[],
+  partyUuid: string,
+): AuthorizedParty | null {
+  for (const party of parties) {
+    if (party.partyUuid === partyUuid) return party;
+    if (party.subunits && party.subunits.length > 0) {
+      const found = findParty(party.subunits, partyUuid);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export const GET: APIRoute = async ({ request }) => {
+  const auth = getAuthContext(request);
+  const requestUrl = new URL(request.url);
+  const partyUuid = requestUrl.searchParams.get("partyUuid") ?? "";
+  const goTo = requestUrl.searchParams.get("goTo") ?? "";
+
+  const fallback = auth.config.endpoints.hostBaseUrl;
+  const redirectTarget = isAllowedRedirect(goTo) ? goTo : fallback;
+
+  if (!auth.isAuthenticated || !isValidUuid(partyUuid)) {
+    return Response.redirect(redirectTarget, 302);
+  }
+
+  try {
+    const url = new URL(
+      `${getAccessManagementApiBaseUrl(auth.config)}/authorizedparties`,
+    );
+    url.searchParams.set("includeAltinn2", "true");
+    url.searchParams.set("includeRoles", "false");
+    url.searchParams.set("includeAccessPackages", "false");
+    url.searchParams.set("includeResources", "false");
+    url.searchParams.set("includeInstances", "false");
+
+    const response = await altinnPlatformFetch(auth, url.toString());
+    if (!response || !response.ok) {
+      return Response.redirect(redirectTarget, 302);
+    }
+
+    const parties = (await response.json()) as AuthorizedParty[] | null;
+    const party = findParty(parties ?? [], partyUuid);
+    if (!party) {
+      return Response.redirect(redirectTarget, 302);
+    }
+
+    const cookieDomain = new URL(auth.config.endpoints.hostBaseUrl).hostname;
+    const secure = cookieDomain !== "localhost";
+    const attributes = `Path=/; Domain=${cookieDomain}; SameSite=Lax${
+      secure ? "; Secure" : ""
+    }`;
+
+    // Bounce via Altinn 2 so its legacy cookies stay in sync (matches AM UI).
+    let finalLocation = redirectTarget;
+    if (auth.config.routeChangeReporteeViaAltinn2) {
+      const bounce = new URL(
+        `${auth.config.endpoints.hostBaseUrl}ui/Reportee/ChangeReporteeAndRedirect`,
+      );
+      bounce.searchParams.set("P", party.partyUuid);
+      bounce.searchParams.set("goTo", redirectTarget);
+      finalLocation = bounce.toString();
+    }
+
+    const headers = new Headers();
+    headers.append("Location", finalLocation);
+    headers.append("Cache-Control", "no-store");
+
+    // Validate the external-JSON values before writing them into Set-Cookie.
+    if (isValidUuid(party.partyUuid)) {
+      headers.append(
+        "Set-Cookie",
+        `AltinnPartyUuid=${party.partyUuid}; ${attributes}`,
+      );
+    }
+    if (typeof party.partyId === "number" && Number.isFinite(party.partyId)) {
+      headers.append(
+        "Set-Cookie",
+        `AltinnPartyId=${party.partyId}; ${attributes}`,
+      );
+    }
+
+    return new Response(null, { status: 302, headers });
+  } catch {
+    return Response.redirect(redirectTarget, 302);
+  }
+};

--- a/astro-infoportal/src/pages/api/users/current.ts
+++ b/astro-infoportal/src/pages/api/users/current.ts
@@ -19,6 +19,7 @@ export const GET: APIRoute = async ({ request }) => {
     const body: CurrentUserResponse = {
       selfAccountUuid: null,
       currentAccountUuid: null,
+      language: null,
     };
     return jsonResponse(body);
   }
@@ -40,6 +41,7 @@ export const GET: APIRoute = async ({ request }) => {
       currentAccountUuid: auth.partyUuid,
       showDeletedEntities:
         profile?.profileSettingPreference?.shouldShowDeletedEntities ?? null,
+      language: profile?.profileSettingPreference?.language ?? null,
     };
     return jsonResponse(body);
   } catch {

--- a/astro-infoportal/src/pages/api/users/preferences/language.ts
+++ b/astro-infoportal/src/pages/api/users/preferences/language.ts
@@ -1,0 +1,74 @@
+import { isLocale, LOCALE_TO_PERSISTENT_CONTEXT } from "@constants/languages";
+import type { APIRoute } from "astro";
+import {
+  altinnPlatformFetch,
+  getAuthContext,
+  jsonResponse,
+} from "../../../../api/altinn/client";
+import { getProfileApiBaseUrl } from "../../../../api/altinn/config";
+
+export const prerender = false;
+
+// Persist language: PATCH the profile + set the cross-Altinn altinnPersistentContext
+// cookie (mirrors AM's SettingsController, calling the platform directly).
+export const POST: APIRoute = async ({ request }) => {
+  const auth = getAuthContext(request);
+  if (!auth.isAuthenticated) {
+    return jsonResponse({ error: "User must be authenticated" }, 400);
+  }
+
+  // CSRF: this mutates context via the auth cookie — reject cross-site callers.
+  const fetchSite = request.headers.get("sec-fetch-site");
+  if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "same-site") {
+    return jsonResponse({ error: "Cross-site request rejected" }, 403);
+  }
+
+  let languageCode: unknown;
+  try {
+    languageCode = (await request.json())?.languageCode;
+  } catch {
+    return jsonResponse({ error: "Invalid request body" }, 400);
+  }
+
+  // Derive cookie + PATCH values from the map, never raw input (injection guard).
+  if (!isLocale(languageCode)) {
+    return jsonResponse({ error: "Unsupported language" }, 400);
+  }
+  const locale = languageCode;
+  const persistentContext = LOCALE_TO_PERSISTENT_CONTEXT[locale];
+
+  try {
+    const response = await altinnPlatformFetch(
+      auth,
+      `${getProfileApiBaseUrl(auth.config)}/users/current/profilesettings`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ language: locale }),
+      },
+    );
+
+    if (!response || !response.ok) {
+      return jsonResponse({ error: "Failed to update language" }, 500);
+    }
+
+    // Parent host (e.g. altinn.no) so other Altinn apps read it — not the info host.
+    const cookieDomain = new URL(auth.config.endpoints.hostBaseUrl).hostname;
+    const secure = cookieDomain !== "localhost";
+    const headers = new Headers();
+    headers.append("Content-Type", "application/json");
+    headers.append("Cache-Control", "no-store");
+    headers.append(
+      "Set-Cookie",
+      `altinnPersistentContext=${persistentContext}; Path=/; Domain=${cookieDomain}; SameSite=Lax; HttpOnly${
+        secure ? "; Secure" : ""
+      }`,
+    );
+    return new Response(JSON.stringify({ language: locale }), {
+      status: 200,
+      headers,
+    });
+  } catch {
+    return jsonResponse({ error: "Failed to update language" }, 500);
+  }
+};

--- a/astro-infoportal/wrangler.jsonc
+++ b/astro-infoportal/wrangler.jsonc
@@ -19,7 +19,9 @@
 		"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 		"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
 		"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
-		"OLD_PORTAL": "https://inte.info.altinn.no"
+		"OLD_PORTAL": "https://inte.info.altinn.no",
+		"USE_NEW_ACTOR_LIST": "false",
+		"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "true"
 	},
 	"env": {
 		"prod": {
@@ -29,8 +31,10 @@
 				"ELASTICSEARCH_URL": "https://infoportal-search-prod-adac85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
 				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui,/hjelp,/en/help,/nn/hjelp,/starte-og-drive,/nn/starte-og-drive,/en/start-and-run-business",
-        		"OLD_PORTAL": "https://prod.info.altinn.no"
-      		}
+				"OLD_PORTAL": "https://prod.info.altinn.no",
+				"USE_NEW_ACTOR_LIST": "false",
+				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "true"
+			}
 		},
 		"at22": {
 			"name": "astro-infoportal-at22",
@@ -39,8 +43,10 @@
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
 				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
-        		"OLD_PORTAL": "https://inte.info.altinn.no"
-      		}
+				"OLD_PORTAL": "https://inte.info.altinn.no",
+				"USE_NEW_ACTOR_LIST": "false",
+				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "true"
+			}
 		},
 		"at23": {
 			"name": "astro-infoportal-at23",
@@ -49,7 +55,9 @@
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
 				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui",
-        		"OLD_PORTAL": "https://inte.info.altinn.no"
+				"OLD_PORTAL": "https://inte.info.altinn.no",
+				"USE_NEW_ACTOR_LIST": "false",
+				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "true"
 			}
 		},
 		"tt02": {
@@ -59,7 +67,9 @@
 				"ELASTICSEARCH_URL": "https://infoportal-search-tt02-ec939c.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
 				"PAGES_FROM_OLD_PORTAL": "/inforportalapi/,/ui,/skjemaoversikt,/en/forms-overview/,/nn/skjemaoversikt",
-        		"OLD_PORTAL": "https://prep.info.altinn.no"
+				"OLD_PORTAL": "https://prep.info.altinn.no",
+				"USE_NEW_ACTOR_LIST": "false",
+				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "true"
 			}
 		}
 	}


### PR DESCRIPTION
Migrate the platform API integration in astro-infoportal to align with altinn-access-management's implementation, and add a profile language feature.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Platform API alignment:
- /api/users/current exposes profileSettingPreference.language
- /api/users/authorized-parties: enduser/connections branch is scaffolded but disabled by default
- New /api/users/change-party Worker route replicates AM's ReporteeController (PR #2167): validate via authorizedparties, set AltinnPartyId/AltinnPartyUuid cookies on the env parent host, redirect via an allowlist, with optional Altinn 2 cookie bounce during the migration period

Language preference (cache-safe, client-side):
- Auto-redirect to the user's preferred locale on landing, reading profileSettingPreference.language
- New /api/users/preferences/language route: closed-enum validation, sets altinnPersistentContext + PATCHes the profile

Feature flags (wrangler.jsonc per env, mirroring AM's FeatureFlags):
- USE_NEW_ACTOR_LIST (default "false") — connections actor list
- ROUTE_CHANGE_REPORTEE_VIA_ALTINN2 (default "true") — A2 cookie; flip "false" after the Altinn 2 shutdown

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/389
- https://github.com/Altinn/info.altinn.no/issues/393

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
