### PR TITLE
fix: remove empty badge

### DIFF
--- a/astro-infoportal/src/Components/Layout/Header/builders/menuBuilder.ts
+++ b/astro-infoportal/src/Components/Layout/Header/builders/menuBuilder.ts
@@ -54,7 +54,6 @@ export const buildMenuItems = (pages: MenuPages, isLoggedIn: boolean, currentPat
       href: pages.inboxPage.url,
       icon: { svgElement: InboxFillIcon, theme: "surface" },
       size: "lg" as const,
-      badge: { variant: 'base', color: 'neutral' },
       selected: isCurrentPage(currentPath, pages.inboxPage.url),
     });
   }
@@ -67,7 +66,6 @@ export const buildMenuItems = (pages: MenuPages, isLoggedIn: boolean, currentPat
       href: pages.accessManagementPage.url,
       icon: { svgElement: PadlockLockedFillIcon, theme: "surface" },
       size: "lg" as const,
-      badge: { variant: 'base', color: 'neutral' },
       selected: isCurrentPage(currentPath, pages.accessManagementPage.url),
     });
   }


### PR DESCRIPTION
Issue: https://github.com/Altinn/info.altinn.no/issues/258#issuecomment-4600131918

Removed the empty badge object from both the Inbox and Access Management menu items
