### PR TITLE
fix(uu): tomme overskrifter og tom tabelloverskrift

### DIFF
--- a/astro-infoportal/package-lock.json
+++ b/astro-infoportal/package-lock.json
@@ -39,6 +39,7 @@
         "sass": "^1.101.0",
         "storybook": "^10.4.4",
         "typescript": "^6.0.3",
+        "vitest": "^4.1.9",
         "wrangler": "^4.100.0"
       }
     },
@@ -6447,6 +6448,13 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@storybook/addon-docs": {
       "version": "10.4.4",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.4.tgz",
@@ -6990,6 +6998,53 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/@vitest/pretty-format": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
@@ -7001,6 +7056,112 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/spy": {
@@ -8338,6 +8499,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -11996,6 +12167,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12072,6 +12250,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/storybook": {
       "version": "10.4.4",
@@ -12320,6 +12512,13 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -13002,6 +13201,172 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -13026,6 +13391,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/astro-infoportal/package.json
+++ b/astro-infoportal/package.json
@@ -8,7 +8,9 @@
     "build": "npm run clean && astro build",
     "dev": "astro dev",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@altinn/altinn-components": "^0.67.12",
@@ -42,6 +44,7 @@
     "sass": "^1.101.0",
     "storybook": "^10.4.4",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.9",
     "wrangler": "^4.100.0"
   },
   "overrides": {

--- a/astro-infoportal/src/Components/Blocks/CompareBlock/CompareBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/CompareBlock/CompareBlock.tsx
@@ -19,12 +19,12 @@ const CompareBlock = ({
 
   return (
     <div className="a-compare-category">
-      <h2>{heading || ""}</h2>
+      {heading && <h2>{heading}</h2>}
       <div className="row">
         {hasColumn1 && (
           <div className="a-compare-container col-xs-6 col-md col-max-4">
             <div className="a-compare-element">
-              <h3>{compareHeading1 || ""}</h3>
+              {compareHeading1 && <h3>{compareHeading1}</h3>}
               {compareText1 && <RichTextArea {...compareText1} />}
             </div>
           </div>
@@ -32,7 +32,7 @@ const CompareBlock = ({
         {hasColumn2 && (
           <div className="a-compare-container col-xs-6 col-md col-max-4">
             <div className="a-compare-element">
-              <h3>{compareHeading2 || ""}</h3>
+              {compareHeading2 && <h3>{compareHeading2}</h3>}
               {compareText2 && <RichTextArea {...compareText2} />}
             </div>
           </div>
@@ -40,7 +40,7 @@ const CompareBlock = ({
         {hasColumn3 && (
           <div className="a-compare-container col-xs-6 col-md col-max-4">
             <div className="a-compare-element">
-              <h3>{compareHeading3 || ""}</h3>
+              {compareHeading3 && <h3>{compareHeading3}</h3>}
               {compareText3 && <RichTextArea {...compareText3} />}
             </div>
           </div>
@@ -48,7 +48,7 @@ const CompareBlock = ({
         {hasColumn4 && (
           <div className="a-compare-container col-xs-6 col-md col-max-4">
             <div className="a-compare-element">
-              <h3>{compareHeading4 || ""}</h3>
+              {compareHeading4 && <h3>{compareHeading4}</h3>}
               {compareText4 && <RichTextArea {...compareText4} />}
             </div>
           </div>

--- a/astro-infoportal/src/Components/Blocks/ContactFormTextBlock/ContactFormTextBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/ContactFormTextBlock/ContactFormTextBlock.tsx
@@ -8,7 +8,7 @@ const ContactFormTextBlock = ({
 }: any) => {
   return (
     <div className="tab-pane contact-form-text-block" id={heading?.replace(/\s/g, "") || ""} role="tabpanel">
-      <h3 className="a-h2">{contactHeading || ""}</h3>
+      {contactHeading && <h3 className="a-h2">{contactHeading}</h3>}
       {teaserText && <RichTextArea {...teaserText} />}
     </div>
   );

--- a/astro-infoportal/src/Components/Blocks/ProviderContactInformationBlock/ProviderContactInformationBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/ProviderContactInformationBlock/ProviderContactInformationBlock.tsx
@@ -59,10 +59,12 @@ const ProviderContactInformationBlock = ({
   return (
     <div className="provider-contact-info">
       <ContactCard items={items}>
-        <Heading size="lg" as="h2" className="provider-contact-info__heading">
-          {providerAvatar && <ListItemIcon icon={providerAvatar} />}
-          {pageName || ""}
-        </Heading>
+        {(pageName || providerAvatar) && (
+          <Heading size="lg" as="h2" className="provider-contact-info__heading">
+            {providerAvatar && <ListItemIcon icon={providerAvatar} />}
+            {pageName || ""}
+          </Heading>
+        )}
 
         {body && (
           <div className="provider-contact-info__body">

--- a/astro-infoportal/src/Components/Blocks/SubscriptionBlock/SubscriptionBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/SubscriptionBlock/SubscriptionBlock.tsx
@@ -28,7 +28,7 @@ const SubscriptionBlock = ({
           alt=""
         />
         <div className="a-cardImage-text">
-          <h2>{title || ''}</h2>
+          {title && <h2>{title}</h2>}
           <p>{ingress || ''}</p>
 
           <form

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.scss
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.scss
@@ -2,6 +2,15 @@ body {
   margin: 0;
 }
 
+/* Accessibility safety net (issue #530): never expose an empty heading to
+   screen readers. Components should avoid rendering headings without text, but
+   this also covers third-party components (e.g. the warning Alert) that always
+   render their heading element. Headings containing an icon/image are not
+   :empty, so they are unaffected. */
+:is(h1, h2, h3, h4, h5, h6):empty {
+  display: none;
+}
+
 /* Sidebar selected item styling */
 .selected {
   font-weight: bold;

--- a/astro-infoportal/src/Components/Pages/SchemaPage/SchemaPage.tsx
+++ b/astro-infoportal/src/Components/Pages/SchemaPage/SchemaPage.tsx
@@ -133,7 +133,12 @@ const SchemaPage = ({
         {(Boolean(orangeMessageTitle?.trim()) ||
           (orangeMessage?.items?.length ?? 0) > 0) && (
           <Section margin="section">
-            <Alert variant="warning" heading={orangeMessageTitle ?? ""}>
+            {/* Alert always renders its heading element; normalise a blank
+                title to "" so the empty-heading CSS net (#530) hides it. */}
+            <Alert
+              variant="warning"
+              heading={orangeMessageTitle?.trim() ? orangeMessageTitle : ""}
+            >
               <RichTextArea {...orangeMessage} />
             </Alert>
           </Section>

--- a/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.test.ts
+++ b/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { transformRichTextHtml } from "./htmlTransforms";
+
+const transform = (html: string) =>
+  transformRichTextHtml(html, {
+    usedIds: new Set<string>(),
+    addAnchors: false,
+  });
+
+const count = (html: string, re: RegExp) => html.match(re)?.length ?? 0;
+const emptyThCount = (html: string) => count(html, /<th[^>]*>\s*<\/th>/gi);
+const thCount = (html: string) => count(html, /<th[\s>]/gi);
+
+describe("rewriteTables: empty header cells (issue #530)", () => {
+  it("keeps an empty first-row corner cell as <td> instead of an empty <th>", () => {
+    const out = transform(
+      "<table><tbody>" +
+        "<tr><td></td><td>Frilanser</td><td>Selvstendig</td></tr>" +
+        "<tr><td>Krav</td><td>Nei</td><td>Ja</td></tr>" +
+        "</tbody></table>",
+    );
+    expect(out).toContain("<thead>");
+    expect(emptyThCount(out)).toBe(0);
+    // the two non-empty header cells are promoted; the empty corner is not
+    expect(thCount(out)).toBe(2);
+  });
+
+  it('adds scope="col" to promoted header cells', () => {
+    const out = transform(
+      "<table><tbody>" +
+        "<tr><td>A</td><td>B</td></tr>" +
+        "<tr><td>1</td><td>2</td></tr>" +
+        "</tbody></table>",
+    );
+    expect(thCount(out)).toBe(2);
+    expect(emptyThCount(out)).toBe(0);
+    expect(count(out, /scope="col"/g)).toBe(2);
+  });
+
+  it("downgrades an authored empty <th> to <td>", () => {
+    const out = transform(
+      "<table><thead><tr><th></th><th>A</th></tr></thead>" +
+        "<tbody><tr><td>x</td><td>y</td></tr></tbody></table>",
+    );
+    expect(emptyThCount(out)).toBe(0);
+    expect(thCount(out)).toBe(1);
+  });
+
+  it("still tags the table with ds-table", () => {
+    const out = transform(
+      "<table><tbody><tr><td>A</td></tr><tr><td>1</td></tr></tbody></table>",
+    );
+    expect(out).toContain("ds-table");
+  });
+});

--- a/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.ts
+++ b/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.ts
@@ -109,6 +109,27 @@ function rewriteTables(root: HTMLElement): void {
     }
 
     promoteFirstRowToHeader(table);
+    downgradeEmptyHeaders(table);
+  }
+}
+
+// A <th> with no text/media is an empty table header (WCAG violation, issue
+// #530). It's not a real header, so downgrade it to a <td>.
+function cellIsEmpty(cell: HTMLElement): boolean {
+  if (cell.querySelector("img, svg, picture, video, iframe")) return false;
+  return !(cell.textContent ?? "").trim();
+}
+
+function downgradeEmptyHeaders(table: HTMLElement): void {
+  for (const th of table.querySelectorAll("th")) {
+    if (!cellIsEmpty(th)) continue;
+    const attrString = Object.entries(th.attributes)
+      .filter(([k]) => k.toLowerCase() !== "scope")
+      .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
+      .join(" ");
+    const td = parse(`<td${attrString ? " " + attrString : ""}></td>`)
+      .firstChild as HTMLElement;
+    th.replaceWith(td);
   }
 }
 
@@ -130,13 +151,21 @@ function promoteFirstRowToHeader(table: HTMLElement): void {
     (n) => (n as HTMLElement).tagName?.toLowerCase() === "td",
   ) as HTMLElement[];
   for (const td of cells) {
+    // Leave blank corner/spacer cells as <td>; an empty <th> is a WCAG
+    // violation (issue #530) and a blank cell isn't a real column header.
+    if (cellIsEmpty(td)) continue;
     const attrs = td.attributes;
     const inner = td.innerHTML;
+    const hasScope = Object.keys(attrs).some(
+      (k) => k.toLowerCase() === "scope",
+    );
     const attrString = Object.entries(attrs)
       .map(([k, v]) => `${k}="${escapeAttr(v)}"`)
       .join(" ");
-    const th = parse(`<th${attrString ? " " + attrString : ""}>${inner}</th>`)
-      .firstChild as HTMLElement;
+    const scopeAttr = hasScope ? "" : ' scope="col"';
+    const th = parse(
+      `<th${scopeAttr}${attrString ? " " + attrString : ""}>${inner}</th>`,
+    ).firstChild as HTMLElement;
     td.replaceWith(th);
   }
 

--- a/astro-infoportal/vitest.config.ts
+++ b/astro-infoportal/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Pure-TS unit tests (e.g. rich-text HTML transforms) run in Node.
+    environment: "node",
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
Issue: #530

Retter to kritiske UU-funn fra Frank Dahles gjennomgang.

### Funn 1 — tomme overskrifter (~408 forekomster / 382 sider)
Flere komponenter rendret et tomt `<h2>`/`<h3>` når CMS-overskriften var tom
(bl.a. det oransje `Alert`-feltet og det røsslyngfargede kontaktfeltet).
- **CSS-sikkerhetsnett:** `:is(h1..h6):empty { display: none }` i `SiteLayout.scss`
  fjerner alle tomme overskrifter fra tilgjengelighetstreet — også fra
  tredjeparts `Alert` som alltid rendrer overskriftselementet sitt.
- **Retting ved kilden:** overskrifter rendres nå kun når de har tekst i
  `ProviderContactInformationBlock`, `SubscriptionBlock`, `ContactFormTextBlock`
  og `CompareBlock`; `SchemaPage` normaliserer blank `Alert`-tittel til "".
- Muligheten for å legge inn overskrifter beholdes (jf. kommentar i issue).

### Funn 2 — tom tabelloverskrift
Førsterad-promoteringen i `htmlTransforms.ts` lagde en tom `<th>` av et blankt
hjørnefelt. Nå: blanke hjørnefelt forblir `<td>`, ekte kolonneoverskrifter får
`scope="col"`, og evt. tomme `<th>` degraderes til `<td>`.

### Testing
- Vitest (TDD), 4/4 grønne — dekker tomt hjørnefelt, `scope="col"`, og
  degradering av forhåndsskrevet tom `<th>`.
- astro-bygg rent. Verifisert i nettleser: tom `<th>` → 0 på frilanser-siden,
  og CSS-nettet skjuler tomme overskrifter (men ikke overskrifter med tekst).