### PR TITLE
feat: Add Linkerd skip-outbound-ports annotation for Umbraco

### DIFF
--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         linkerd.io/inject: enabled
-        config.linkerd.io/skip-outbound-ports: "443"
+        config.linkerd.io/skip-outbound-ports: "443,587"
     spec:
       serviceAccountName: umbraco
       nodeSelector:

--- a/syncroot/base/umbraco/deployment.yaml
+++ b/syncroot/base/umbraco/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         linkerd.io/inject: enabled
+        config.linkerd.io/skip-outbound-ports: "443"
     spec:
       serviceAccountName: umbraco
       nodeSelector:


### PR DESCRIPTION
Skip port 443 to prevent Linkerd from intercepting outbound HTTPS traffic.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
