### PR TITLE
fix(uu): accessibility fixes for Help & Contact pages

### DIFF
--- a/Infoportal.RichText.Tests/Infoportal.RichText.Tests.csproj
+++ b/Infoportal.RichText.Tests/Infoportal.RichText.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Infoportal.RichText\Infoportal.RichText.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Infoportal.RichText.Tests/RichTextNormalizerTests.cs
+++ b/Infoportal.RichText.Tests/RichTextNormalizerTests.cs
@@ -1,0 +1,105 @@
+using System.Text.RegularExpressions;
+using Infoportal.RichText;
+using Xunit;
+
+namespace Infoportal.RichText.Tests;
+
+public class RichTextNormalizerTests
+{
+    private static int Count(string html, string pattern) =>
+        Regex.Matches(html, pattern, RegexOptions.IgnoreCase).Count;
+
+    // --- collapseConsecutiveBreaks (#4) ---
+
+    [Fact]
+    public void Collapses_double_br_into_single()
+    {
+        var output = RichTextNormalizer.Normalize("<p>a</p><br><br><p>b</p>");
+        Assert.Equal(1, Count(output, "<br"));
+    }
+
+    [Fact]
+    public void Collapses_br_run_ignoring_whitespace_between()
+    {
+        var output = RichTextNormalizer.Normalize("a<br>\n<br> <br>b");
+        Assert.Equal(1, Count(output, "<br"));
+    }
+
+    [Fact]
+    public void Leaves_single_br_untouched()
+    {
+        var output = RichTextNormalizer.Normalize("a<br>b");
+        Assert.Equal(1, Count(output, "<br"));
+    }
+
+    // --- wrapLooseLinkRuns (#2) ---
+
+    [Fact]
+    public void Wraps_br_separated_links_in_single_ul_with_one_li_each()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<a href=\"/x\">X</a><br><a href=\"/y\">Y</a>");
+        Assert.Equal(1, Count(output, "<ul"));
+        Assert.Equal(2, Count(output, "<li"));
+        Assert.Contains(">X</a>", output);
+        Assert.Contains(">Y</a>", output);
+        Assert.DoesNotContain("<br", output);
+    }
+
+    [Fact]
+    public void Wraps_run_of_three_loose_links()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<a href=\"/x\">X</a><br><a href=\"/y\">Y</a><br><a href=\"/z\">Z</a>");
+        Assert.Equal(1, Count(output, "<ul"));
+        Assert.Equal(3, Count(output, "<li"));
+    }
+
+    [Fact]
+    public void Does_not_wrap_a_single_link()
+    {
+        var output = RichTextNormalizer.Normalize("<a href=\"/x\">X</a>");
+        Assert.DoesNotContain("<ul", output);
+    }
+
+    [Fact]
+    public void Does_not_wrap_inline_links_separated_by_text_in_paragraph()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<p>see <a href=\"/x\">X</a> and <a href=\"/y\">Y</a></p>");
+        Assert.DoesNotContain("<ul", output);
+    }
+
+    [Fact]
+    public void Does_not_produce_invalid_ul_inside_paragraph()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<p><a href=\"/x\">X</a><br><a href=\"/y\">Y</a></p>");
+        Assert.DoesNotContain("<ul", output);
+    }
+
+    [Fact]
+    public void Leaves_existing_link_list_intact()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<ul><li><a href=\"/x\">X</a></li><li><a href=\"/y\">Y</a></li></ul>");
+        Assert.Equal(1, Count(output, "<ul"));
+        Assert.Equal(2, Count(output, "<li"));
+    }
+
+    [Fact]
+    public void Empty_or_null_input_is_safe()
+    {
+        Assert.Equal(string.Empty, RichTextNormalizer.Normalize(null));
+        Assert.Equal(string.Empty, RichTextNormalizer.Normalize(""));
+    }
+
+    [Fact]
+    public void Leaves_content_without_breaks_or_link_runs_byte_for_byte()
+    {
+        // No <br> and fewer than 2 links: must be returned verbatim, i.e. the
+        // DOM round-trip is skipped so unrelated markup isn't reserialised.
+        const string input = "<p><img src=\"a.jpg\" /> hello <b>world</b></p>";
+        Assert.Equal(input, RichTextNormalizer.Normalize(input));
+    }
+}

--- a/Infoportal.RichText/Infoportal.RichText.csproj
+++ b/Infoportal.RichText/Infoportal.RichText.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="1.5.1" />
+  </ItemGroup>
+
+</Project>

--- a/Infoportal.RichText/RichTextNormalizer.cs
+++ b/Infoportal.RichText/RichTextNormalizer.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+
+namespace Infoportal.RichText;
+
+/// <summary>
+/// Normalises editor-authored rich-text HTML for accessibility before it is
+/// returned by the Umbraco Delivery API:
+///  - collapses stacked &lt;br&gt; runs (screen readers announce each as "blank");
+///  - wraps loose link runs in a &lt;ul&gt; so they are announced as a list.
+/// Runs server-side over a real DOM (AngleSharp); design-system styling stays
+/// in the frontend.
+/// </summary>
+public static class RichTextNormalizer
+{
+    private static readonly HtmlParser Parser = new();
+
+    // Matches an opening <a> tag (followed by whitespace or '>'), not <article>/<aside>.
+    private static readonly Regex AnchorOpenTag =
+        new(@"<a[\s>]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // Block-level containers where an injected <ul> is valid markup and where we
+    // look for loose link runs. Deliberately excludes <p>, headings and existing
+    // lists, so inline links are left untouched.
+    private static readonly HashSet<string> LinkListContainers =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "DIV",
+            "SECTION",
+            "ARTICLE",
+            "MAIN",
+            "ASIDE",
+        };
+
+    public static string Normalize(string? html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return html ?? string.Empty;
+        }
+
+        // Cheap pre-check: only touch the DOM when there's something we might
+        // change (a <br> to collapse, or 2+ links to maybe wrap). Avoids
+        // reserialising the bulk of rich text that needs no normalisation.
+        var hasBreak = html.Contains("<br", StringComparison.OrdinalIgnoreCase);
+        if (!hasBreak && AnchorOpenTag.Matches(html).Count < 2)
+        {
+            return html;
+        }
+
+        var document = Parser.ParseDocument(html);
+        var body = document.Body;
+        if (body is null)
+        {
+            return html;
+        }
+
+        CollapseConsecutiveBreaks(body);
+        WrapLooseLinkRuns(body);
+
+        return body.InnerHtml;
+    }
+
+    // Editors sometimes stack <br><br> for vertical spacing. Collapse any run of
+    // consecutive breaks (ignoring whitespace text between them) to a single <br>.
+    private static void CollapseConsecutiveBreaks(IElement root)
+    {
+        foreach (var br in root.QuerySelectorAll("br").ToArray())
+        {
+            if (PreviousSignificantSibling(br) is IElement { TagName: "BR" })
+            {
+                br.Remove();
+            }
+        }
+    }
+
+    // A sequence of sibling <a> elements separated only by <br>/whitespace is a
+    // link list authored without list semantics; wrap such runs (2+ links) in a
+    // <ul><li>. Recurses into block containers only, so inline links inside <p>
+    // or headings are left alone.
+    private static void WrapLooseLinkRuns(IElement container)
+    {
+        foreach (var child in container.Children.ToArray())
+        {
+            if (LinkListContainers.Contains(child.TagName))
+            {
+                WrapLooseLinkRuns(child);
+            }
+        }
+
+        foreach (var run in CollectLinkRuns(container))
+        {
+            var list = container.Owner!.CreateElement("ul");
+            container.InsertBefore(list, run[0]);
+
+            foreach (var node in run)
+            {
+                if (IsAnchor(node))
+                {
+                    var item = container.Owner!.CreateElement("li");
+                    item.AppendChild(node); // moves the anchor out of the container
+                    list.AppendChild(item);
+                }
+                else
+                {
+                    container.RemoveChild(node); // drop the <br>/whitespace separators
+                }
+            }
+        }
+    }
+
+    // Groups of links (plus the separators between them) that should each become
+    // one <ul>. Read-only: the caller mutates the tree afterwards.
+    private static List<List<INode>> CollectLinkRuns(IElement container)
+    {
+        var runs = new List<List<INode>>();
+        var children = container.ChildNodes.ToArray();
+        var i = 0;
+
+        while (i < children.Length)
+        {
+            if (!IsAnchor(children[i]))
+            {
+                i++;
+                continue;
+            }
+
+            var run = new List<INode> { children[i] };
+            var lastAnchorIndex = 0;
+            var j = i + 1;
+            while (j < children.Length)
+            {
+                var node = children[j];
+                if (IsAnchor(node))
+                {
+                    run.Add(node);
+                    lastAnchorIndex = run.Count - 1;
+                }
+                else if (IsBreak(node) || IsWhitespace(node))
+                {
+                    run.Add(node);
+                }
+                else
+                {
+                    break;
+                }
+
+                j++;
+            }
+
+            // Drop trailing separators so the run ends on its last link.
+            var trimmed = run.Take(lastAnchorIndex + 1).ToList();
+            if (trimmed.Count(IsAnchor) >= 2)
+            {
+                runs.Add(trimmed);
+            }
+
+            i = j;
+        }
+
+        return runs;
+    }
+
+    private static INode? PreviousSignificantSibling(INode node)
+    {
+        var sibling = node.PreviousSibling;
+        while (sibling is not null)
+        {
+            if (!IsWhitespace(sibling))
+            {
+                return sibling;
+            }
+
+            sibling = sibling.PreviousSibling;
+        }
+
+        return null;
+    }
+
+    private static bool IsAnchor(INode node) => node is IElement { TagName: "A" };
+
+    private static bool IsBreak(INode node) => node is IElement { TagName: "BR" };
+
+    private static bool IsWhitespace(INode node) =>
+        node.NodeType == NodeType.Text && string.IsNullOrWhiteSpace(node.TextContent);
+}

--- a/astro-infoportal/src/Components/ContactFormModal/ContactForm.tsx
+++ b/astro-infoportal/src/Components/ContactFormModal/ContactForm.tsx
@@ -103,9 +103,43 @@ const ContactForm = ({
   const [attachment, setAttachment] = useState<File | undefined>(undefined);
   const [errors, setErrors] = useState<ContactFormErrors>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [attachmentStatus, setAttachmentStatus] = useState("");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const uploadButtonRef = useRef<HTMLButtonElement>(null);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
+  const hadAttachmentRef = useRef(false);
 
   const emailRegex = useMemo(() => /^[^\s@]+@[^\s@]+\.[^\s@]+$/, []);
+
+  // When an attachment is added the upload button unmounts (and vice-versa on
+  // delete), so move focus to the control that replaces it and announce the
+  // change — otherwise screen-reader focus is dropped to the top of the page.
+  useEffect(() => {
+    const hasAttachment = !!attachment;
+    const had = hadAttachmentRef.current;
+    hadAttachmentRef.current = hasAttachment;
+
+    if (hasAttachment === had) return;
+
+    if (hasAttachment) {
+      // attachmentLabel often already ends in ":" (it's the field label), so
+      // strip a trailing colon before composing to avoid "Vedlegg:: file".
+      const label = (
+        getLabelValue(labels, "attachmentLabel") || "Attachment"
+      ).replace(/[\s:]+$/, "");
+      setAttachmentStatus(
+        getLabelValue(labels, "attachmentAddedStatus") ||
+          `${label}: ${attachment?.name ?? ""}`,
+      );
+      requestAnimationFrame(() => deleteButtonRef.current?.focus());
+    } else {
+      setAttachmentStatus(
+        getLabelValue(labels, "attachmentRemovedStatus") ||
+          "Attachment removed",
+      );
+      requestAnimationFrame(() => uploadButtonRef.current?.focus());
+    }
+  }, [attachment, labels]);
 
   // Re-validate confirm email when email field changes
   useEffect(() => {
@@ -548,6 +582,7 @@ const ContactForm = ({
               />
               {!attachment && (
                 <Button
+                  ref={uploadButtonRef}
                   variant="secondary"
                   className="contact-form__file-button"
                   onClick={() => fileInputRef.current?.click()}
@@ -568,6 +603,7 @@ const ContactForm = ({
                     </span>
                   </div>
                   <Button
+                    ref={deleteButtonRef}
                     type="button"
                     variant="tertiary"
                     className="contact-form__file-delete"
@@ -595,6 +631,13 @@ const ContactForm = ({
             {errors.attachment && (
               <ValidationMessage>{errors.attachment}</ValidationMessage>
             )}
+            <div
+              className="contact-form__sr-status"
+              role="status"
+              aria-live="polite"
+            >
+              {attachmentStatus}
+            </div>
           </Field>
         )}
 

--- a/astro-infoportal/src/Components/ContactFormModal/ContactFormModal.scss
+++ b/astro-infoportal/src/Components/ContactFormModal/ContactFormModal.scss
@@ -181,6 +181,20 @@
     width: 100%;
   }
 
+  // Visually-hidden live region; announces attachment add/remove to screen
+  // readers without affecting the visual layout.
+  &__sr-status {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
   &__file {
     display: flex;
     flex-direction: column;

--- a/astro-infoportal/src/Components/ContactFormModal/ContactFormModal.tsx
+++ b/astro-infoportal/src/Components/ContactFormModal/ContactFormModal.tsx
@@ -329,18 +329,14 @@ const ContactFormModal = ({
                 formTypeArea.items &&
                 formTypeArea.items.length > 0 && (
                   <Fieldset className="contact-form-modal__formtype">
-                    {(teaserText || teaserHeading) && (
+                    <Fieldset.Legend>
+                      {teaserHeading ||
+                        getLabelValue(labels, 'formTypeLegend') ||
+                        headerTitle}
+                    </Fieldset.Legend>
+                    {teaserText && (
                       <Fieldset.Description>
-                        {teaserText && <RichTextArea {...teaserText} />}
-                        {teaserHeading && (
-                          <Heading
-                            as="h2"
-                            size="lg"
-                            style={{marginTop: '2rem'}}
-                          >
-                            {teaserHeading}
-                          </Heading>
-                        )}
+                        <RichTextArea {...teaserText} />
                       </Fieldset.Description>
                     )}
                     {formTypeArea.items.map((item: any, index: number) => (

--- a/astro-infoportal/src/Components/ContactFormModal/ContactFormTypes.ts
+++ b/astro-infoportal/src/Components/ContactFormModal/ContactFormTypes.ts
@@ -73,6 +73,11 @@ export interface ContactFormLabels {
   attachmentDelete: string;
   attachmentSizeError: string;
   attachmentExtensionError: string;
+  // Optional: screen-reader announcements when an attachment is added/removed.
+  attachmentAddedStatus?: string;
+  attachmentRemovedStatus?: string;
+  // Optional: accessible legend for the form-type radio group.
+  formTypeLegend?: string;
   submitButton: string;
   submitting: string;
   closeButton: string;

--- a/astro-infoportal/src/Components/Pages/HelpStartPage/HelpStartPage.scss
+++ b/astro-infoportal/src/Components/Pages/HelpStartPage/HelpStartPage.scss
@@ -19,6 +19,14 @@
     }
   }
 
+  // Rendered as a <ul> (semantic list of drilldown cards) but laid out as a
+  // grid, so strip the default list bullets/indentation.
+  &__drilldown-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
   &__question-section {
     margin-top: 3rem;
 

--- a/astro-infoportal/src/Components/Pages/HelpStartPage/HelpStartPage.tsx
+++ b/astro-infoportal/src/Components/Pages/HelpStartPage/HelpStartPage.tsx
@@ -52,7 +52,13 @@ const HelpStartPage = ({
               {newVersionHeading}
             </Heading>
           )}
-          <Grid color="company" spacing={3} cols={2}>
+          <Grid
+            as="ul"
+            className="help-start-page__drilldown-grid"
+            color="company"
+            spacing={3}
+            cols={2}
+          >
             {newDrilldownPages.map((page: any, idx: number) => {
               const iconName = (page as any).akselIcon;
               const IconComponent = getIcon(iconName);
@@ -81,7 +87,13 @@ const HelpStartPage = ({
               {currentVersionHeading}
             </Heading>
           )}
-          <Grid color="company" spacing={3} cols={2}>
+          <Grid
+            as="ul"
+            className="help-start-page__drilldown-grid"
+            color="company"
+            spacing={3}
+            cols={2}
+          >
             {oldDrilldownPages.map((page: any, idx: number) => {
               const iconName = (page as any).akselIcon;
               const IconComponent = getIcon(iconName);

--- a/umbraco-infoportal/MarkupFilter.cs
+++ b/umbraco-infoportal/MarkupFilter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Text.Json;
+using Infoportal.RichText;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PublishedCache;
@@ -32,6 +33,9 @@ public class MarkupFilter
         markup = ReplaceImages(markup);
         markup = ReplaceInternalLinks(markup);
         markup = ReplaceLegacyLinks(markup);
+        // Accessibility normalisation: collapse stacked <br> and wrap loose link
+        // runs in a <ul>, after internal links/media have been resolved to URLs.
+        markup = RichTextNormalizer.Normalize(markup);
         return markup;
     }
 

--- a/umbraco-infoportal/umbraco-infoportal.csproj
+++ b/umbraco-infoportal/umbraco-infoportal.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Adapters\Infoportal.Adapters.Elasticsearch\Infoportal.Adapters.Elasticsearch.csproj" />
     <ProjectReference Include="..\Adapters\Infoportal.Adapters.Cloudflare\Infoportal.Adapters.Cloudflare.csproj" />
+    <ProjectReference Include="..\Infoportal.RichText\Infoportal.RichText.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/umbraco-infoportal/umbraco-infoportal.sln
+++ b/umbraco-infoportal/umbraco-infoportal.sln
@@ -11,6 +11,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infoportal.Adapters.Elastic
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infoportal.Adapters.Cloudflare", "..\Adapters\Infoportal.Adapters.Cloudflare\Infoportal.Adapters.Cloudflare.csproj", "{99F1F05B-CBC4-429E-BB32-55CD474358EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infoportal.RichText", "..\Infoportal.RichText\Infoportal.RichText.csproj", "{B44A1503-7DE0-4657-863B-3AE4A571DC33}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infoportal.RichText.Tests", "..\Infoportal.RichText.Tests\Infoportal.RichText.Tests.csproj", "{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +61,30 @@ Global
 		{99F1F05B-CBC4-429E-BB32-55CD474358EE}.Release|x64.Build.0 = Release|Any CPU
 		{99F1F05B-CBC4-429E-BB32-55CD474358EE}.Release|x86.ActiveCfg = Release|Any CPU
 		{99F1F05B-CBC4-429E-BB32-55CD474358EE}.Release|x86.Build.0 = Release|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Debug|x64.Build.0 = Debug|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Debug|x86.Build.0 = Debug|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Release|x64.ActiveCfg = Release|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Release|x64.Build.0 = Release|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Release|x86.ActiveCfg = Release|Any CPU
+		{B44A1503-7DE0-4657-863B-3AE4A571DC33}.Release|x86.Build.0 = Release|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Release|x64.Build.0 = Release|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB488F4E-C6FC-4C1B-8031-9A8559E21E24}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Closes #331

Retter funnene fra UU-testingen på hjelpesiden (`/hjelp/`) og kontaktskjemaet.
Rettingene er fordelt på to stacker: presentasjons-/oppførselsrettinger i
`astro-infoportal`, og korrekt rich-text-HTML i `umbraco-infoportal` slik at
Delivery API-et returnerer semantisk korrekt HTML for alle konsumenter.

### Funn som er rettet
| # | Alvorlighet | Retting | Hvor |
|---|-------------|---------|------|
| 1 | Kritisk | Hjelpekortene var `<li>` uten `<ul>`-forelder → `<Grid as="ul">` (listesemantikk, samme grid-layout) | astro `HelpStartPage` |
| 2 | Bør fikses | Løse lenker adskilt av `<br>` pakkes i `<ul><li>` | Umbraco `RichTextNormalizer` |
| 3 | Bør fikses | `<fieldset>` for skjematype manglet `<legend>` → lagt til (bruker `teaserHeading`) | astro `ContactFormModal` |
| 4 | Ikke kritisk | Stablede `<br><br>` (leses opp som «blank») slås sammen til én `<br>` | Umbraco `RichTextNormalizer` |
| 5 | Litt kritisk | Skjermleser mistet fokus ved opplasting/sletting av vedlegg → fokus flyttes til kontrollen som erstatter, + `aria-live`-varsling | astro `ContactForm` |

### Endringer
**astro-infoportal**
- `HelpStartPage.tsx` / `.scss` — `<Grid as="ul">` + nullstilling av liste-styling (`#1`)
- `ContactFormModal.tsx` — `Fieldset.Legend` på skjematype-gruppa (`#3`)
- `ContactForm.tsx`, `ContactFormModal.scss`, `ContactFormTypes.ts` — fokushåndtering for vedlegg + visuelt skjult live-region (`#5`)

**umbraco-infoportal**
- Nytt klassebibliotek `Infoportal.RichText` (AngleSharp): `RichTextNormalizer.Normalize()` slår sammen `<br>`-kjeder (`#4`) og pakker løse lenker i `<ul>` (`#2`). Har en vakt som lar innhold uten noe å normalisere være byte-for-byte uendret.
- `MarkupFilter.FilterMarkup()` kaller den etter at interne lenker/media er løst opp, så den kjører på all rich-text som Delivery API-et returnerer.
- Nytt testprosjekt `Infoportal.RichText.Tests` (xUnit) — 11 tester; prosjekt + referanse lagt til i solution-fila.

### Hvorfor `#2`/`#4` ligger i Umbraco
Dette handler om korrekt innhold (ikke designsystem), så det hører hjemme ved kilden — Delivery API-utdataen blir korrekt for alle konsumenter, sammen med de eksisterende `MarkupFilter`-omskrivingene for lenker/media. Designsystem-styling (`ds-link`, `ds-table`, overskriftsankere) blir værende i astro.

### Testing
- C#-enhetstester (TDD): 11/11 grønne — dekker stablede `<br>`, lenker adskilt av `<br>`, inline-lenker i `<p>`, eksisterende lister, og byte-identitet-vakten.
- Umbraco-bygg: 0 feil. astro-bygg: rent.
- `#1`/`#3`/`#5` verifisert i nettleser mot `/hjelp/` (drilldown-gridet er en `<ul>`, skjematype-fieldset har `<legend>`, fokus flyttes til slett-/opplastingsknapp ved opplasting/sletting).

### Merknader
- `#2` pakker konservativt kun løse lenker adskilt av `<br>` i blokk-containere; lenker som er skrevet én-per-`<p>` røres ikke (en `<ul>` inni `<p>` ville vært ugyldig).
- Statustekstene for vedlegg (`attachmentAddedStatus` / `attachmentRemovedStatus`) faller tilbake til engelsk; legg inn oversatte verdier i Umbraco for nb/nn/en.