### PR TITLE
fix(uu): html lang fallback

### DIFF
--- a/astro-infoportal/src/pages/404.astro
+++ b/astro-infoportal/src/pages/404.astro
@@ -29,8 +29,13 @@ const globalData: any = getGlobalData(
   umbracoPageData?.contentType,
 );
 
+// Use the effective content language for <html lang> (an NB-only error page
+// served at /en/ falls back to nb content), not the URL locale (issue #494).
+const contentLocale: Locale =
+  umbracoPageData?.cultures && umbracoPageData.cultures[locale] ? locale : "nb";
+
 const pageData = await new JSONTransformer().Transform(umbracoPageData, globalData);
-const metadata = buildMetadata(umbracoPageData, locale);
+const metadata = buildMetadata(umbracoPageData, contentLocale);
 
 Astro.response.status = 404;
 Astro.response.headers.set("Cache-Control", pageCacheControl(Astro.url.hostname));

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -133,7 +133,10 @@ globalData = {
 
 const pageData = await new JSONTransformer().Transform(umbracoPageData, globalData);
 const metadata = {
-  ...buildMetadata(umbracoPageData, locale),
+  // Drive <html lang> from the effective content language, not the URL locale:
+  // an NB-only page served at /en/ falls back to nb content, so lang must be nb
+  // to match the actual text a screen reader reads (issue #494 follow-up).
+  ...buildMetadata(umbracoPageData, contentLocale),
   ...(isLocaleRoot ? { title: "Altinn - Start" } : {}),
 };
 


### PR DESCRIPTION
Issue #494

`<html lang>` ble satt fra URL-locale i stedet for det faktiske innholdsspråket.
Når en side bare finnes på bokmål, men åpnes på en `/en/`- eller `/nn/`-URL,
faller Umbraco Delivery API tilbake til nb-innhold — men siden fikk likevel
`lang="en"`/`lang="nn"`. Skjermlesere leste da norsk tekst (f.eks. overskriften
«Be om fullmakt») med engelsk uttale. Hele `/hjelp/*`-seksjonen (kun bokmål) var
rammet under `/en/`.

(Selve hovedfeilen i #494 — at `lang` ble stående på `nb` ved språkbytte — ble
allerede rettet i #103. Denne PR-en tar det gjenstående fallback-tilfellet.)

### Endring
`<html lang>` settes nå fra `contentLocale` (det effektive innholdsspråket) i
stedet for URL-`locale`:
- `src/pages/[...slug].astro` — `buildMetadata(umbracoPageData, contentLocale)`
- `src/pages/404.astro` — beregner `contentLocale` og bruker den

For fullt oversatte sider er `contentLocale === locale`, så de er uendret.
Tittel/meta hentes uansett fra det hentede innholdet, så dette er konsistent.

### Testing
- `npm run build` rent.
- Verifisert i nettleser (9 URL-er):
  - nb-fallback under `/en/` og `/nn/` (`/hjelp/.../be-om-fullmakt/`):
    `en`/`nn` → **`nb`** (matcher overskriften «Be om fullmakt»).
  - Oversatte sider uendret: `/en/.../freelancers/` = `en`, `/`/`/en/`/`/nn/`
    = `nb`/`en`/`nn`, `/en/search` = `en`, nb-innhold = `nb`.

### Avgrensning
Den engelske «chrome-en» (header/footer) på fallback-sider bør ideelt merkes
med `lang="en"` via *Language of Parts* — det hører hjemme i altinn-components, ikke her.