### PR TITLE
feat: Add Kinorgeportal Elasticsearch TT02 infrastructure

### DIFF
--- a/.github/workflows/kinorgeportal-elasticsearch-tt02.yml
+++ b/.github/workflows/kinorgeportal-elasticsearch-tt02.yml
@@ -1,0 +1,90 @@
+name: kinorgeportal-elasticsearch-tt02 deploy
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/kinorgeportal-elasticsearch-tt02.yml
+      - infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/**
+      - infrastructure/modules/kinorgeportal-elasticsearch/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/kinorgeportal-elasticsearch-tt02.yml
+      - infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/**
+      - infrastructure/modules/kinorgeportal-elasticsearch/**
+  workflow_dispatch:
+    inputs:
+      log_level:
+        required: true
+        description: Terraform Log Level
+        default: ERROR
+        type: choice
+        options:
+          - TRACE
+          - DEBUG
+          - INFO
+          - WARN
+          - ERROR
+
+env:
+  TF_STATE_NAME: kinorgeportal-elasticsearch-tt02.tfstate
+  WORKING_DIRECTORY: ./infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02
+  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID_ALTINN_PORTALER_TEST }}
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID_ALTINN_PORTALER_TEST }}
+  TF_VAR_elastic_cloud_api_key: ${{ secrets.ELASTIC_CLOUD_API_KEY }}
+  TF_VAR_elasticsearch_api_key: ${{ secrets.ELASTICSEARCH_API_KEY_KINORGEPORTAL_TT02 }}
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  plan:
+    name: Plan
+    environment: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Plan
+        uses: Altinn/altinn-platform/actions/terraform/plan@e3d55565a6da4ea3d64cbcc4489fe363226c8567 # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: test
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    environment: test
+    if: github.ref == 'refs/heads/main'
+    needs: plan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Terraform Apply
+        uses: Altinn/altinn-platform/actions/terraform/apply@e3d55565a6da4ea3d64cbcc4489fe363226c8567 # main
+        with:
+          working_directory: ${{ env.WORKING_DIRECTORY }}
+          oidc_type: environment
+          oidc_value: test
+          arm_client_id: ${{ env.ARM_CLIENT_ID }}
+          arm_subscription_id: ${{ env.ARM_SUBSCRIPTION_ID }}
+          tf_state_name: ${{ env.TF_STATE_NAME }}
+          tf_log_level: ${{ github.event.inputs.log_level || 'ERROR' }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/imports.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/imports.tf
@@ -1,0 +1,14 @@
+import {
+  to = azurerm_resource_group.main
+  id = "/subscriptions/fdc58270-273a-4afc-b996-83e97fe5173a/resourceGroups/kinorgeportal-elasticsearch-tt02"
+}
+
+import {
+  to = module.elasticsearch.azurerm_elastic_cloud_elasticsearch.search
+  id = "/subscriptions/fdc58270-273a-4afc-b996-83e97fe5173a/resourceGroups/kinorgeportal-elasticsearch-tt02/providers/Microsoft.Elastic/monitors/kinorgeportal-elasticsearch-tt02"
+}
+
+import {
+  to = module.elasticsearch.ec_elasticsearch_project.search
+  id = "a61b244f20b14002a0bf4f35f0d643bc"
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/main.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/main.tf
@@ -1,0 +1,34 @@
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "main" {
+  name     = "kinorgeportal-elasticsearch-tt02"
+  location = "Germany West Central"
+  tags     = local.tags
+}
+
+locals {
+  tags = {
+    finops_environment = "tt02"
+    finops_product     = "kinorgeportal"
+    repository         = "https://github.com/Altinn/info.altinn.no"
+    env                = "tt02"
+    product            = "kinorgeportal"
+  }
+}
+
+module "elasticsearch" {
+  source = "../../modules/kinorgeportal-elasticsearch"
+
+  environment                 = "tt02"
+  location                    = azurerm_resource_group.main.location
+  resource_group_name         = azurerm_resource_group.main.name
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  terraform_object_id         = data.azurerm_client_config.current.object_id
+  eso_object_id               = var.eso_object_id
+  elastic_cloud_api_key       = var.elastic_cloud_api_key
+  elastic_cloud_email_address = var.elastic_cloud_email_address
+  sku_name                    = var.sku_name
+  elasticsearch_api_key       = var.elasticsearch_api_key
+  allowed_cidr_blocks         = var.allowed_cidr_blocks
+  tags                        = local.tags
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/outputs.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/outputs.tf
@@ -1,0 +1,12 @@
+output "key_vault_name" {
+  value = module.elasticsearch.key_vault_name
+}
+
+output "key_vault_uri" {
+  value = module.elasticsearch.key_vault_uri
+}
+
+output "elasticsearch_endpoint" {
+  value     = module.elasticsearch.elasticsearch_endpoint
+  sensitive = true
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/providers.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/providers.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.14.0"
+
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = "~> 0.12.5"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.71.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.8.1"
+    }
+  }
+
+  backend "azurerm" {
+    use_azuread_auth     = true
+    storage_account_name = ""
+    container_name       = ""
+    key                  = ""
+  }
+}
+
+provider "ec" {
+  apikey = var.elastic_cloud_api_key
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/terraform.tfvars
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/terraform.tfvars
@@ -1,0 +1,4 @@
+elastic_cloud_email_address = "aas-bfred-prod@ai-dev.no"
+sku_name                    = "ess-consumption-2024_Monthly@TIDn7ja87drquhy"
+elasticsearch_endpoint      = "https://kinorgeportal-elasticsearch-tt02-a61b24.es.germanywestcentral.azure.elastic.cloud"
+eso_object_id               = "4e20a3a6-2c50-4a23-a02b-23fc8597d3a7"

--- a/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/variables.tf
+++ b/infrastructure/altinn-portaler-test/kinorgeportal-elasticsearch-tt02/variables.tf
@@ -1,0 +1,38 @@
+variable "elastic_cloud_api_key" {
+  description = "Elastic Cloud API key for authenticating the elastic/ec provider"
+  type        = string
+  sensitive   = true
+}
+
+variable "elastic_cloud_email_address" {
+  description = "Email address associated with the Elastic Cloud account"
+  type        = string
+}
+
+variable "sku_name" {
+  description = "SKU name for the Elastic Cloud Elasticsearch resource"
+  type        = string
+}
+
+variable "elasticsearch_endpoint" {
+  description = "Elasticsearch endpoint URL for the serverless project, used to configure the elasticstack provider"
+  type        = string
+}
+
+variable "elasticsearch_api_key" {
+  description = "Elasticsearch API key for the elasticstack provider (base64 encoded id:api_key), created once in the Elastic Cloud console"
+  type        = string
+  sensitive   = true
+}
+
+variable "eso_object_id" {
+  description = "Object ID of the ESO workload identity / managed identity that reads Key Vault secrets. Leave empty to skip the role assignment."
+  type        = string
+  default     = ""
+}
+
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the Elasticsearch project. Empty list allows all traffic."
+  type        = list(string)
+  default     = []
+}

--- a/infrastructure/modules/kinorgeportal-elasticsearch/main.tf
+++ b/infrastructure/modules/kinorgeportal-elasticsearch/main.tf
@@ -1,0 +1,76 @@
+resource "random_string" "keyvault_suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+resource "azurerm_key_vault" "elasticsearch" {
+  name                       = "kinorgeportal-es-${var.environment}-${random_string.keyvault_suffix.result}"
+  location                   = var.location
+  resource_group_name        = var.resource_group_name
+  tenant_id                  = var.tenant_id
+  sku_name                   = "standard"
+  rbac_authorization_enabled = true
+  tags                       = var.tags
+}
+
+resource "azurerm_role_assignment" "terraform_keyvault_officer" {
+  scope                = azurerm_key_vault.elasticsearch.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = var.terraform_object_id
+}
+
+resource "azurerm_role_assignment" "eso_keyvault_reader" {
+  count                = var.eso_object_id != "" ? 1 : 0
+  scope                = azurerm_key_vault.elasticsearch.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = var.eso_object_id
+}
+
+resource "azurerm_elastic_cloud_elasticsearch" "search" {
+  name                        = "kinorgeportal-elasticsearch-${var.environment}"
+  resource_group_name         = var.resource_group_name
+  location                    = var.location
+  sku_name                    = var.sku_name
+  elastic_cloud_email_address = var.elastic_cloud_email_address
+  tags                        = var.tags
+
+  logs {
+    send_activity_logs     = false
+    send_azuread_logs      = false
+    send_subscription_logs = false
+  }
+}
+
+resource "ec_serverless_traffic_filter" "allowed_sources" {
+  count  = length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+  name   = "kinorgeportal-${var.environment}-allowed-sources"
+  region = "azure-germanywestcentral"
+  type   = "ip"
+
+  rules = [for cidr in var.allowed_cidr_blocks : { source = cidr }]
+}
+
+resource "ec_elasticsearch_project" "search" {
+  name               = "kinorgeportal-elasticsearch-${var.environment}"
+  region_id          = "azure-germanywestcentral"
+  traffic_filter_ids = length(var.allowed_cidr_blocks) > 0 ? [ec_serverless_traffic_filter.allowed_sources[0].id] : []
+}
+
+resource "azurerm_key_vault_secret" "es_endpoint" {
+  name         = "elasticsearch-endpoint"
+  value        = ec_elasticsearch_project.search.endpoints.elasticsearch
+  key_vault_id = azurerm_key_vault.elasticsearch.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.terraform_keyvault_officer]
+}
+
+resource "azurerm_key_vault_secret" "es_api_key" {
+  name         = "elasticsearch-api-key"
+  value        = var.elasticsearch_api_key
+  key_vault_id = azurerm_key_vault.elasticsearch.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.terraform_keyvault_officer]
+}

--- a/infrastructure/modules/kinorgeportal-elasticsearch/outputs.tf
+++ b/infrastructure/modules/kinorgeportal-elasticsearch/outputs.tf
@@ -1,0 +1,12 @@
+output "key_vault_name" {
+  value = azurerm_key_vault.elasticsearch.name
+}
+
+output "key_vault_uri" {
+  value = azurerm_key_vault.elasticsearch.vault_uri
+}
+
+output "elasticsearch_endpoint" {
+  value     = ec_elasticsearch_project.search.endpoints.elasticsearch
+  sensitive = true
+}

--- a/infrastructure/modules/kinorgeportal-elasticsearch/providers.tf
+++ b/infrastructure/modules/kinorgeportal-elasticsearch/providers.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    ec = {
+      source = "elastic/ec"
+    }
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}

--- a/infrastructure/modules/kinorgeportal-elasticsearch/variables.tf
+++ b/infrastructure/modules/kinorgeportal-elasticsearch/variables.tf
@@ -1,0 +1,64 @@
+variable "environment" {
+  description = "Environment name (e.g. tt02, prod)"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region for the Key Vault"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Name of the Azure resource group"
+  type        = string
+}
+
+variable "tenant_id" {
+  description = "Azure tenant ID"
+  type        = string
+}
+
+variable "terraform_object_id" {
+  description = "Object ID of the Terraform identity, used to grant Key Vault Secrets Officer"
+  type        = string
+}
+
+variable "eso_object_id" {
+  description = "Object ID of the ESO workload identity / managed identity that reads Key Vault secrets. Leave empty to skip the role assignment (e.g. before ESO is deployed)."
+  type        = string
+  default     = ""
+}
+
+variable "elastic_cloud_email_address" {
+  description = "Email address associated with the Elastic Cloud account"
+  type        = string
+}
+
+variable "sku_name" {
+  description = "SKU name for the Elastic Cloud Elasticsearch resource"
+  type        = string
+}
+
+variable "elasticsearch_api_key" {
+  description = "Encoded Elasticsearch API key (base64 id:api_key) for application access, created once in the Elastic Cloud console"
+  type        = string
+  sensitive   = true
+}
+
+variable "elastic_cloud_api_key" {
+  description = "Elastic Cloud API key for authenticating the elastic/ec provider"
+  type        = string
+  sensitive   = true
+}
+
+variable "allowed_cidr_blocks" {
+  description = "List of CIDR blocks allowed to access the Elasticsearch project. Empty list allows all traffic."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags to apply to all taggable resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Adds Terraform configuration for Kinorgeportal Elasticsearch in the TT02 test environment, including Azure Key Vault for secrets storage, Elastic Cloud Elasticsearch deployment, and GitHub Actions CI/CD workflow for automated plan and apply operations.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
