### PR TITLE
feat: migrate legacy /inforportalapi/* controllers to astro worker

### DIFF
--- a/astro-infoportal/src/pages/inforportalapi/[lang]/getcategory.ts
+++ b/astro-infoportal/src/pages/inforportalapi/[lang]/getcategory.ts
@@ -1,0 +1,55 @@
+import type { APIRoute } from "astro";
+import { rejectIfQueryString } from "../_lib/legacyGuards";
+import { normalizeLegacyLocale } from "../_lib/legacyLocale";
+import { legacyError, legacyJson } from "../_lib/legacyResponse";
+import {
+  loadSchemaJoinedData,
+  schemaSummary,
+  stripDashPrefix,
+} from "../_lib/schemaJoinedData";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, url }) => {
+  const blocked = rejectIfQueryString(url);
+  if (blocked) return blocked;
+
+  const locale = normalizeLegacyLocale(params.lang);
+  if (!locale) return legacyError("unsupported locale", 400);
+
+  try {
+    const data = await loadSchemaJoinedData(locale);
+
+    const response = data.categories.map((cat, idx) => {
+      const subCats = data.subCategoriesByCategory[idx] ?? [];
+      return {
+        id: cat.id,
+        heading: cat.name ?? "",
+        icon: cat.properties?.icon ?? "",
+        contentLink: { id: cat.id },
+        subCategories: subCats.map((sc) => {
+          const schemaList = (data.schemasBySubCategory.get(sc.id) ?? []).map(
+            (s) => schemaSummary(s, data.providerById),
+          );
+          schemaList.sort((a, b) =>
+            a.title.localeCompare(b.title, locale, { sensitivity: "base" }),
+          );
+          return {
+            id: sc.id,
+            heading: stripDashPrefix(sc.name ?? ""),
+            contentLink: { id: sc.id },
+            schemaList,
+          };
+        }),
+      };
+    });
+
+    return legacyJson(response);
+  } catch (error) {
+    console.error("[inforportalapi/getcategory] fetch failed", {
+      locale,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return legacyError("upstream error", 502);
+  }
+};

--- a/astro-infoportal/src/pages/inforportalapi/[lang]/getprovider.ts
+++ b/astro-infoportal/src/pages/inforportalapi/[lang]/getprovider.ts
@@ -1,0 +1,52 @@
+import type { APIRoute } from "astro";
+import { rejectIfQueryString } from "../_lib/legacyGuards";
+import { normalizeLegacyLocale } from "../_lib/legacyLocale";
+import { legacyError, legacyJson } from "../_lib/legacyResponse";
+import { loadSchemaJoinedData, schemaSummary } from "../_lib/schemaJoinedData";
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ params, url }) => {
+  const blocked = rejectIfQueryString(url);
+  if (blocked) return blocked;
+
+  const locale = normalizeLegacyLocale(params.lang);
+  if (!locale) return legacyError("unsupported locale", 400);
+
+  try {
+    const data = await loadSchemaJoinedData(locale);
+
+    const providers = [...data.providers].sort((a, b) =>
+      (a.name ?? "").localeCompare(b.name ?? "", locale, {
+        sensitivity: "base",
+      }),
+    );
+
+    // `mainbody` is always null — legacy contract field, never populated.
+    const response = providers.map((p) => {
+      const list = (data.schemasByProvider.get(p.id) ?? []).map((s) =>
+        schemaSummary(s, data.providerById),
+      );
+      list.sort((a, b) =>
+        a.title.localeCompare(b.title, locale, { sensitivity: "base" }),
+      );
+      return {
+        id: p.id,
+        heading: p.name ?? "",
+        acronym: p.properties?.providerAcronym ?? "",
+        orgNr: p.properties?.providerOrgNr ?? "",
+        mainbody: null,
+        contentLink: { id: p.id },
+        list,
+      };
+    });
+
+    return legacyJson(response);
+  } catch (error) {
+    console.error("[inforportalapi/getprovider] fetch failed", {
+      locale,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return legacyError("upstream error", 502);
+  }
+};

--- a/astro-infoportal/src/pages/inforportalapi/_lib/legacyGuards.ts
+++ b/astro-infoportal/src/pages/inforportalapi/_lib/legacyGuards.ts
@@ -1,0 +1,26 @@
+// Keeps the edge cache key stable and blocks cache-busting via ?bust=N.
+export function rejectIfQueryString(url: URL): Response | null {
+  if (url.searchParams.size > 0) {
+    return new Response(
+      JSON.stringify({ error: "query parameters not supported" }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  return null;
+}
+
+export type MunicipalityIdKind = "guid" | "legacy" | "invalid";
+
+const GUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const NUMERIC_RE = /^\d+$/;
+
+// Numeric IDs are legacy Optimizely ContentReferences and won't resolve in Umbraco.
+export function classifyMunicipalityId(id: string): MunicipalityIdKind {
+  if (GUID_RE.test(id)) return "guid";
+  if (NUMERIC_RE.test(id)) return "legacy";
+  return "invalid";
+}

--- a/astro-infoportal/src/pages/inforportalapi/_lib/legacyLocale.ts
+++ b/astro-infoportal/src/pages/inforportalapi/_lib/legacyLocale.ts
@@ -1,0 +1,16 @@
+export type LegacyLocale = "nb" | "nn" | "en";
+
+// "no" is the legacy alias for "nb".
+const LEGACY_LOCALE_MAP: Record<string, LegacyLocale> = {
+  no: "nb",
+  nb: "nb",
+  nn: "nn",
+  en: "en",
+};
+
+export function normalizeLegacyLocale(
+  lang: string | undefined,
+): LegacyLocale | null {
+  if (!lang) return null;
+  return LEGACY_LOCALE_MAP[lang.toLowerCase()] ?? null;
+}

--- a/astro-infoportal/src/pages/inforportalapi/_lib/legacyResponse.ts
+++ b/astro-infoportal/src/pages/inforportalapi/_lib/legacyResponse.ts
@@ -1,0 +1,23 @@
+// Short s-maxage until publish-driven invalidation covers these URLs.
+const LEGACY_CACHE_HEADERS = {
+  "Content-Type": "application/json; charset=utf-8",
+  "Cache-Control": "public, max-age=300, s-maxage=60",
+} as const;
+
+export function legacyJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: LEGACY_CACHE_HEADERS,
+  });
+}
+
+export function legacyError(
+  message: string,
+  status = 400,
+  extra?: Record<string, unknown>,
+): Response {
+  return new Response(JSON.stringify({ error: message, ...extra }), {
+    status,
+    headers: LEGACY_CACHE_HEADERS,
+  });
+}

--- a/astro-infoportal/src/pages/inforportalapi/_lib/schemaJoinedData.ts
+++ b/astro-infoportal/src/pages/inforportalapi/_lib/schemaJoinedData.ts
@@ -1,0 +1,201 @@
+import {
+  fetchUmbracoChildren,
+  fetchUmbracoContentList,
+} from "@api/umbraco/client";
+
+export const CATEGORY_ROOT_GUID = "7be52f06-4b7f-43e3-be3e-7871e56c27fc";
+// Delivery API rejects skip + take > 1000; fetchAllSchemas paginates around it.
+const MAX_ITEMS = 1000;
+
+export interface Ref {
+  id: string;
+  name?: string;
+  route?: { path?: string };
+}
+
+export interface CategoryNode extends Ref {
+  contentType: "categoryPage";
+  properties?: {
+    icon?: string;
+    showInNavigation?: boolean;
+  };
+}
+
+export interface SubCategoryNode extends Ref {
+  contentType: "subCategoryPage";
+  properties?: {
+    showInNavigation?: boolean;
+  };
+}
+
+export interface RichTextValue {
+  items?: Array<{ html?: string }>;
+}
+
+export interface SchemaNode extends Ref {
+  contentType: "schemaPage";
+  properties?: {
+    portalSchemaId?: number;
+    schemaCode?: string;
+    mainIntro?: RichTextValue | null;
+    subCategories?: Ref[] | null;
+    providers?: Ref[] | null;
+  };
+}
+
+export interface ProviderNode extends Ref {
+  contentType: "providerPage";
+  properties?: {
+    providerAcronym?: string;
+    providerOrgNr?: string | null;
+    showInNavigation?: boolean;
+  };
+}
+
+export interface SchemaJoinedData {
+  categories: CategoryNode[];
+  subCategoriesByCategory: SubCategoryNode[][];
+  schemas: SchemaNode[];
+  providers: ProviderNode[];
+  providerById: Map<string, ProviderNode>;
+  schemasBySubCategory: Map<string, SchemaNode[]>;
+  schemasByProvider: Map<string, SchemaNode[]>;
+}
+
+// Per-provider fan-out sidesteps the Delivery API's skip+take cap. A single
+// provider returning 500 is logged + skipped so one bad record doesn't fail
+// the whole response.
+export async function fetchAllSchemas(
+  providers: ProviderNode[],
+  locale: string,
+): Promise<SchemaNode[]> {
+  const perProvider = await Promise.all(
+    providers.map(async (p) => {
+      if (!p.route?.path) return [] as SchemaNode[];
+      try {
+        return (await fetchUmbracoChildren(
+          p.route.path,
+          MAX_ITEMS,
+          locale,
+        )) as SchemaNode[];
+      } catch (error) {
+        console.warn("[inforportalapi] provider children fetch failed", {
+          providerId: p.id,
+          path: p.route.path,
+          locale,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        return [] as SchemaNode[];
+      }
+    }),
+  );
+  return perProvider.flat().filter((s) => s.contentType === "schemaPage");
+}
+
+export async function loadSchemaJoinedData(
+  locale: string,
+): Promise<SchemaJoinedData> {
+  const [categories, providers] = await Promise.all([
+    fetchUmbracoChildren(CATEGORY_ROOT_GUID, MAX_ITEMS, locale) as Promise<
+      CategoryNode[]
+    >,
+    fetchUmbracoContentList(
+      ["contentType:providerPage"],
+      MAX_ITEMS,
+      locale,
+    ) as Promise<ProviderNode[]>,
+  ]);
+  const schemas = await fetchAllSchemas(providers, locale);
+
+  const subCategoriesByCategory = (await Promise.all(
+    categories.map((cat) =>
+      cat.route?.path
+        ? fetchUmbracoChildren(cat.route.path, MAX_ITEMS, locale)
+        : Promise.resolve([]),
+    ),
+  )) as SubCategoryNode[][];
+
+  const providerById = new Map<string, ProviderNode>();
+  for (const p of providers) providerById.set(p.id, p);
+
+  const schemasBySubCategory = new Map<string, SchemaNode[]>();
+  const schemasByProvider = new Map<string, SchemaNode[]>();
+  for (const s of schemas) {
+    for (const ref of s.properties?.subCategories ?? []) {
+      const arr = schemasBySubCategory.get(ref.id) ?? [];
+      arr.push(s);
+      schemasBySubCategory.set(ref.id, arr);
+    }
+    for (const ref of s.properties?.providers ?? []) {
+      const arr = schemasByProvider.get(ref.id) ?? [];
+      arr.push(s);
+      schemasByProvider.set(ref.id, arr);
+    }
+  }
+
+  return {
+    categories,
+    subCategoriesByCategory,
+    schemas,
+    providers,
+    providerById,
+    schemasBySubCategory,
+    schemasByProvider,
+  };
+}
+
+// SubCategory names ship as "{idx} - {name}"; the prefix isn't part of the contract.
+export function stripDashPrefix(name: string): string {
+  const idx = name.indexOf("-");
+  return idx >= 0 ? name.slice(idx + 2) : name;
+}
+
+export interface ProviderSummary {
+  name: string;
+  acronym: string;
+  orgNr: string;
+  url: string;
+  pageLink: { id: string };
+}
+
+export function providersForSchema(
+  schema: SchemaNode,
+  providerById: Map<string, ProviderNode>,
+): ProviderSummary[] {
+  const refs = schema.properties?.providers ?? [];
+  return refs
+    .map((ref) => providerById.get(ref.id))
+    .filter((p): p is ProviderNode => !!p)
+    .map((p) => ({
+      name: p.name ?? "",
+      acronym: p.properties?.providerAcronym ?? "",
+      orgNr: p.properties?.providerOrgNr ?? "",
+      url: p.route?.path ?? "",
+      pageLink: { id: p.id },
+    }));
+}
+
+export interface SchemaSummary {
+  id: string;
+  title: string;
+  url: string;
+  providers: ProviderSummary[];
+  language: string;
+  pageLink: { id: string };
+}
+
+export function schemaSummary(
+  schema: SchemaNode,
+  providerById: Map<string, ProviderNode>,
+): SchemaSummary {
+  const code = schema.properties?.schemaCode;
+  const baseTitle = schema.name ?? "";
+  return {
+    id: schema.id,
+    title: code ? `${baseTitle} (${code})` : baseTitle,
+    url: schema.route?.path ?? "",
+    providers: providersForSchema(schema, providerById),
+    language: "",
+    pageLink: { id: schema.id },
+  };
+}

--- a/astro-infoportal/src/pages/inforportalapi/getcounty/[id]/[lang].ts
+++ b/astro-infoportal/src/pages/inforportalapi/getcounty/[id]/[lang].ts
@@ -1,0 +1,76 @@
+import { fetchUmbracoChildren } from "@api/umbraco/client";
+import type { APIRoute } from "astro";
+import {
+  classifyMunicipalityId,
+  rejectIfQueryString,
+} from "../../_lib/legacyGuards";
+import { normalizeLegacyLocale } from "../../_lib/legacyLocale";
+import { legacyError, legacyJson } from "../../_lib/legacyResponse";
+
+export const prerender = false;
+
+interface SchemaTreeNode {
+  contentType: string;
+  name?: string;
+  route?: { path?: string };
+  properties?: {
+    externalUrl?: string | null;
+  };
+}
+
+interface MunicipalityItem {
+  name: string;
+  url: string;
+  parent: string;
+}
+
+export const GET: APIRoute = async ({ params, url }) => {
+  const blocked = rejectIfQueryString(url);
+  if (blocked) return blocked;
+
+  const locale = normalizeLegacyLocale(params.lang);
+  if (!locale) return legacyError("unsupported locale", 400);
+
+  const id = params.id;
+  if (!id) return legacyError("missing id", 400);
+
+  const kind = classifyMunicipalityId(id);
+  if (kind === "invalid") return legacyError("invalid id", 400);
+  if (kind === "legacy") {
+    console.warn("[inforportalapi/getcounty] legacy numeric id, unsupported", {
+      id,
+      locale,
+    });
+    return legacyError("legacy_id_unsupported", 422, { id, locale });
+  }
+
+  try {
+    const children = (await fetchUmbracoChildren(id, 500, locale)) as
+      | SchemaTreeNode[]
+      | undefined;
+    const counties = (children ?? []).filter(
+      (c) => c.contentType === "schemaCountyPage",
+    );
+
+    const items: MunicipalityItem[] = counties.map((c) => ({
+      name: c.name ?? "",
+      url: c.properties?.externalUrl || c.route?.path || "#",
+      parent: "",
+    }));
+    items.sort((a, b) =>
+      a.name.localeCompare(b.name, locale, { sensitivity: "base" }),
+    );
+
+    if (items.length === 0) {
+      console.warn("[inforportalapi/getcounty] no items", { id, locale });
+    }
+    return legacyJson({ items });
+  } catch (error) {
+    console.error("[inforportalapi/getcounty] fetch failed", {
+      id,
+      locale,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return legacyError("upstream error", 502);
+  }
+};

--- a/astro-infoportal/src/pages/inforportalapi/getmunicipality/[id]/[lang].ts
+++ b/astro-infoportal/src/pages/inforportalapi/getmunicipality/[id]/[lang].ts
@@ -1,0 +1,103 @@
+import { fetchUmbracoChildren } from "@api/umbraco/client";
+import type { APIRoute } from "astro";
+import {
+  classifyMunicipalityId,
+  rejectIfQueryString,
+} from "../../_lib/legacyGuards";
+import { normalizeLegacyLocale } from "../../_lib/legacyLocale";
+import { legacyError, legacyJson } from "../../_lib/legacyResponse";
+
+export const prerender = false;
+
+interface SchemaTreeNode {
+  contentType: string;
+  name?: string;
+  route?: { path?: string };
+  properties?: {
+    externalUrl?: string | null;
+  };
+}
+
+interface MunicipalityItem {
+  name: string;
+  url: string;
+  parent: string;
+}
+
+function toItem(node: SchemaTreeNode, parent: string): MunicipalityItem {
+  return {
+    name: node.name ?? "",
+    url: node.properties?.externalUrl || node.route?.path || "#",
+    parent,
+  };
+}
+
+export const GET: APIRoute = async ({ params, url }) => {
+  const blocked = rejectIfQueryString(url);
+  if (blocked) return blocked;
+
+  const locale = normalizeLegacyLocale(params.lang);
+  if (!locale) return legacyError("unsupported locale", 400);
+
+  const id = params.id;
+  if (!id) return legacyError("missing id", 400);
+
+  const kind = classifyMunicipalityId(id);
+  if (kind === "invalid") return legacyError("invalid id", 400);
+  if (kind === "legacy") {
+    console.warn(
+      "[inforportalapi/getmunicipality] legacy numeric id, unsupported",
+      { id, locale },
+    );
+    return legacyError("legacy_id_unsupported", 422, { id, locale });
+  }
+
+  try {
+    const children = ((await fetchUmbracoChildren(id, 500, locale)) ??
+      []) as SchemaTreeNode[];
+    const counties = children.filter(
+      (c) => c.contentType === "schemaCountyPage" && c.route?.path,
+    );
+    const directMunicipalities = children.filter(
+      (c) => c.contentType === "schemaMunicipalityPage",
+    );
+
+    let items: MunicipalityItem[];
+
+    if (counties.length === 0 && directMunicipalities.length > 0) {
+      items = directMunicipalities.map((m) => toItem(m, ""));
+    } else if (counties.length > 0) {
+      const perCounty = await Promise.all(
+        counties.map(async (county) => {
+          const munis = (await fetchUmbracoChildren(
+            county.route?.path ?? "",
+            500,
+            locale,
+          )) as SchemaTreeNode[] | undefined;
+          return (munis ?? [])
+            .filter((m) => m.contentType === "schemaMunicipalityPage")
+            .map((m) => toItem(m, county.name ?? ""));
+        }),
+      );
+      items = perCounty.flat();
+    } else {
+      items = [];
+    }
+
+    items.sort((a, b) =>
+      a.name.localeCompare(b.name, locale, { sensitivity: "base" }),
+    );
+
+    if (items.length === 0) {
+      console.warn("[inforportalapi/getmunicipality] no items", { id, locale });
+    }
+    return legacyJson({ items });
+  } catch (error) {
+    console.error("[inforportalapi/getmunicipality] fetch failed", {
+      id,
+      locale,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return legacyError("upstream error", 502);
+  }
+};

--- a/astro-infoportal/src/pages/inforportalapi/getsubsidy/[lang].ts
+++ b/astro-infoportal/src/pages/inforportalapi/getsubsidy/[lang].ts
@@ -1,0 +1,82 @@
+import { fetchUmbracoContentList } from "@api/umbraco/client";
+import type { APIRoute } from "astro";
+import { rejectIfQueryString } from "../_lib/legacyGuards";
+import { normalizeLegacyLocale } from "../_lib/legacyLocale";
+import { legacyError, legacyJson } from "../_lib/legacyResponse";
+
+export const prerender = false;
+
+const MAX_ITEMS = 1000;
+
+type FilterItem = {
+  id: string;
+  name: string;
+};
+
+type SubsidyItem = {
+  id: string;
+  name: string;
+  route?: { path?: string };
+  properties?: {
+    mainIntro?: string;
+    purposes?: FilterItem[] | null;
+    industries?: FilterItem[] | null;
+  };
+};
+
+function filterIds(items?: FilterItem[] | null): string[] {
+  return Array.isArray(items) ? items.map((item) => item.id) : [];
+}
+
+export const GET: APIRoute = async ({ params, url }) => {
+  const blocked = rejectIfQueryString(url);
+  if (blocked) return blocked;
+
+  const locale = normalizeLegacyLocale(params.lang);
+  if (!locale) return legacyError("unsupported locale", 400);
+
+  try {
+    const [purposeItems, industryItems, subsidyItems] = await Promise.all([
+      fetchUmbracoContentList(["contentType:purposePage"], MAX_ITEMS, locale),
+      fetchUmbracoContentList(["contentType:industryPage"], MAX_ITEMS, locale),
+      fetchUmbracoContentList(["contentType:subsidyPage"], MAX_ITEMS, locale),
+    ]);
+
+    const subsidiesList = (subsidyItems as SubsidyItem[]).map((s) => ({
+      subsidyName: s.name,
+      subsidyIntro: s.properties?.mainIntro ?? "",
+      url: s.route?.path ?? "#",
+      purposes: filterIds(s.properties?.purposes),
+      industries: filterIds(s.properties?.industries),
+    }));
+
+    // Hide filter options that no subsidy references.
+    const referencedPurposes = new Set(
+      subsidiesList.flatMap((s) => s.purposes),
+    );
+    const referencedIndustries = new Set(
+      subsidiesList.flatMap((s) => s.industries),
+    );
+
+    const purposeList = (purposeItems as FilterItem[])
+      .filter((p) => referencedPurposes.has(p.id))
+      .map((p) => ({ filterId: p.id, filterName: p.name }));
+
+    const industryList = (industryItems as FilterItem[])
+      .filter((i) => referencedIndustries.has(i.id))
+      .map((i) => ({ filterId: i.id, filterName: i.name }));
+
+    return legacyJson({
+      purposeList,
+      industryList,
+      subsidiesList,
+      maxItems: 10,
+    });
+  } catch (error) {
+    console.error("[inforportalapi/getsubsidy] fetch failed", {
+      locale,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return legacyError("upstream error", 502);
+  }
+};

--- a/astro-infoportal/src/pages/inforportalapi/schemalist/[lang].ts
+++ b/astro-infoportal/src/pages/inforportalapi/schemalist/[lang].ts
@@ -1,0 +1,117 @@
+import {
+  fetchUmbracoChildren,
+  fetchUmbracoContentList,
+} from "@api/umbraco/client";
+import type { APIRoute } from "astro";
+import { rejectIfQueryString } from "../_lib/legacyGuards";
+import { normalizeLegacyLocale } from "../_lib/legacyLocale";
+import { legacyError, legacyJson } from "../_lib/legacyResponse";
+import {
+  CATEGORY_ROOT_GUID,
+  fetchAllSchemas,
+  type ProviderNode,
+  type RichTextValue,
+  type SchemaNode,
+  stripDashPrefix,
+} from "../_lib/schemaJoinedData";
+
+export const prerender = false;
+
+const CATEGORIES_TAKE = 100;
+const PROVIDERS_TAKE = 200;
+
+type Ref = {
+  id: string;
+  name?: string;
+  route?: { path?: string };
+};
+
+type CategoryItem = Ref & {
+  contentType: "categoryPage";
+};
+
+type SubCategoryItem = Ref & {
+  contentType: "subCategoryPage";
+};
+
+function extractRichTextHtml(
+  mainIntro: RichTextValue | null | undefined,
+): string {
+  if (!mainIntro || !mainIntro.items) return "";
+  return mainIntro.items
+    .map((item) => item.html ?? "")
+    .filter(Boolean)
+    .join("");
+}
+
+export const GET: APIRoute = async ({ params, url }) => {
+  const blocked = rejectIfQueryString(url);
+  if (blocked) return blocked;
+
+  const locale = normalizeLegacyLocale(params.lang);
+  if (!locale) return legacyError("unsupported locale", 400);
+
+  try {
+    const [categories, providers] = await Promise.all([
+      fetchUmbracoChildren(CATEGORY_ROOT_GUID, CATEGORIES_TAKE, locale),
+      fetchUmbracoContentList(
+        ["contentType:providerPage"],
+        PROVIDERS_TAKE,
+        locale,
+      ) as Promise<ProviderNode[]>,
+    ]);
+    const schemas: SchemaNode[] = await fetchAllSchemas(providers, locale);
+
+    const subCategoriesByCategory = await Promise.all(
+      (categories as CategoryItem[]).map((cat) =>
+        cat.route?.path
+          ? fetchUmbracoChildren(cat.route.path, CATEGORIES_TAKE, locale)
+          : Promise.resolve([]),
+      ),
+    );
+
+    const categoryPackages = (categories as CategoryItem[]).map((cat, idx) => {
+      const subCats = (subCategoriesByCategory[idx] as SubCategoryItem[]) ?? [];
+      return {
+        id: cat.id,
+        texts: [{ name: cat.name ?? "", language: locale }],
+        subCategories: subCats.map((sc) => ({
+          id: sc.id,
+          texts: [{ name: stripDashPrefix(sc.name ?? ""), language: locale }],
+        })),
+      };
+    });
+
+    // Schemas without a portalSchemaId aren't real services.
+    const servicePackages = schemas
+      .filter((s) => (s.properties?.portalSchemaId ?? 0) > 0)
+      .map((s) => {
+        const props = s.properties ?? {};
+        const subCategoryIds = Array.isArray(props.subCategories)
+          ? props.subCategories.map((ref) => ref.id)
+          : [];
+        return {
+          serviceCode: props.portalSchemaId ?? 0,
+          texts: [
+            {
+              language: locale,
+              name: s.name ?? "",
+              intro: extractRichTextHtml(props.mainIntro),
+            },
+          ],
+          categories: subCategoryIds,
+        };
+      });
+
+    return legacyJson({
+      categories: categoryPackages,
+      services: servicePackages,
+    });
+  } catch (error) {
+    console.error("[inforportalapi/schemalist] fetch failed", {
+      locale,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return legacyError("upstream error", 502);
+  }
+};


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Recreate 5 Optimizely controllers (SubsidyList, SchemaSearch, SchemaList, SchemaCounty) as 6 Astro routes preserving URL paths for the /skjemaoversikt/* and /tilskuddsordninger/*.

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/338

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
