### PR TITLE
fix: connections actor list mapping + update @altinn/altinn-components

### DIFF
--- a/astro-infoportal/package-lock.json
+++ b/astro-infoportal/package-lock.json
@@ -8,11 +8,11 @@
       "name": "astro-infoportal",
       "version": "0.0.1",
       "dependencies": {
-        "@altinn/altinn-components": "^0.63.8",
+        "@altinn/altinn-components": "^0.66.0",
         "@astrojs/cloudflare": "^13.5.5",
         "@astrojs/react": "^5.0.5",
-        "@digdir/designsystemet-css": "^1.14.0",
-        "@digdir/designsystemet-react": "^1.14.0",
+        "@digdir/designsystemet-css": "^1.15.0",
+        "@digdir/designsystemet-react": "^1.15.0",
         "@digdir/designsystemet-theme": "^1.11.0",
         "@navikt/aksel-icons": "^8.11.0",
         "astro": "^6.3.8",
@@ -50,9 +50,9 @@
       "license": "MIT"
     },
     "node_modules/@altinn/altinn-components": {
-      "version": "0.63.8",
-      "resolved": "https://registry.npmjs.org/@altinn/altinn-components/-/altinn-components-0.63.8.tgz",
-      "integrity": "sha512-4o3qjjIusqQQ4kWzAvkyZTnLCwBSzYneaJ6myOa0wANRcHCuESSme6lapoHPjuF4TaF2OvVxePtOHVlWmhXfig==",
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@altinn/altinn-components/-/altinn-components-0.66.0.tgz",
+      "integrity": "sha512-sC7z4mZgMS6+NF/G2WBB8mq/Z4XcrjupYuCfozcwrC48Z4hWGq4ObjY71WrtemPW2JFLceP1JuQDdx+5vgkU0A==",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "^1.14.0",
@@ -2057,9 +2057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2077,9 +2074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2097,9 +2091,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2117,9 +2108,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3803,25 +3791,25 @@
       }
     },
     "node_modules/@digdir/designsystemet-css": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-css/-/designsystemet-css-1.14.0.tgz",
-      "integrity": "sha512-qAIpcrFgO80p5TrVWcRUC8xO1ZAEp1j39kQ+WLyBuM/BBsgLXBZVIUaju3ZI1rsQFNyY/QZ9CKQslnoOVAeCkQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-css/-/designsystemet-css-1.15.0.tgz",
+      "integrity": "sha512-U2BisgpZ66yfB3/Wasj8lu4VjZjrEXR05IhvCMpkiIgewUcyiBsopSi0cP6LcALtx8Z+8bR8zW9dqjtTh9Ca9w==",
       "license": "MIT",
       "dependencies": {
-        "@digdir/designsystemet-types": "1.14.0"
+        "@digdir/designsystemet-types": "1.15.0"
       }
     },
     "node_modules/@digdir/designsystemet-react": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-react/-/designsystemet-react-1.14.0.tgz",
-      "integrity": "sha512-m4lYxbWv0bY5ayg0L+DueSrrhk2W+A0ovs443MteABwcx6pLDYPQMVl0FGZ/Wtn2gB92ZivvWuVhUxdom13dKg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-react/-/designsystemet-react-1.15.0.tgz",
+      "integrity": "sha512-x3lRxvOBmkRhnFNNYIg06Yi6iKYQMADqhbfh3Ray/qIEs8tQepF4mprBfKI26sdJ9X3e/RM3nnU+E0QqHPjW/A==",
       "license": "MIT",
       "dependencies": {
-        "@digdir/designsystemet-types": "1.14.0",
-        "@digdir/designsystemet-web": "1.14.0",
+        "@digdir/designsystemet-types": "1.15.0",
+        "@digdir/designsystemet-web": "1.15.0",
         "@floating-ui/dom": "^1.7.6",
         "@floating-ui/react": "0.26.23",
-        "@navikt/aksel-icons": "^8.10.3",
+        "@navikt/aksel-icons": "^8.10.5",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-virtual": "^3.13.24",
         "clsx": "^2.1.1"
@@ -3842,15 +3830,15 @@
       }
     },
     "node_modules/@digdir/designsystemet-types": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-types/-/designsystemet-types-1.14.0.tgz",
-      "integrity": "sha512-d/JZhwebAgclFsE7ax0Z8mWotEk3GE4e9+iC8Cq8EN5BQ+bOptwFrVipSrL+NAt8/7AX9WzrnAScPuxCb4vvgQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-types/-/designsystemet-types-1.15.0.tgz",
+      "integrity": "sha512-TBZlldpl0RBcFkrCMjRZFDwsI6A8btIbNpP2LnNElsKThoL1ZFSUutra+NwibV28lBRgSMi2gf46yY08GaoBsg==",
       "license": "MIT"
     },
     "node_modules/@digdir/designsystemet-web": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-web/-/designsystemet-web-1.14.0.tgz",
-      "integrity": "sha512-dmUnV/0wzTOSPnSGqQwjYyneuO+/QqfugAr2SP1N1m/VzfMal3Y5hD+AkDWWzWhJ7EJrhGtYwG5JVRM8iYuVeQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@digdir/designsystemet-web/-/designsystemet-web-1.15.0.tgz",
+      "integrity": "sha512-WsDhMS08sw7FnP/5BmvdP+Tbj6e4I1CdboZ8fPzU6WVAkV95JIcTWP1uFGtunNsMAyM/kYSSIUUqdMfG/wBiBw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
@@ -5075,9 +5063,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5095,9 +5080,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5115,9 +5097,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5135,9 +5114,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5155,9 +5131,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5175,9 +5148,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5195,9 +5165,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5215,9 +5182,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5430,9 +5394,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5447,9 +5408,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5464,9 +5422,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5481,9 +5436,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5498,9 +5450,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5515,9 +5464,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5532,9 +5478,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5549,9 +5492,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5635,6 +5575,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5674,6 +5615,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5694,6 +5636,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5714,6 +5657,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5734,6 +5678,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5754,6 +5699,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5774,6 +5720,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5794,6 +5741,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5814,6 +5762,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5834,6 +5783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5854,6 +5804,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5874,6 +5825,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5894,6 +5846,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5914,6 +5867,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8832,6 +8786,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8858,6 +8813,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10125,6 +10081,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/astro-infoportal/package.json
+++ b/astro-infoportal/package.json
@@ -11,11 +11,11 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.63.8",
+    "@altinn/altinn-components": "^0.66.0",
     "@astrojs/cloudflare": "^13.5.5",
     "@astrojs/react": "^5.0.5",
-    "@digdir/designsystemet-css": "^1.14.0",
-    "@digdir/designsystemet-react": "^1.14.0",
+    "@digdir/designsystemet-css": "^1.15.0",
+    "@digdir/designsystemet-react": "^1.15.0",
     "@digdir/designsystemet-theme": "^1.11.0",
     "@navikt/aksel-icons": "^8.11.0",
     "astro": "^6.3.8",

--- a/astro-infoportal/src/api/altinn/types.ts
+++ b/astro-infoportal/src/api/altinn/types.ts
@@ -69,7 +69,7 @@ export interface ConnectionEntity {
   variant?: string | null;
   parent?: ConnectionEntity | null;
   children?: ConnectionEntity[] | null;
-  partyId?: number | null;
+  partyid?: number | null;
   organizationIdentifier?: string | null;
   dateOfBirth?: string | null;
   isDeleted: boolean;
@@ -88,5 +88,5 @@ export interface Connection {
 
 export interface PaginatedResult<T> {
   links?: { next?: string | null } | null;
-  items: T[];
+  data?: T[];
 }

--- a/astro-infoportal/src/pages/api/users/authorized-parties.ts
+++ b/astro-infoportal/src/pages/api/users/authorized-parties.ts
@@ -62,7 +62,7 @@ function entityToAuthorizedParty(
       ? null
       : (entity.organizationIdentifier ?? null),
     dateOfBirth: isPerson ? (entity.dateOfBirth ?? null) : null,
-    partyId: entity.partyId ?? 0,
+    partyId: entity.partyid ?? 0,
     type: isPerson ? "Person" : "Organization",
     unitType: entity.variant ?? null,
     isDeleted: entity.isDeleted,
@@ -107,8 +107,10 @@ async function fetchNewActorList(
   if (!response || !response.ok) {
     throw new Error("connections request failed");
   }
-  const data = (await response.json()) as PaginatedResult<Connection> | null;
-  return (data?.items ?? []).map((connection) =>
+  // Spec wraps the array in `data` (ConnectionDtoPaginatedResult).
+  const parsed = (await response.json()) as PaginatedResult<Connection> | null;
+  const list = parsed?.data ?? [];
+  return list.map((connection) =>
     entityToAuthorizedParty(connection.party, connection.roles),
   );
 }

--- a/astro-infoportal/wrangler.jsonc
+++ b/astro-infoportal/wrangler.jsonc
@@ -18,7 +18,7 @@
 		"UMBRACO_API_URL": "https://infoportal.at22.dis-core.altinn.cloud/",
 		"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 		"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-		"USE_NEW_ACTOR_LIST": "true",
+		"USE_NEW_ACTOR_LIST": "false",
 		"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "false"
 	},
 	"env": {
@@ -28,7 +28,7 @@
 				"UMBRACO_API_URL": "https://infoportal.prod.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-prod-adac85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"USE_NEW_ACTOR_LIST": "true",
+				"USE_NEW_ACTOR_LIST": "false",
 				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "false"
 			}
 		},
@@ -38,7 +38,7 @@
 				"UMBRACO_API_URL": "https://infoportal.at22.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"USE_NEW_ACTOR_LIST": "true",
+				"USE_NEW_ACTOR_LIST": "false",
 				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "false"
 			}
 		},
@@ -48,7 +48,7 @@
 				"UMBRACO_API_URL": "https://infoportal.at23.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-at22-f6bd85.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"USE_NEW_ACTOR_LIST": "true",
+				"USE_NEW_ACTOR_LIST": "false",
 				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "false"
 			}
 		},
@@ -58,7 +58,7 @@
 				"UMBRACO_API_URL": "https://infoportal.tt02.dis-core.altinn.cloud/",
 				"ELASTICSEARCH_URL": "https://infoportal-search-tt02-ec939c.es.germanywestcentral.azure.elastic.cloud",
 				"ELASTICSEARCH_INDEX_PREFIX": "infoportal",
-				"USE_NEW_ACTOR_LIST": "true",
+				"USE_NEW_ACTOR_LIST": "false",
 				"ROUTE_CHANGE_REPORTEE_VIA_ALTINN2": "false"
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Read the enduser/connections actor list from the `data` wrapper (ConnectionDtoPaginatedResult per the platform OpenAPI spec), not `items`, and map the lowercase `partyid` (CompactEntityDto.partyid). The new actor list came back empty when USE_NEW_ACTOR_LIST was enabled. Set the flag false in all envs to mirror am-ui (which serves the authorizedparties actor list everywhere); the connections mapping is now correct but dormant until upstream enables it.

Update @altinn/altinn-components 0.63.8 -> 0.66.0 and @digdir/designsystemet-* 1.14 -> 1.15.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
