### PR TITLE
Render self-identified (SI) users as persons in header

### DIFF
--- a/astro-infoportal/package-lock.json
+++ b/astro-infoportal/package-lock.json
@@ -8,7 +8,7 @@
       "name": "astro-infoportal",
       "version": "0.0.1",
       "dependencies": {
-        "@altinn/altinn-components": "^0.67.12",
+        "@altinn/altinn-components": "^0.68.9",
         "@astrojs/cloudflare": "^13.7.0",
         "@astrojs/react": "^5.0.7",
         "@digdir/designsystemet-css": "^1.15.0",
@@ -51,16 +51,16 @@
       "license": "MIT"
     },
     "node_modules/@altinn/altinn-components": {
-      "version": "0.67.12",
-      "resolved": "https://registry.npmjs.org/@altinn/altinn-components/-/altinn-components-0.67.12.tgz",
-      "integrity": "sha512-qGw4yojP5st8Vy7GxUIQZa8kb32BfhXfJAlg71x0OZnVdBiX5bx9AblyDGJoQMzscyRpook8NKTpEqqzsrnGUg==",
+      "version": "0.68.9",
+      "resolved": "https://registry.npmjs.org/@altinn/altinn-components/-/altinn-components-0.68.9.tgz",
+      "integrity": "sha512-29TfUNeKp3o+5tiyup4EQ07mO8LPRhqN05zJalycZn35gxyfGzBrMU9XvRI2a59gLeEtSdLQ1gg2mWx4b7XXKQ==",
       "license": "ISC",
       "dependencies": {
         "@digdir/designsystemet-css": "^1.14.0",
         "@digdir/designsystemet-react": "^1.14.0",
         "@digdir/designsystemet-theme": "^1.11.0",
         "@navikt/aksel-icons": "^8.9.0",
-        "@tanstack/react-virtual": "^3.13.9",
+        "@tanstack/react-virtual": "^3.14.2",
         "classnames": "^2.5.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -2061,9 +2061,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2081,9 +2078,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2101,9 +2095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -2121,9 +2112,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -6661,12 +6649,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.24",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
-      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.14.0"
+        "@tanstack/virtual-core": "3.17.1"
       },
       "funding": {
         "type": "github",
@@ -6678,9 +6666,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
-      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/astro-infoportal/package.json
+++ b/astro-infoportal/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@altinn/altinn-components": "^0.67.12",
+    "@altinn/altinn-components": "^0.68.9",
     "@astrojs/cloudflare": "^13.7.0",
     "@astrojs/react": "^5.0.7",
     "@digdir/designsystemet-css": "^1.15.0",

--- a/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
+++ b/astro-infoportal/src/Components/Layout/Header/useHeaderConfig.ts
@@ -21,6 +21,12 @@ const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const isValidUuid = (value: string): boolean => UUID_RE.test(value);
 
+// SI (self-identified / Altinn 2) parties have no verified name — their party
+// `name` is the login username. Render them as persons, matching
+// @altinn/altinn-components useAccountSelector (groups "SelfIdentified" with "Person").
+const isPersonType = (type: number | string | undefined): boolean =>
+  type === 1 || type === "Person" || type === 3 || type === "SelfIdentified";
+
 // Determines the visual theme for the header and layout
 const getAccountColor = (
   userType: number | string | undefined,
@@ -30,7 +36,7 @@ const getAccountColor = (
     return "company";
   }
 
-  if (userType === 1 || userType === "Person") {
+  if (isPersonType(userType)) {
     return "person";
   }
 
@@ -171,9 +177,7 @@ const useHeaderConfig = (
 
   const userType = useMemo(() => {
     if (!currentUser) return "person";
-    return currentUser.type === 1 || currentUser.type === "Person"
-      ? "person"
-      : "company";
+    return isPersonType(currentUser.type) ? "person" : "company";
   }, [currentUser]);
 
   const accountColor = useMemo(
@@ -202,7 +206,7 @@ const useHeaderConfig = (
   );
 
   const transformParty = (party: AuthorizedPartyData): LibAuthorizedParty => {
-    const isPerson = party.type === 1 || party.type === "Person";
+    const isPerson = isPersonType(party.type);
 
     return {
       partyUuid: party.partyUuid,


### PR DESCRIPTION
## Description

- Self-identified (SI / Altinn 2 self-registered) users were rendered as a **company** in the header (company icon, "Virksomheter" group, blank "Org.nr.") because `useHeaderConfig` collapsed party type `"SelfIdentified"`/`3` to `"Organization"` before the data reached `@altinn/altinn-components`.
- Added an `isPersonType()` helper that treats both `"SelfIdentified"` and numeric `3` as a person — mirroring the library's own `useAccountSelector` grouping — and routed `getAccountColor`, the `userType` memo, and `transformParty` through it. The SI self account now renders under "Personer" with the **login username** and the person theme.
- Also updates `@altinn/altinn-components` `0.67.4 -> 0.68.9` (upstream fixes, parity with the access-management frontend; React 19 peer-compatible, no documented breaking changes, build passes).

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/564
