### PR TITLE
fix(uu): tomme lenker (heading-ankere + tomme lenker i innhold)

### DIFF
--- a/Infoportal.RichText.Tests/RichTextNormalizerTests.cs
+++ b/Infoportal.RichText.Tests/RichTextNormalizerTests.cs
@@ -102,4 +102,40 @@ public class RichTextNormalizerTests
         const string input = "<p><img src=\"a.jpg\" /> hello <b>world</b></p>";
         Assert.Equal(input, RichTextNormalizer.Normalize(input));
     }
+
+    // --- empty links (#533) ---
+
+    [Fact]
+    public void Removes_a_truly_empty_link_word_artifact()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<p>x</p><a id=\"_anchor_7\" href=\"#_msocom_7\"></a>");
+        Assert.DoesNotContain("<a", output);
+    }
+
+    [Fact]
+    public void Unwraps_a_link_that_contains_only_a_break()
+    {
+        var output = RichTextNormalizer.Normalize("<a href=\"/x\"><br></a>");
+        Assert.DoesNotContain("<a", output);
+        Assert.Contains("<br", output);
+    }
+
+    [Fact]
+    public void Keeps_a_link_that_has_text()
+    {
+        const string input = "<p>See <a href=\"/x\">link</a></p>";
+        var output = RichTextNormalizer.Normalize(input);
+        Assert.Contains(">link</a>", output);
+        // single link with text: nothing to do, returned verbatim
+        Assert.Equal(input, output);
+    }
+
+    [Fact]
+    public void Keeps_an_image_link_with_alt_text()
+    {
+        var output = RichTextNormalizer.Normalize(
+            "<a href=\"/x\"><img src=\"i.png\" alt=\"desc\"></a>");
+        Assert.Contains("<a", output);
+    }
 }

--- a/Infoportal.RichText/RichTextNormalizer.cs
+++ b/Infoportal.RichText/RichTextNormalizer.cs
@@ -23,6 +23,14 @@ public static class RichTextNormalizer
     private static readonly Regex AnchorOpenTag =
         new(@"<a[\s>]", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
+    // Matches an <a> whose content is empty or only whitespace/<br> — the common
+    // empty-link shapes (Word paste artifacts, links that lost their text).
+    private static readonly Regex EmptyLinkPattern =
+        new(
+            @"<a\b[^>]*>(?:\s|<br\s*/?>)*</a>",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled
+        );
+
     // Block-level containers where an injected <ul> is valid markup and where we
     // look for loose link runs. Deliberately excludes <p>, headings and existing
     // lists, so inline links are left untouched.
@@ -44,10 +52,13 @@ public static class RichTextNormalizer
         }
 
         // Cheap pre-check: only touch the DOM when there's something we might
-        // change (a <br> to collapse, or 2+ links to maybe wrap). Avoids
-        // reserialising the bulk of rich text that needs no normalisation.
+        // change (a <br> to collapse, 2+ links to maybe wrap, or an empty link
+        // to strip). Avoids reserialising the bulk of rich text — in particular,
+        // a single link with text is left byte-for-byte unchanged.
         var hasBreak = html.Contains("<br", StringComparison.OrdinalIgnoreCase);
-        if (!hasBreak && AnchorOpenTag.Matches(html).Count < 2)
+        var anchorCount = AnchorOpenTag.Matches(html).Count;
+        var hasEmptyLink = anchorCount > 0 && EmptyLinkPattern.IsMatch(html);
+        if (!hasBreak && anchorCount < 2 && !hasEmptyLink)
         {
             return html;
         }
@@ -59,10 +70,61 @@ public static class RichTextNormalizer
             return html;
         }
 
+        RemoveEmptyLinks(body);
         CollapseConsecutiveBreaks(body);
         WrapLooseLinkRuns(body);
 
         return body.InnerHtml;
+    }
+
+    // An <a> with no accessible name (no text, no alt'd image, no aria-label/
+    // title) is an empty link (WCAG, issue #533) — e.g. <a><br></a> or Word
+    // paste artifacts <a href="#_msocom_7"></a>. Unwrap it: keep any inner
+    // markup (so a <br> survives as a line break) and drop the link itself.
+    private static void RemoveEmptyLinks(IElement root)
+    {
+        foreach (var anchor in root.QuerySelectorAll("a").ToArray())
+        {
+            if (AnchorHasAccessibleName(anchor))
+            {
+                continue;
+            }
+
+            var parent = anchor.ParentElement;
+            if (parent is null)
+            {
+                continue;
+            }
+
+            while (anchor.FirstChild is not null)
+            {
+                parent.InsertBefore(anchor.FirstChild, anchor);
+            }
+            anchor.Remove();
+        }
+    }
+
+    private static bool AnchorHasAccessibleName(IElement anchor)
+    {
+        if (!string.IsNullOrWhiteSpace(anchor.TextContent))
+        {
+            return true;
+        }
+        if (!string.IsNullOrWhiteSpace(anchor.GetAttribute("aria-label")))
+        {
+            return true;
+        }
+        if (!string.IsNullOrWhiteSpace(anchor.GetAttribute("title")))
+        {
+            return true;
+        }
+        if (anchor.GetAttribute("aria-labelledby") is not null)
+        {
+            return true;
+        }
+        var image = anchor.QuerySelector("img");
+        return image is not null
+            && !string.IsNullOrWhiteSpace(image.GetAttribute("alt"));
     }
 
     // Editors sometimes stack <br><br> for vertical spacing. Collapse any run of

--- a/astro-infoportal/src/Components/Shared/RichText/RichText.scss
+++ b/astro-infoportal/src/Components/Shared/RichText/RichText.scss
@@ -6,49 +6,38 @@
     margin-bottom: 1.5rem;
   }
 
-  h2,
-  h3 {
+  h2 {
     position: relative;
 
+    /* Section permalink: hidden until the heading is hovered or the link is
+       focused (keyboard users), so it's unobtrusive but reachable. */
     .heading-anchor {
       position: absolute;
       left: -1.25em;
       top: 0.15em;
       display: inline-flex;
       align-items: center;
-      opacity: 0;
       color: #000;
       text-decoration: none;
+      opacity: 0;
       transition: opacity 120ms ease-in-out;
-
-      .heading-anchor__icon {
-        font-size: 0.95em;
-        line-height: 1;
-      }
     }
 
-    /* Keep anchor color black regardless of state */
-    .heading-anchor,
-    .heading-anchor:link,
-    .heading-anchor:visited,
-    .heading-anchor:hover,
-    .heading-anchor:focus {
-      color: #000;
-    }
-
-    /* Only reveal on heading hover or anchor focus/hover */
-    &:hover .heading-anchor,
     .heading-anchor:hover,
     .heading-anchor:focus,
     .heading-anchor:focus-visible {
-      opacity: 1;
+      color: #000;
     }
 
-    .heading-anchor [data-heading-icon] {
-      display: inline-flex;
-      width: 1em;
-      height: 1em;
+    .heading-anchor__icon {
+      font-size: 0.95em;
       line-height: 1;
+    }
+
+    &:hover .heading-anchor,
+    .heading-anchor:focus,
+    .heading-anchor:focus-visible {
+      opacity: 1;
     }
   }
 }

--- a/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.test.ts
+++ b/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.test.ts
@@ -53,3 +53,49 @@ describe("rewriteTables: empty header cells (issue #530)", () => {
     expect(out).toContain("ds-table");
   });
 });
+
+describe("accessible heading section anchors (issue #533)", () => {
+  const transformWithAnchors = (html: string) =>
+    transformRichTextHtml(html, {
+      usedIds: new Set<string>(),
+      addAnchors: true,
+      anchorLabel: "Lenke til seksjonen",
+    });
+
+  const firstAnchorTag = (html: string) => html.match(/<a\b[^>]*>/)?.[0] ?? "";
+
+  it("assigns a slug id to the heading", () => {
+    expect(transformWithAnchors("<h2>Skatt</h2>")).toContain('id="skatt"');
+  });
+
+  it("adds a labelled, focusable anchor that is not empty or aria-hidden", () => {
+    const a = firstAnchorTag(transformWithAnchors("<h2>Skatt</h2>"));
+    expect(a).toContain('class="heading-anchor"');
+    expect(a).toContain('href="#skatt"');
+    expect(a).toContain('aria-label="Lenke til seksjonen Skatt"');
+    expect(a).not.toContain("aria-hidden"); // the <a> stays in the a11y tree
+    expect(a).not.toContain('tabindex="-1"'); // keyboard-accessible
+  });
+
+  it("keeps the decorative icon aria-hidden", () => {
+    expect(transformWithAnchors("<h2>Skatt</h2>")).toContain(
+      'class="heading-anchor__icon" aria-hidden="true"',
+    );
+  });
+
+  it("escapes quotes in the aria-label", () => {
+    const a = firstAnchorTag(transformWithAnchors('<h2>Skatt "x"</h2>'));
+    expect(a).toContain("&quot;");
+    expect(a).not.toContain('"x"');
+  });
+
+  it("does not add an anchor to an empty heading", () => {
+    expect(transformWithAnchors("<h2></h2>")).not.toContain("heading-anchor");
+  });
+
+  it("keeps ids unique across repeated heading text", () => {
+    const out = transformWithAnchors("<h2>Skatt</h2><h2>Skatt</h2>");
+    expect(out).toContain('id="skatt"');
+    expect(out).toContain('id="skatt-2"');
+  });
+});

--- a/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.ts
+++ b/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.ts
@@ -6,6 +6,9 @@ const LINK_ICON_SVG =
 export interface RichTextTransformOptions {
   usedIds: Set<string>;
   addAnchors: boolean;
+  // Localized prefix for the heading permalink's accessible name, e.g.
+  // "Lenke til seksjonen" → aria-label "Lenke til seksjonen {heading}".
+  anchorLabel?: string;
 }
 
 export function transformRichTextHtml(
@@ -17,7 +20,7 @@ export function transformRichTextHtml(
   const root = parse(html);
 
   if (options.addAnchors) {
-    addHeadingAnchors(root, options.usedIds);
+    addHeadingAnchors(root, options.usedIds, options.anchorLabel ?? "");
   }
   rewriteTables(root);
   rewriteLinks(root);
@@ -44,10 +47,18 @@ export function walkAndTransformRichText(node: unknown): void {
   // present at a few sites); `addAnchors` is read from the container.
   if ("items" in node && Array.isArray(node.items)) {
     const addAnchors = "addAnchors" in node && node.addAnchors === true;
+    const anchorLabel =
+      "anchorLabel" in node && typeof node.anchorLabel === "string"
+        ? node.anchorLabel
+        : undefined;
     const usedIds = new Set<string>();
     for (const item of node.items) {
       if (isRichTextItem(item)) {
-        item.html = transformRichTextHtml(item.html, { usedIds, addAnchors });
+        item.html = transformRichTextHtml(item.html, {
+          usedIds,
+          addAnchors,
+          anchorLabel,
+        });
       }
     }
   }
@@ -70,25 +81,37 @@ function isRichTextItem(
   );
 }
 
-function addHeadingAnchors(root: HTMLElement, usedIds: Set<string>): void {
-  const headings = root.querySelectorAll("h2");
-  for (const h of headings) {
-    let id = h.getAttribute("id");
-    if (id?.trim()) {
+// Gives every <h2> a stable slug `id` (so #section deep-links work) and a
+// "permalink" anchor for editors. The anchor is a real, keyboard-focusable,
+// labelled link — NOT an empty/aria-hidden one — so it doesn't trip the WCAG
+// "empty link" / "aria-hidden on focusable" checks (issue #533). Only the
+// decorative icon inside is aria-hidden.
+function addHeadingAnchors(
+  root: HTMLElement,
+  usedIds: Set<string>,
+  anchorLabel: string,
+): void {
+  for (const h of root.querySelectorAll("h2")) {
+    let id = h.getAttribute("id")?.trim() || "";
+    if (id) {
       usedIds.add(id);
     } else {
-      const text = decodeEntities(h.textContent ?? "");
-      id = makeUniqueSlug(slugify(text), usedIds);
+      id = makeUniqueSlug(
+        slugify(decodeEntities(h.textContent ?? "")),
+        usedIds,
+      );
       h.setAttribute("id", id);
     }
 
-    const hasAnchor =
-      h.querySelector("a.heading-anchor") !== null ||
-      h.innerHTML.includes("heading-anchor");
-    if (hasAnchor) continue;
+    const text = decodeEntities(h.textContent ?? "").trim();
+    // Don't anchor an empty heading (#530), and don't double-add.
+    if (!text || h.querySelector("a.heading-anchor")) continue;
 
-    const anchorHtml = `<a class="heading-anchor" href="#${id}" aria-hidden="true" tabindex="-1"><span class="heading-anchor__icon" aria-hidden="true">${LINK_ICON_SVG}</span></a>`;
-    h.insertAdjacentHTML("afterbegin", anchorHtml);
+    const label = escapeAttr(`${anchorLabel} ${text}`.trim());
+    h.insertAdjacentHTML(
+      "afterbegin",
+      `<a class="heading-anchor" href="#${id}" aria-label="${label}"><span class="heading-anchor__icon" aria-hidden="true">${LINK_ICON_SVG}</span></a>`,
+    );
   }
 }
 
@@ -178,6 +201,7 @@ function rewriteLinks(root: HTMLElement): void {
   const links = root.querySelectorAll("a");
   for (const link of links) {
     const classes = splitClasses(link.getAttribute("class"));
+    // The heading permalink is a special icon link, not a content link.
     if (classes.some((c) => c.toLowerCase() === "heading-anchor")) continue;
 
     if (!classes.some((c) => c.toLowerCase() === "ds-link")) {

--- a/astro-infoportal/src/Components/Shared/RichTextArea/RichTextArea.types.ts
+++ b/astro-infoportal/src/Components/Shared/RichTextArea/RichTextArea.types.ts
@@ -6,4 +6,5 @@ export interface RichTextAreaItem {
 export interface RichTextAreaProps {
   items: RichTextAreaItem[];
   addAnchors?: boolean;
+  anchorLabel?: string;
 }

--- a/astro-infoportal/src/i18n/locales/en.json
+++ b/astro-infoportal/src/i18n/locales/en.json
@@ -5,6 +5,7 @@
   "common.nextStep": "Next step",
   "common.clickHere": "Click here",
   "common.lastUpdated": "Last updated",
+  "common.linkToSection": "Link to section",
   "common.and": "and",
   "common.to": "To",
   "common.from": "From",

--- a/astro-infoportal/src/i18n/locales/nb.json
+++ b/astro-infoportal/src/i18n/locales/nb.json
@@ -5,6 +5,7 @@
   "common.nextStep": "Gå videre",
   "common.clickHere": "Klikk her",
   "common.lastUpdated": "Sist oppdatert",
+  "common.linkToSection": "Lenke til seksjonen",
   "common.and": "og",
   "common.to": "Til",
   "common.from": "Fra",

--- a/astro-infoportal/src/i18n/locales/nn.json
+++ b/astro-infoportal/src/i18n/locales/nn.json
@@ -5,6 +5,7 @@
   "common.nextStep": "Gå videre",
   "common.clickHere": "Klikk her",
   "common.lastUpdated": "Sist oppdatert",
+  "common.linkToSection": "Lenke til seksjonen",
   "common.and": "og",
   "common.to": "Til",
   "common.from": "Frå",

--- a/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
+++ b/astro-infoportal/src/transformers/HeroArticlePageBaseTransformer.ts
@@ -85,7 +85,13 @@ export class HeroArticlePageBaseTransformer implements IJSONTransformer {
       pageName: cmsPageData.name,
       articlePageHero: {},
       mainIntro: props.mainIntro,
-      mainBody: mainBody ? { ...mainBody, addAnchors: true } : mainBody,
+      mainBody: mainBody
+        ? {
+            ...mainBody,
+            addAnchors: true,
+            anchorLabel: t("common.linkToSection", locale),
+          }
+        : mainBody,
       breadcrumb,
       lastUpdatedDateText: lastUpdatedDateString ? t("common.lastUpdated", locale) : undefined,
       lastUpdatedDateString,

--- a/astro-infoportal/src/transformers/SubsidyPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SubsidyPageTransformer.ts
@@ -34,7 +34,13 @@ export class SubsidyPageTransformer implements IJSONTransformer {
       componentName: "SubsidyPage",
       pageName: cmsPageData.name,
       mainIntro: props.mainIntro || undefined,
-      mainBody: mainBody ? { ...mainBody, addAnchors: true } : undefined,
+      mainBody: mainBody
+        ? {
+            ...mainBody,
+            addAnchors: true,
+            anchorLabel: t("common.linkToSection", locale),
+          }
+        : undefined,
       timeline: props.timeline || [],
       breadcrumb,
       lastUpdatedDateText,


### PR DESCRIPTION
Issue #533

Retter det kritiske WCAG-funnet om tomme lenker på AS-siden og mange andre
sider. To årsaker, rettet hver for seg.

### Heading-ankere — beholdt, men gjort tilgjengelige
`addHeadingAnchors` la inn en tom, `aria-hidden`-lenke med kun et ikon foran
hver `<h2>` — flagget som «empty link» (og `aria-hidden` på et fokuserbart
element) på alle sider med ankerlenker.

Redaktørene bruker disse ankrene til å hente lenker til seksjoner, så de er
**beholdt og gjort tilgjengelige** i stedet for fjernet:
- Lenken har nå et tilgjengelig navn: `aria-label="Lenke til seksjonen
  {overskrift}"` (lokalisert via ny nøkkel `common.linkToSection`, nb/nn/en),
  satt av `HeroArticlePageBaseTransformer` og `SubsidyPageTransformer`.
- `aria-hidden` fjernet fra `<a>`, og lenken er **tastaturfokuserbar** (ikke
  lenger `tabindex="-1"`); kun det dekorative ikonet er `aria-hidden`.
- Ankeret er skjult til overskriften har hover eller lenken har fokus, så det
  er diskré men tilgjengelig.
- Overskrifter får fortsatt en slug-`id`, så `#seksjon`-dyplenker virker.

### Tomme lenker i innhold (Umbraco `RichTextNormalizer`)
Redaksjonelt innhold inneholdt tomme lenker — `<a><br></a>` og Word-artefakter
(`<a href="#_msocom_7"></a>`).
- Ny `RemoveEmptyLinks`: pakker ut enhver `<a>` uten tilgjengelig navn (ingen
  tekst, ingen bilde med alt, ingen `aria-label`/`title`), beholder innholdet
  (en `<br>` overlever, tomme Word-ankere forsvinner).
- Pre-sjekken utvidet slik at enkeltstående tomme lenker fanges, mens en
  enkelt lenke *med* tekst fortsatt returneres byte-for-byte uendret.

### Testing
- Vitest 10/10 (6 nye anker-tester + 4 tabelltester) og xUnit 15/15 (4 nye
  tomme-lenke-tester), alle TDD (RED → GREEN).
- astro-bygg rent, lint/format rent.
- Verifisert i nettleser på AS-siden: 12 heading-ankere er nå merket
  (`aria-label`), ikke `aria-hidden` og tastaturfokuserbare; tomme lenker
  15 → 3 (de 3 gjenværende kommer fra det eksterne Delivery API-et og er
  mønstrene Umbraco-rettingen fjerner ved deploy); overskrifter beholder `id`.