### PR TITLE
fix(uu): empty header in maintanace warning

### DIFF
--- a/astro-infoportal/src/Components/Pages/SchemaAttachmentPage/SchemaAttachmentPage.tsx
+++ b/astro-infoportal/src/Components/Pages/SchemaAttachmentPage/SchemaAttachmentPage.tsx
@@ -80,7 +80,10 @@ const SchemaAttachmentPage = ({
 
       {orangeMessage && (
         <Section margin="section">
-          <Alert variant="warning" heading={orangeMessageTitle ?? ""}>
+          <Alert
+            variant="warning"
+            heading={orangeMessageTitle?.trim() ? orangeMessageTitle : ""}
+          >
             <RichTextArea {...orangeMessage} />
           </Alert>
         </Section>

--- a/astro-infoportal/src/Components/Shared/OperationalMessage/OperationalMessage.tsx
+++ b/astro-infoportal/src/Components/Shared/OperationalMessage/OperationalMessage.tsx
@@ -11,13 +11,12 @@ const OperationalMessage = ({
 }: any) => {
   const variant = colorVariant || (isCritical ? "danger" : "warning");
   const body = message ?? mainBody ?? "";
+  // Alert always renders its heading as an <h2>; normalise blank/whitespace/
+  // &nbsp; titles to "" so the empty-heading CSS net hides it (issue #530).
+  const heading = (pageName ?? "").trim();
 
   return (
-    <Alert
-      variant={variant}
-      heading={pageName || ""}
-      message={body}
-    >
+    <Alert variant={variant} heading={heading} message={body}>
       {url && urlText && <a href={url}>{urlText}</a>}
     </Alert>
   );


### PR DESCRIPTION
Issue: https://github.com/Altinn/info.altinn.no/issues/530

Oppfølging av tilbakemelding på #530: tabelloverskrift er OK, men overskrifta i
driftsvarsel (i skjemakatalogen) viste fortsatt feil.

### Årsak
`altinn-components` sin `Alert` rendrar alltid eit `<h2>` for `heading`.
CSS-nettet frå #530 (`:is(h1..h6):empty { display: none }`) skjuler berre
*heilt tomme* overskrifter — ein overskrift med berre mellomrom/`&nbsp;` er
ikkje `:empty` og blei difor verande synleg/flagga. `OperationalMessage`
(komponenten bak alle driftsvarsel) brukte `heading={pageName || ""}`, og `||`
fjernar berre falsy-verdiar, ikkje mellomrom. (#530 retta SchemaPage sin *andre*
Alert, ikkje denne.)

### Endring
Normaliser overskrifta slik at tom/mellomrom/`&nbsp;` blir `""` (då fangar
CSS-nettet `<h2>`-en):
- `OperationalMessage.tsx` — `const heading = (pageName ?? "").trim();` →
  `heading={heading}` (var `heading={pageName || ""}`). Dekkjer alle sider som
  viser driftsvarsel (skjemasider/skjemakatalog, leverandør, forside, vedlegg).
- `SchemaAttachmentPage.tsx` — oransje Alert: `heading={orangeMessageTitle?.trim()
  ? orangeMessageTitle : ""}` (var `?? ""`), same mellomrom-gap.

`.trim()` fjernar både vanlege mellomrom og `&nbsp;` (U+00A0). Reelle titlar er
upåverka.

### Testing
- `npm run build` rent, Biome lint/format rent.
- Mekanismen er verifisert i nettlesar: heilt tomt `<h2>` → `display:none`,
  `<h2> </h2>`/`<h2>&nbsp;</h2>` → `block`. Rettinga gjer mellomrom-tilfellet om
  til eit heilt tomt (skjult) `<h2>`.
- Ingen aktiv driftsvarsel med tom overskrift akkurat no til å demonstrere
  ende-til-ende — endeleg verifisering er redaktør si re-skanning etter deploy.