### PR TITLE
fix: correct HelpStartPage heading and hide ThemePage system folders

### DIFF
--- a/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
+++ b/astro-infoportal/src/transformers/HelpStartPageTransformer.ts
@@ -106,7 +106,7 @@ export class HelpStartPageTransformer implements IJSONTransformer {
       mainIntro: props.mainIntro,
       newVersionHeading: props.newDrillDownTitle,
       newDrilldownPages,
-      currentVersionHeading: props.oldDrillDownTitle,
+      currentVersionHeading: props.oldDrilldownTitle,
       oldDrilldownPages,
       questionAreaHeading: props.questionAreaTitle,
       questionArea,

--- a/astro-infoportal/src/transformers/ThemePageTransformer.ts
+++ b/astro-infoportal/src/transformers/ThemePageTransformer.ts
@@ -76,6 +76,11 @@ const contentTypesWithChildLinks = new Set([
   "themeContainerPage",
 ]);
 
+const systemFolderContentTypes = new Set([
+  "sysContentAssetFolder",
+  "sysContentFolder",
+]);
+
 export class ThemePageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData.properties ?? {};
@@ -87,7 +92,9 @@ export class ThemePageTransformer implements IJSONTransformer {
 
     const allChildren = await fetchUmbracoChildrenInEditorOrder(cmsPageData.route.path, 100, contentLocale);
     const children = allChildren.filter(
-      (c: any) => c.properties?.showInNavigation !== false,
+      (c: any) =>
+        c.properties?.showInNavigation !== false &&
+        !systemFolderContentTypes.has(c.contentType),
     );
 
     const themeGroups = await Promise.all(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- HelpStartPage: read oldDrilldownTitle (correct Delivery API alias casing) so the "Få hjelp i gammel Altinn" old-version heading renders.
- ThemePage: exclude sysContentAssetFolder/sysContentFolder children (e.g. "Sideblokker"). Their showInNavigation is null — not false — so the existing flag filter missed them; exclude by contentType instead.

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/278

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
