### PR TITLE
fix: Override request host with configured BackOfficeHost

### DIFF
--- a/umbraco-infoportal/Program.cs
+++ b/umbraco-infoportal/Program.cs
@@ -116,6 +116,25 @@ await app.BootUmbracoAsync();
 
 app.UseForwardedHeaders();
 
+// The cluster gateway does not forward X-Forwarded-Host, so Request.Host is always
+// the internal hostname (infoportal.*.dis-core.altinn.cloud). Umbraco builds OAuth
+// redirects and media URLs from Request.Host, which breaks login and thumbnails in
+// environments where the internal hostname is IP-filtered (prod) or differs from the
+// public hostname. Override Host to BackOfficeHost so all URL generation is correct.
+string? configuredBackOfficeHost = app.Configuration["Umbraco:CMS:Security:BackOfficeHost"];
+if (!string.IsNullOrEmpty(configuredBackOfficeHost) &&
+    Uri.TryCreate(configuredBackOfficeHost, UriKind.Absolute, out Uri? backOfficeUri))
+{
+    app.Use(async (context, next) =>
+    {
+        if (!context.Request.Host.Host.Equals(backOfficeUri.Host, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Request.Host = new HostString(backOfficeUri.Host);
+        }
+        await next(context);
+    });
+}
+
 app.UseUmbraco()
     .WithMiddleware(u =>
     {


### PR DESCRIPTION
Ensures OAuth redirects and media URLs are generated using the public hostname instead of the internal
cluster gateway hostname, fixing login and thumbnail issues in IP-filtered or multi-host environments.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
