### PR TITLE
feat: make top banner editable via Umbraco CMS

### DIFF
--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -13,26 +13,6 @@ import {
 } from "@constants/startPageLinks";
 import { type Locale, t } from "@i18n/index";
 
-function buildAltinnShutdownBanner(closeButtonText: string) {
-  return {
-    message: {
-      items: [
-        {
-          html: '<p>19. juni blir gamle Altinn skrudd av.&nbsp;<a href="/nyheter/sjekk-om-du-ma-gjore-noe-for-vi-slar-av-gamle-altinn/" class="ds-link">Dette m&aring; du passe p&aring;.</a></p>',
-          componentName: "RichText",
-        },
-      ],
-      componentName: "RichTextArea",
-    },
-    isActive: true,
-    colorTheme: "warning",
-    closeButtonText,
-    contentHash: "altinn-shutdown-2026-06-19-v1",
-    localStoragePrefix: "infoportal-banner-dismissed",
-    componentName: "BannerBlock",
-  };
-}
-
 export function getGlobalData(
   locale: Locale = "nb",
   searchPageUrl = "/sok/",
@@ -50,9 +30,7 @@ export function getGlobalData(
 
   return {
     headerViewModel: {
-      banner:
-        buildBanner(p?.banner, t("banner.closeButton", locale)) ??
-        buildAltinnShutdownBanner(t("banner.closeButton", locale)),
+      banner: buildBanner(p?.banner, t("banner.closeButton", locale)),
       startAndRunCompany: buildLink(
         p?.startAndRunCompany,
         t("header.startAndRunCompany", locale),

--- a/astro-infoportal/src/Constants/startPageLinks.ts
+++ b/astro-infoportal/src/Constants/startPageLinks.ts
@@ -29,14 +29,6 @@ export function buildLink(
   return { text, url };
 }
 
-type RichTextValue = string | { markup?: string } | undefined | null;
-
-function resolveRichText(value: RichTextValue): string | null {
-  if (!value) return null;
-  if (typeof value === "string") return value;
-  return value.markup ?? null;
-}
-
 // Simple 64-bit FNV-1a hash, rendered as hex. Used to version banner dismissal:
 // when the message changes, the hash changes, so users see the new banner.
 function hashMessage(html: string): string {
@@ -49,23 +41,38 @@ function hashMessage(html: string): string {
   return h.toString(16).padStart(16, "0");
 }
 
-export function buildBanner(pickerValue: unknown, closeButtonText: string) {
-  if (!pickerValue) return null;
-  const first = Array.isArray(pickerValue) ? pickerValue[0] : pickerValue;
-  const props = (first as { properties?: Record<string, unknown> })?.properties;
+// "Banner Color" dropdown labels → Designsystemet roles (BannerBlock.scss keys on these).
+const BANNER_COLOR_BY_LABEL: Record<string, string> = {
+  "blå": "accent",
+  "lyseblå": "info",
+  "grønn": "success",
+  gul: "warning",
+  "rød": "danger",
+};
+
+// `message` arrives pre-shaped as { items: [...] } from the backend RichText converter.
+export function buildBanner(bannerValue: unknown, closeButtonText: string) {
+  const first = Array.isArray(bannerValue) ? bannerValue[0] : bannerValue;
+  const props = (first as { properties?: Record<string, unknown> } | null | undefined)
+    ?.properties;
   if (!props) return null;
 
-  const html = resolveRichText(props.message as RichTextValue);
+  const messageItems = (props.message as { items?: unknown[] } | undefined)?.items;
+  if (!Array.isArray(messageItems) || messageItems.length === 0) return null;
+
+  const html = messageItems
+    .map((item) => (item as { html?: string })?.html ?? "")
+    .join("");
   if (!html) return null;
 
   return {
-    message: {
-      items: [{ html, componentName: "RichText" }],
-      componentName: "RichTextArea",
-    },
+    message: { items: messageItems, componentName: "RichTextArea" },
     isActive: Boolean(props.isActive),
     badgeText: (props.badgeText as string) ?? "",
-    colorTheme: (props.colorTheme as string) ?? "accent",
+    colorTheme:
+      BANNER_COLOR_BY_LABEL[
+        ((props.colorTheme as string) ?? "").trim().toLowerCase()
+      ] ?? "accent",
     closeButtonText,
     contentHash: hashMessage(html),
     localStoragePrefix: "infoportal-banner-dismissed",

--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -62,9 +62,14 @@ function deliveryUrl(pathname: string, search?: string): string {
   return url.toString();
 }
 
-export async function fetchUmbracoContent(path: string, culture?: string) {
+export async function fetchUmbracoContent(
+  path: string,
+  culture?: string,
+  expand?: string,
+) {
   const url = deliveryUrl(
     `/umbraco/delivery/api/v2/content/item${normalizeDeliveryPath(normalizeItemPath(path))}`,
+    expand ? new URLSearchParams({ expand }).toString() : undefined,
   );
 
   let response = await fetch(url, { headers: cultureHeader(culture) });
@@ -93,16 +98,17 @@ export async function fetchUmbracoContent(path: string, culture?: string) {
 export async function fetchUmbracoContentWithLocaleFallback(
   path: string,
   culture?: string,
+  expand?: string,
 ) {
   try {
-    return await fetchUmbracoContent(path, culture);
+    return await fetchUmbracoContent(path, culture, expand);
   } catch (error) {
     if (culture && culture !== "nb") {
       const normalized = normalizeItemPath(path);
       const prefix = `/${culture}/`;
       if (normalized.startsWith(prefix)) {
         const fallbackPath = normalized.slice(prefix.length - 1) || "/";
-        return await fetchUmbracoContent(fallbackPath, "nb");
+        return await fetchUmbracoContent(fallbackPath, "nb", expand);
       }
     }
     throw error;
@@ -326,6 +332,8 @@ export async function fetchUmbracoStartPage(locale?: string) {
   const params = new URLSearchParams({
     filter: "contentType:startPage",
     take: "1",
+    // expand the banner picker so buildBanner gets the node's properties inline
+    expand: "properties[banner]",
   });
   const url = deliveryUrl("/umbraco/delivery/api/v2/content", params.toString());
 

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -72,7 +72,12 @@ if (contentUrl && wasRouteOverridden) {
 const isLocaleRoot = isNorwegianStartRoot || /^\/(nn|en)\/?$/.test(path);
 const umbracoPath = isNorwegianStartRoot ? "/" : path;
 
-const pagePromise = fetchUmbracoContentWithLocaleFallback(umbracoPath, locale);
+// On a locale root the page IS the startPage — expand the banner picker so buildBanner gets it.
+const pagePromise = fetchUmbracoContentWithLocaleFallback(
+  umbracoPath,
+  locale,
+  isLocaleRoot ? "properties[banner]" : undefined,
+);
 const startPagePromise = isLocaleRoot ? pagePromise : fetchUmbracoStartPage(locale);
 
 const [pageResult, startPageResult] = await Promise.allSettled([

--- a/astro-infoportal/src/pages/index.astro
+++ b/astro-infoportal/src/pages/index.astro
@@ -15,7 +15,8 @@ let umbracoPageData: any = null;
 // Fetch the correct Umbraco path for the locale
 const umbracoPath = locale === "en" ? "/en/" : "/";
 const [pageResult] = await Promise.allSettled([
-  fetchUmbracoContent(umbracoPath, locale),
+  // expand the banner picker so buildBanner gets the node's properties (see fetchUmbracoStartPage)
+  fetchUmbracoContent(umbracoPath, locale, "properties[banner]"),
 ]);
 
 if (pageResult.status === 'rejected') {

--- a/umbraco-infoportal/uSync/v17/ContentTypes/banner.config
+++ b/umbraco-infoportal/uSync/v17/ContentTypes/banner.config
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ContentType Key="97c1ca52-7481-407f-a065-b4ac9a5e6e25" Alias="banner" Level="1">
+  <Info>
+    <Name>Banner</Name>
+    <Icon>icon-document</Icon>
+    <Thumbnail>folder.png</Thumbnail>
+    <Description></Description>
+    <AllowAtRoot>False</AllowAtRoot>
+    <ListView>00000000-0000-0000-0000-000000000000</ListView>
+    <Variations>Culture</Variations>
+    <IsElement>false</IsElement>
+    <HistoryCleanup>
+      <PreventCleanup>False</PreventCleanup>
+      <KeepAllVersionsNewerThanDays></KeepAllVersionsNewerThanDays>
+      <KeepLatestVersionPerDayForDays></KeepLatestVersionPerDayForDays>
+    </HistoryCleanup>
+    <Compositions />
+    <DefaultTemplate></DefaultTemplate>
+    <AllowedTemplates />
+  </Info>
+  <Structure />
+  <GenericProperties>
+    <GenericProperty>
+      <Key>cb77bf7d-cf36-4d26-8e6f-194be7d080cf</Key>
+      <Name>Badge</Name>
+      <Alias>badgeText</Alias>
+      <Definition>0cc0eba1-9960-42c9-bf9b-60e150b429ae</Definition>
+      <Type>Umbraco.TextBox</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Badge med tekst]]></Description>
+      <SortOrder>1</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>bd888ead-fbbe-4800-a6cb-67a3ab557743</Key>
+      <Name>Fargetema</Name>
+      <Alias>colorTheme</Alias>
+      <Definition>ffe44abe-b3f1-44c3-a651-14a7d7228592</Definition>
+      <Type>Umbraco.DropDown.Flexible</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Velg fargetema]]></Description>
+      <SortOrder>3</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>4633cf44-663d-4763-a050-b1ac1e9d3940</Key>
+      <Name>Er aktiv</Name>
+      <Alias>isActive</Alias>
+      <Definition>92897bc6-a5f3-4ffe-ae27-f2e7e33dda49</Definition>
+      <Type>Umbraco.TrueFalse</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Vis eller skjul banneret]]></Description>
+      <SortOrder>2</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Nothing</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+    <GenericProperty>
+      <Key>c4da7cc3-70ca-4918-9892-94540f63a24b</Key>
+      <Name>Melding</Name>
+      <Alias>message</Alias>
+      <Definition>ca90c950-0aff-4e72-b976-a30b1ac57dad</Definition>
+      <Type>Umbraco.RichText</Type>
+      <Mandatory>false</Mandatory>
+      <Validation></Validation>
+      <Description><![CDATA[Banner riktekst]]></Description>
+      <SortOrder>0</SortOrder>
+      <Tab Alias="innhold">Innhold</Tab>
+      <Variations>Culture</Variations>
+      <MandatoryMessage></MandatoryMessage>
+      <ValidationRegExpMessage></ValidationRegExpMessage>
+      <LabelOnTop>false</LabelOnTop>
+    </GenericProperty>
+  </GenericProperties>
+  <Tabs>
+    <Tab>
+      <Key>603a2b32-47c2-45af-ae83-adee6baa7832</Key>
+      <Caption>Innhold</Caption>
+      <Alias>innhold</Alias>
+      <Type>Group</Type>
+      <SortOrder>0</SortOrder>
+    </Tab>
+  </Tabs>
+</ContentType>

--- a/umbraco-infoportal/uSync/v17/DataTypes/BannerColor.config
+++ b/umbraco-infoportal/uSync/v17/DataTypes/BannerColor.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DataType Key="ffe44abe-b3f1-44c3-a651-14a7d7228592" Alias="Banner color" Level="1">
+  <Info>
+    <Name>Banner color</Name>
+    <EditorAlias>Umbraco.DropDown.Flexible</EditorAlias>
+    <EditorUIAlias>Umb.PropertyEditorUi.Dropdown</EditorUIAlias>
+  </Info>
+  <Config><![CDATA[{
+  "items": [
+    "Bl\u00E5",
+    "Lysebl\u00E5",
+    "Gr\u00F8nn",
+    "Gul",
+    "R\u00F8d"
+  ],
+  "multiple": false
+}]]></Config>
+</DataType>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace the hardcoded shutdown banner with an editor-managed Banner block picked on the start page's Konfigurasjon tab.

- buildBanner: read the picked Banner node's expanded properties and map the Norwegian colour labels (Blå/Lyseblå/Grønn/Gul/Rød) to Designsystemet roles (accent/info/success/warning/danger)
- add expand=properties[banner] to every start-page fetch path so the banner resolves on all routes (homepage, locale roots, content pages, 404, search)
- removed the buildAltinnShutdownBanner fallback so the banner is fully CMS-controlled (show / hide via "Er aktiv" / remove)
- uSync: add Banner document type + Banner Color data type

Rollout: the hardcoded banner is removed, so the CMS banner must be set up in each environment (esp. prod) before/with the deploy.

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/334

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
