### PR TITLE
fix: ancher/deep links scroll to section

### DIFF
--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
@@ -8,6 +8,7 @@ import useSidebarConfig from '../../Shared/PageSidebar/useSidebarConfig';
 import useFooterConfig from '../Footer/useFooterConfig';
 import useHeaderConfig from '../Header/useHeaderConfig';
 import {useLanguagePreference} from '../Header/hooks/useLanguagePreference';
+import {useHashScroll} from './useHashScroll';
 import './SiteLayout.scss';
 import {SkipLink} from '@digdir/designsystemet-react';
 import BannerBlock from '../../../Components/Blocks/BannerBlock/BannerBlock';
@@ -21,9 +22,8 @@ const SiteLayout = ({
 }: SiteLayoutProps) => {
   const Comp = child ? (Components as any)[child.componentName] : null;
 
-  // Only enable GlobalHeader on client side to avoid SSR issues
-  // const [isClient, setIsClient] = useState(false);
-  // useEffect(() => setIsClient(true), []);
+  // Scroll to a #section target on cold loads once layout has settled.
+  useHashScroll();
 
   const currentLanguage = headerViewModel?.menuLanguageList?.find(
     (l: any) => l.selected,

--- a/astro-infoportal/src/Components/Layout/SiteLayout/useHashScroll.ts
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/useHashScroll.ts
@@ -1,0 +1,78 @@
+import { useEffect } from "react";
+
+/**
+ * On a cold/first load of a `…/#section` URL, the browser's native fragment
+ * scroll fires before the React tree (rendered via `client:load`) has hydrated
+ * and the layout has settled (web-font + content reflow). It lands at the top
+ * and never retries — so the section isn't reached, even though the heading id
+ * is present in the server-rendered HTML. (Warm/cached loads happen to be fast
+ * enough to land correctly, which is why "the second paste works".)
+ *
+ * This hook re-scrolls to the hash target once the page is ready — instantly,
+ * and only on the initial load. It bails out the moment the user starts
+ * scrolling, so it never fights them.
+ */
+export function useHashScroll(): void {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const rawHash = window.location.hash;
+    if (rawHash.length < 2) return;
+
+    // Decode so percent-encoded ids (e.g. "#informasjons-og-p%C3%A5seplikt")
+    // match the heading's id ("informasjons-og-påseplikt").
+    const id = decodeURIComponent(rawHash.slice(1));
+    let active = true;
+
+    const scrollToTarget = () => {
+      if (!active) return;
+      document
+        .getElementById(id)
+        ?.scrollIntoView({ block: "start", behavior: "instant" });
+    };
+
+    // Stop auto-scrolling the instant the user takes control.
+    const stop = () => {
+      active = false;
+    };
+    const userEvents = [
+      "wheel",
+      "touchstart",
+      "keydown",
+      "pointerdown",
+    ] as const;
+    for (const evt of userEvents) {
+      window.addEventListener(evt, stop, { passive: true });
+    }
+
+    // Re-scroll on the discrete "layout probably changed" milestones.
+    const onLoad = () => scrollToTarget();
+    window.addEventListener("load", onLoad);
+    document.fonts?.ready.then(scrollToTarget).catch(() => {});
+
+    // Bounded retry to absorb hydration/layout shift right after mount.
+    const startedAt = performance.now();
+    let rafId = 0;
+    let timerId = 0;
+    const tick = () => {
+      if (!active) return;
+      scrollToTarget();
+      if (performance.now() - startedAt < 1200) {
+        timerId = window.setTimeout(() => {
+          rafId = requestAnimationFrame(tick);
+        }, 150);
+      }
+    };
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      active = false;
+      window.removeEventListener("load", onLoad);
+      for (const evt of userEvents) {
+        window.removeEventListener(evt, stop);
+      }
+      cancelAnimationFrame(rafId);
+      clearTimeout(timerId);
+    };
+  }, []);
+}

--- a/astro-infoportal/src/Components/Pages/SubCategoryPage/SubCategoryPage.scss
+++ b/astro-infoportal/src/Components/Pages/SubCategoryPage/SubCategoryPage.scss
@@ -1,7 +1,3 @@
-:root {
-    scroll-behavior: smooth;
-}
-
 .schema-link {
     color: #000000;
     text-decoration: none;


### PR DESCRIPTION
Issue: https://github.com/Altinn/info.altinn.no/issues/566

Oppfølging av ankerlenkene (heading-permalenker) fra #533. Testere meldte at
direkte-lenker til seksjoner (`…/#seksjon`) ikke fungerer: i en ny fane havner
man øverst i artikkelen i stedet for på seksjonen, mens samme lenke limt inn på
nytt i en allerede åpen fane treffer riktig.

### Årsak
Overskriftene har riktig `id` i den server-rendra HTML-en, og dokumentet er
selve scroll-containeren. Men ved en kald/første lasting kjører nettleserens
native fragment-scroll **før** React-treet (rendra via `client:load`) er
hydrert og layouten har satt seg (skrift-/innholds-reflow) — den havner øverst
og prøver aldri på nytt. Varme/hurtigbufra lastinger (og «andre innliming») er
raske nok til å treffe. To medvirkende ting:
- Det fantes **ingen klientside-fallback** for hash-scroll.
- `scroll-behavior: smooth` lakk globalt fra `SubCategoryPage.scss`
  (`:root { … }` i et ikke-scopet `.scss` → gjaldt hele nettstedet), noe som
  gjør fragment-scroll ustabilt i det ustabile kald-lasting-vinduet.

### Endring (kun klientside/CSS)
- **Ny `useHashScroll`-hook** (`SiteLayout/useHashScroll.ts`), kalt fra
  `SiteLayout`: ved første lasting scroller den til `#hash` **instant** når
  layouten er klar — med ny-scroll på `window.load` og `document.fonts.ready`
  og en begrensa retry (~1,2 s) for å absorbere hydrerings-/reflow-forskyvning.
  **Avbryter straks brukeren scroller**, så den aldri kjemper imot. Dekoder
  prosent-koda id-er (`%C3%A5` → `å`). No-op når det ikke er noen hash.
- **Fjernet den globale `scroll-behavior: smooth`-lekkasjen** fra
  `SubCategoryPage.scss` (`<html>` er tilbake til `auto`).
- `scroll-margin-top` viste seg unødvendig — ingen sticky header skjuler
  overskrifta (verifisert).

### Dekning
Lenke-ikonene finnes på fire innholdstyper: `articlePage`,
`sectionArticlePage`, `newsArticlePage` (alle via `HeroArticlePageBase`) og
`subsidyPage`. Siden fixen ligger i `SiteLayout` — som alle sider rendres i —
og `scrollIntoView` håndterer vilkårlige scroll-containere, dekkes alle.