### PR TITLE
fix: Update Umbraco CMS URL to new domain

### DIFF
--- a/syncroot/at23/kustomization.yaml
+++ b/syncroot/at23/kustomization.yaml
@@ -25,7 +25,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://infoportal.at23.dis-core.altinn.cloud
+          value: https://cms.at23.altinn.info
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/syncroot/prod/kustomization.yaml
+++ b/syncroot/prod/kustomization.yaml
@@ -27,7 +27,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://infoportal.prod.dis-core.altinn.cloud
+          value: https://cms.prod.altinn.info
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:

--- a/syncroot/tt02/kustomization.yaml
+++ b/syncroot/tt02/kustomization.yaml
@@ -27,7 +27,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: Umbraco__CMS__WebRouting__UmbracoApplicationUrl
-          value: https://infoportal.tt02.dis-core.altinn.cloud
+          value: https://cms.tt02.altinn.info
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:


### PR DESCRIPTION
Replace infoportal.*.dis-core.altinn.cloud with
cms.*.altinn.info across all environments (at23, prod, tt02).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
