### PR TITLE
Increased cache age

### DIFF
--- a/astro-infoportal/src/Constants/cache.ts
+++ b/astro-infoportal/src/Constants/cache.ts
@@ -1,5 +1,5 @@
 const SHORT_CMS_CACHE =
-  "public, max-age=0, s-maxage=300, stale-while-revalidate=86400";
+  "public, max-age=1440, s-maxage=86400, stale-while-revalidate=86400";
 
 function isLocalHost(hostname: string): boolean {
   return (


### PR DESCRIPTION
The caching header with s-maxage set to 300 was use by Cloudflare cache, which caused downtime for deployments. Changed this to 24 hours.

It seems that Cloudflare's behaviour has changed, as s-maxage was not respected earlier.
