### PR TITLE
feat: subject radio buttons for "Hvordan bruke Altinn" contact form

### DIFF
--- a/astro-infoportal/package-lock.json
+++ b/astro-infoportal/package-lock.json
@@ -8,7 +8,7 @@
       "name": "astro-infoportal",
       "version": "0.0.1",
       "dependencies": {
-        "@altinn/altinn-components": "^0.66.0",
+        "@altinn/altinn-components": "^0.67.4",
         "@astrojs/cloudflare": "^13.5.5",
         "@astrojs/react": "^5.0.5",
         "@digdir/designsystemet-css": "^1.15.0",
@@ -50,9 +50,9 @@
       "license": "MIT"
     },
     "node_modules/@altinn/altinn-components": {
-      "version": "0.66.0",
-      "resolved": "https://registry.npmjs.org/@altinn/altinn-components/-/altinn-components-0.66.0.tgz",
-      "integrity": "sha512-sC7z4mZgMS6+NF/G2WBB8mq/Z4XcrjupYuCfozcwrC48Z4hWGq4ObjY71WrtemPW2JFLceP1JuQDdx+5vgkU0A==",
+      "version": "0.67.4",
+      "resolved": "https://registry.npmjs.org/@altinn/altinn-components/-/altinn-components-0.67.4.tgz",
+      "integrity": "sha512-eYfUhJ1GJikJPa8LU7fFkA23lD62D08tn+0tt7Ka1iFk2Zxd2pz4fJPGXJvnCJopkmsC3bESchFgcE7KypgjmA==",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "^1.14.0",
@@ -5575,6 +5575,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5614,6 +5615,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5634,6 +5636,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5654,6 +5657,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5674,6 +5678,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5694,6 +5699,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5714,6 +5720,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5734,6 +5741,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5754,6 +5762,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5774,6 +5783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5794,6 +5804,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5814,6 +5825,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5834,6 +5846,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5854,6 +5867,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8772,6 +8786,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8798,6 +8813,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10065,6 +10081,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/astro-infoportal/package.json
+++ b/astro-infoportal/package.json
@@ -11,7 +11,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.66.0",
+    "@altinn/altinn-components": "^0.67.4",
     "@astrojs/cloudflare": "^13.5.5",
     "@astrojs/react": "^5.0.5",
     "@digdir/designsystemet-css": "^1.15.0",

--- a/astro-infoportal/src/Components/Blocks/ContactFormBlock/ContactFormBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/ContactFormBlock/ContactFormBlock.tsx
@@ -8,6 +8,7 @@ const ContactFormBlock = ({
   text,
   schemaId,
   showAttachment,
+  startCompanyFormat,
   useRecaptcha,
   recaptchaSiteKey,
   labels,
@@ -96,6 +97,7 @@ const ContactFormBlock = ({
       <ContactForm
         schemaId={schemaId}
         showAttachment={showAttachment}
+        useSubjectOptions={!startCompanyFormat}
         useRecaptcha={useRecaptcha}
         recaptchaSiteKey={recaptchaSiteKey}
         onSuccess={handleSuccess}

--- a/astro-infoportal/src/Components/ContactFormModal/ContactForm.tsx
+++ b/astro-infoportal/src/Components/ContactFormModal/ContactForm.tsx
@@ -1,8 +1,10 @@
 import {
   Button,
   Field,
+  Fieldset,
   Input,
   Label,
+  Radio,
   Textarea,
   ValidationMessage,
 } from "@digdir/designsystemet-react";
@@ -32,6 +34,9 @@ declare global {
 interface ContactFormProps extends ContactFormModalProps {
   onSuccess: () => void;
   onError: (message: string) => void;
+  // When true, the Subject field renders as a radio group of preset options
+  // (the "Hvordan bruke Altinn" form) instead of a free-text input.
+  useSubjectOptions?: boolean;
 }
 
 const fallbackLocalization = (key: string): string => {
@@ -86,6 +91,7 @@ const ContactForm = ({
   onSuccess,
   onError,
   labels,
+  useSubjectOptions,
 }: ContactFormProps) => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -181,6 +187,17 @@ const ContactForm = ({
   };
 
   const validateSubject = () => {
+    if (useSubjectOptions) {
+      if (!subject) {
+        setErrors((prev) => ({
+          ...prev,
+          subject: getLabelValue(labels, "subjectValidation"),
+        }));
+        return false;
+      }
+      setErrors((prev) => ({ ...prev, subject: undefined }));
+      return true;
+    }
     if (!subject || subject.trim().length < 3) {
       setErrors((prev) => ({
         ...prev,
@@ -449,24 +466,47 @@ const ContactForm = ({
           )}
         </Field>
 
-        <Field className="contact-form__field">
-          <Label htmlFor="contact-subject">
-            {getLabelValue(labels, "topicLabel") || ""}
-          </Label>
-          <Input
-            id="contact-subject"
-            type="text"
-            value={subject}
-            onChange={(e) => setSubject(e.target.value)}
-            onBlur={validateSubject}
-            placeholder={getLabelValue(labels, "topicPlaceholder") || ""}
-            disabled={isSubmitting}
-            aria-required
-          />
-          {errors.subject && (
-            <ValidationMessage>{errors.subject}</ValidationMessage>
-          )}
-        </Field>
+        {useSubjectOptions ? (
+          <Fieldset className="contact-form__field">
+            <Fieldset.Legend>
+              {getLabelValue(labels, "topicLabel") || ""}
+            </Fieldset.Legend>
+            {(labels?.subjectOptions ?? []).map((option: string) => (
+              <Radio
+                key={option}
+                label={option}
+                name="contact-subject"
+                value={option}
+                checked={subject === option}
+                onChange={() => setSubject(option)}
+                disabled={isSubmitting}
+                aria-required
+              />
+            ))}
+            {errors.subject && (
+              <ValidationMessage>{errors.subject}</ValidationMessage>
+            )}
+          </Fieldset>
+        ) : (
+          <Field className="contact-form__field">
+            <Label htmlFor="contact-subject">
+              {getLabelValue(labels, "topicLabel") || ""}
+            </Label>
+            <Input
+              id="contact-subject"
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              onBlur={validateSubject}
+              placeholder={getLabelValue(labels, "topicPlaceholder") || ""}
+              disabled={isSubmitting}
+              aria-required
+            />
+            {errors.subject && (
+              <ValidationMessage>{errors.subject}</ValidationMessage>
+            )}
+          </Field>
+        )}
 
         <Field className="contact-form__field">
           <Label htmlFor="contact-message">

--- a/astro-infoportal/src/Components/ContactFormModal/ContactFormTypes.ts
+++ b/astro-infoportal/src/Components/ContactFormModal/ContactFormTypes.ts
@@ -79,4 +79,6 @@ export interface ContactFormLabels {
   successMessage: string;
   errorMessage: string;
   retryButton: string;
+  subjectValidation: string;
+  subjectOptions: string[];
 }

--- a/astro-infoportal/src/i18n/locales/en.json
+++ b/astro-infoportal/src/i18n/locales/en.json
@@ -256,6 +256,11 @@
   "contactform.successMessage": "Thank you for your inquiry! We will respond as soon as possible.",
   "contactform.errorMessage": "An error occurred while submitting the form. Please try again later.",
   "contactform.retryButton": "Try again",
+  "contactform.subjectInbox": "Inbox",
+  "contactform.subjectAccess": "Access management",
+  "contactform.subjectForms": "Forms",
+  "contactform.subjectNotifications": "Notifications",
+  "contactform.subjectOther": "Other",
 
   "subscription.types.newsletterInTitle": "newsletter",
   "subscription.types.newsletterInIngress": "news",

--- a/astro-infoportal/src/i18n/locales/nb.json
+++ b/astro-infoportal/src/i18n/locales/nb.json
@@ -256,6 +256,11 @@
   "contactform.successMessage": "Takk for din henvendelse! Vi vil svare deg så snart som mulig",
   "contactform.errorMessage": "En feil oppstod ved sending av skjema. Vennligst prøv igjen senere",
   "contactform.retryButton": "Prøv igjen",
+  "contactform.subjectInbox": "Innboks",
+  "contactform.subjectAccess": "Tilganger",
+  "contactform.subjectForms": "Skjema",
+  "contactform.subjectNotifications": "Varslinger",
+  "contactform.subjectOther": "Annet",
 
   "subscription.types.newsletterInTitle": "nyhetsbrev",
   "subscription.types.newsletterInIngress": "nyheter",

--- a/astro-infoportal/src/i18n/locales/nn.json
+++ b/astro-infoportal/src/i18n/locales/nn.json
@@ -247,6 +247,11 @@
   "contactform.successMessage": "Takk for di henvendelse! Vi vil svare deg så snart som mogleg.",
   "contactform.errorMessage": "Ein feil oppstod ved sending av skjema. Ver vennleg og prøv igjen seinare.",
   "contactform.retryButton": "Prøv igjen",
+  "contactform.subjectInbox": "Innboks",
+  "contactform.subjectAccess": "Tilgangar",
+  "contactform.subjectForms": "Skjema",
+  "contactform.subjectNotifications": "Varslingar",
+  "contactform.subjectOther": "Anna",
 
   "subscription.types.newsletterInTitle": "nyheitsbrev",
   "subscription.types.newsletterInIngress": "nyheiter",

--- a/astro-infoportal/src/transformers/contactFormData.ts
+++ b/astro-infoportal/src/transformers/contactFormData.ts
@@ -56,6 +56,14 @@ function buildContactFormLabels(locale: Locale) {
     successMessage: t("contactform.successMessage", locale),
     errorMessage: t("contactform.errorMessage", locale),
     retryButton: t("contactform.retryButton", locale),
+    subjectValidation: t("contactform.topicRequired", locale),
+    subjectOptions: [
+      t("contactform.subjectInbox", locale),
+      t("contactform.subjectAccess", locale),
+      t("contactform.subjectForms", locale),
+      t("contactform.subjectNotifications", locale),
+      t("contactform.subjectOther", locale),
+    ],
   };
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace the free-text Subject input with a 5-option radio group for the "Hvordan bruke Altinn" contact form, keyed on the existing startCompanyFormat block flag (false -> radio, true -> text input). The "Hvordan starte og drive" form keeps its free-text input.

- Options live in i18n (nb/nn/en) and are submitted as the localized label to /api/contactform/send; subject stays free text.
- Wire startCompanyFormat through ContactFormBlock -> ContactForm via a new useSubjectOptions prop

Also update @altinn/altinn-components 0.66.0 -> 0.67.4 (frontend design system).

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/318)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
