### PR TITLE
fix: bokmaal fallback for missing english content

### DIFF
--- a/astro-infoportal/src/transformers/ProviderPageTransformer.ts
+++ b/astro-infoportal/src/transformers/ProviderPageTransformer.ts
@@ -3,10 +3,15 @@ import { ProviderResolver } from "@services/Providers/ProviderResolver";
 import {
   fetchUmbracoAncestors,
   fetchUmbracoChildren,
+  fetchUmbracoContentById,
   resolveBlockReferences,
 } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
+import {
+  buildProviderContactInfo,
+  resolvePromoAreaWithNbFallback,
+} from "./promoAreaContact";
 
 export class ProviderPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
@@ -78,43 +83,22 @@ export class ProviderPageTransformer implements IJSONTransformer {
     );
     schemas.sort((a: any, b: any) => a.title.localeCompare(b.title, locale));
 
-    // `promoArea` (editor label "Faglig brukerstøtte") is a Block List. Items
-    // wrap each block as `{ content: { contentType, properties }, settings }`
-    // with inline properties (no picker hydration needed). We map the first
-    // `formElementContactFreetext` (or legacy `formElementContact`, which has
-    // no `heading` field) block to a ProviderContactInformationBlock view-model
-    // — same shape as on schemaPage.
-    const promoBlockItems: any[] = Array.isArray(props.promoArea?.items)
-      ? props.promoArea.items
-      : [];
-    let contactInfo: any;
-    for (const wrapper of promoBlockItems) {
-      const content = wrapper?.content ?? wrapper;
-      if (
-        content?.contentType !== "formElementContactFreetext" &&
-        content?.contentType !== "formElementContact"
-      ) {
-        continue;
-      }
-      const bp = content.properties ?? {};
-      contactInfo = {
-        componentName: "ProviderContactInformationBlock",
-        body: bp.body ?? undefined,
-        bottomText: bp.bottomText ?? undefined,
-        webpageLink: bp.webpageLink ?? undefined,
-        telephone: bp.telephone ?? "",
-        telephoneLabel: bp.telephoneLabel ?? "",
-        email: bp.email ?? "",
-        emailTitle: bp.emailTitle ?? "",
-        // Editor-supplied heading wins; provider name is the fallback. The
-        // emblem only shows when the heading isn't set (matches schemaPage).
-        pageName: bp.heading || cmsPageData.name,
-        providerIcon: !bp.heading
-          ? { name: cmsPageData.name, imageUrl: providerIcon.imageUrl }
-          : undefined,
-      };
-      break;
-    }
+    // `promoArea` (editor label "Faglig brukerstøtte") is a Block List. We map
+    // the first contact block to a ProviderContactInformationBlock view-model,
+    // using the provider name + emblem as the heading fallback (the emblem only
+    // shows when the editor left the heading unset). The block is only authored
+    // on NB content, so fall back to the NB node when the localised value is
+    // empty (issue #365).
+    const promoAreaData = await resolvePromoAreaWithNbFallback(
+      cmsPageData.id,
+      props.promoArea,
+      contentLocale,
+      (id) => fetchUmbracoContentById(id, "nb"),
+    );
+    const contactInfo = buildProviderContactInfo(promoAreaData, {
+      name: cmsPageData.name,
+      imageUrl: providerIcon.imageUrl,
+    });
 
     const pageSidebarViewModel = {
       titleItem: {

--- a/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
@@ -5,11 +5,16 @@ import {
 } from "@services/Providers/ProviderResolver";
 import {
   fetchUmbracoAncestors,
+  fetchUmbracoContentById,
   resolveBlockReferences,
 } from "../api/umbraco/client";
 import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
+import {
+  buildPromoAreaContentArea,
+  resolvePromoAreaWithNbFallback,
+} from "./promoAreaContact";
 
 export class SchemaAttachmentPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
@@ -50,9 +55,21 @@ export class SchemaAttachmentPageTransformer implements IJSONTransformer {
     });
     const accordianList = props.accordianList || undefined;
 
-    const promoArea = props.promoArea
-      ? BlockTransformer.TransformBlocks(props.promoArea)
-      : undefined;
+    // promoArea ("Faglig brukerstøtte"): contact blocks must render as
+    // ProviderContactInformationBlock — passing them through raw BlockTransformer
+    // emits a non-existent `FormElementContact` component, so the block silently
+    // disappears even on NB attachment pages. NB fallback for empty localised
+    // content (issue #365).
+    const promoAreaData = await resolvePromoAreaWithNbFallback(
+      cmsPageData.id,
+      props.promoArea,
+      contentLocale,
+      (id) => fetchUmbracoContentById(id, "nb"),
+    );
+    const promoArea = buildPromoAreaContentArea(
+      promoAreaData,
+      (content) => BlockTransformer.TransformBlocks([content]).items[0],
+    );
 
     const resolvedSchemas = await resolveBlockReferences(props.schemas, contentLocale);
     const relatedSchemas = await Promise.all(

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -5,6 +5,7 @@ import {
   fetchUmbracoAncestors,
   fetchUmbracoChildren,
   fetchUmbracoContent,
+  fetchUmbracoContentById,
   resolveBlockReferences,
 } from "../api/umbraco/client";
 import { buildMunicipalitySearch } from "../api/umbraco/municipalitySearch";
@@ -12,6 +13,10 @@ import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import { stripCategoryPrefix } from "./categoryPrefix";
 import type { IJSONTransformer } from "./IJSONTransformer";
+import {
+  buildPromoAreaContentArea,
+  resolvePromoAreaWithNbFallback,
+} from "./promoAreaContact";
 
 // Prefer rich text when an editor has populated it; fall back to the legacy plain-text field.
 const richTextOrText = (rich: any, text: any) =>
@@ -109,44 +114,22 @@ export class SchemaPageTransformer implements IJSONTransformer {
       };
     });
 
-    // `promoArea` (editor label "Faglig brukerstøtte") is a Block List. Items wrap
-    // each block as `{ content: { contentType, id, properties }, settings }`, with
-    // properties inline (no picker hydration needed). Both `formElementContactFreetext`
-    // and the legacy `formElementContact` (no `heading` field) map to
-    // ProviderContactInformationBlock; other block types fall back to
-    // BlockTransformer's contentType-keyed registry.
-    const promoBlockItems: any[] = Array.isArray(props.promoArea?.items)
-      ? props.promoArea.items
-      : [];
-    const promoItems = promoBlockItems
-      .map((wrapper: any) => {
-        const content = wrapper?.content ?? wrapper;
-        const blockProps = content?.properties ?? {};
-        if (
-          content?.contentType === "formElementContactFreetext" ||
-          content?.contentType === "formElementContact"
-        ) {
-          return {
-            componentName: "ProviderContactInformationBlock",
-            body: blockProps.body ?? undefined,
-            bottomText: blockProps.bottomText ?? undefined,
-            webpageLink: blockProps.webpageLink ?? undefined,
-            telephone: blockProps.telephone ?? "",
-            telephoneLabel: blockProps.telephoneLabel ?? "",
-            email: blockProps.email ?? "",
-            emailTitle: blockProps.emailTitle ?? "",
-            // schemaPage shows only the editor-supplied heading; no provider
-            // name / emblem fallback (providerPage handles the fallback case).
-            pageName: blockProps.heading || "",
-            providerIcon: undefined,
-          };
-        }
-        return BlockTransformer.TransformBlocks([content]).items[0];
-      })
-      .filter(Boolean);
-    const promoArea = promoItems.length
-      ? { componentName: "ContentArea", items: promoItems }
-      : undefined;
+    // `promoArea` (editor label "Faglig brukerstøtte") is a Block List. Contact
+    // blocks render as ProviderContactInformationBlock; other blocks fall back to
+    // BlockTransformer's contentType-keyed registry. schemaPage passes no heading
+    // fallback, so an unset heading shows no provider name/emblem. The block is
+    // only authored on NB content, so fall back to the NB node when the localised
+    // value is empty (issue #365).
+    const promoAreaData = await resolvePromoAreaWithNbFallback(
+      cmsPageData.id,
+      props.promoArea,
+      contentLocale,
+      (id) => fetchUmbracoContentById(id, "nb"),
+    );
+    const promoArea = buildPromoAreaContentArea(
+      promoAreaData,
+      (content) => BlockTransformer.TransformBlocks([content]).items[0],
+    );
 
     // Sidebar: schema's tree parent is a providerPage (URL: /skjemaoversikt/<provider>/<schema>/),
     // so the category/subcategory comes from the `subCategories` Content Picker property.

--- a/astro-infoportal/src/transformers/promoAreaContact.test.ts
+++ b/astro-infoportal/src/transformers/promoAreaContact.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPromoAreaContentArea,
+  buildProviderContactInfo,
+  isContactBlock,
+  mapContactBlock,
+  promoAreaIsEmpty,
+  resolvePromoAreaWithNbFallback,
+} from "./promoAreaContact";
+
+const contactBlock = (properties: Record<string, unknown>) => ({
+  content: { contentType: "formElementContact", properties },
+});
+const freetextBlock = (properties: Record<string, unknown>) => ({
+  content: { contentType: "formElementContactFreetext", properties },
+});
+const otherBlock = (properties: Record<string, unknown>) => ({
+  content: { contentType: "linkButtonBlock", properties },
+});
+
+describe("isContactBlock", () => {
+  it("recognises both Faglig brukerstøtte block content types", () => {
+    expect(isContactBlock("formElementContact")).toBe(true);
+    expect(isContactBlock("formElementContactFreetext")).toBe(true);
+  });
+
+  it("rejects other content types and undefined", () => {
+    expect(isContactBlock("linkButtonBlock")).toBe(false);
+    expect(isContactBlock(undefined)).toBe(false);
+  });
+});
+
+describe("promoAreaIsEmpty", () => {
+  it("treats null, missing items and empty items as empty", () => {
+    expect(promoAreaIsEmpty(null)).toBe(true);
+    expect(promoAreaIsEmpty(undefined)).toBe(true);
+    expect(promoAreaIsEmpty({})).toBe(true);
+    expect(promoAreaIsEmpty({ items: [] })).toBe(true);
+    expect(promoAreaIsEmpty([])).toBe(true);
+  });
+
+  it("treats a populated block list as non-empty", () => {
+    expect(promoAreaIsEmpty({ items: [contactBlock({})] })).toBe(false);
+    expect(promoAreaIsEmpty([contactBlock({})])).toBe(false);
+  });
+});
+
+describe("mapContactBlock", () => {
+  it("maps contact properties onto a ProviderContactInformationBlock view-model", () => {
+    const body = { items: [{ html: "<p>hi</p>", componentName: "RichText" }] };
+    const vm = mapContactBlock({
+      body,
+      telephone: "22 86 03 12",
+      telephoneLabel: "Tlf",
+      email: "post@toll.no",
+      emailTitle: "E-post",
+      heading: "Trenger du hjelp?",
+    });
+
+    expect(vm).toMatchObject({
+      componentName: "ProviderContactInformationBlock",
+      body,
+      telephone: "22 86 03 12",
+      telephoneLabel: "Tlf",
+      email: "post@toll.no",
+      emailTitle: "E-post",
+      pageName: "Trenger du hjelp?",
+      providerIcon: undefined,
+    });
+  });
+
+  it("uses the provider name and emblem as the heading fallback when the block has no heading", () => {
+    const vm = mapContactBlock(
+      { email: "post@patentstyret.no" },
+      { name: "Patentstyret", imageUrl: "/img/pat.svg" },
+    );
+
+    expect(vm.pageName).toBe("Patentstyret");
+    expect(vm.providerIcon).toEqual({
+      name: "Patentstyret",
+      imageUrl: "/img/pat.svg",
+    });
+  });
+
+  it("prefers the block heading over the fallback name and then hides the emblem", () => {
+    const vm = mapContactBlock(
+      { heading: "Kontakt oss" },
+      { name: "Patentstyret" },
+    );
+    expect(vm.pageName).toBe("Kontakt oss");
+    expect(vm.providerIcon).toBeUndefined();
+  });
+
+  it("falls back to an empty heading and no emblem when there is no heading and no fallback", () => {
+    const vm = mapContactBlock({ email: "x@y.no" });
+    expect(vm.pageName).toBe("");
+    expect(vm.providerIcon).toBeUndefined();
+  });
+});
+
+describe("buildPromoAreaContentArea", () => {
+  const transformOther = (content: any) => ({
+    componentName: "OtherBlock",
+    ...content.properties,
+  });
+
+  it("maps a contact block to a ProviderContactInformationBlock inside a ContentArea", () => {
+    const result = buildPromoAreaContentArea(
+      { items: [freetextBlock({ email: "post@toll.no" })] },
+      transformOther,
+    );
+
+    expect(result).toEqual({
+      componentName: "ContentArea",
+      items: [
+        expect.objectContaining({
+          componentName: "ProviderContactInformationBlock",
+          email: "post@toll.no",
+        }),
+      ],
+    });
+  });
+
+  it("delegates non-contact blocks to the supplied transformer", () => {
+    const spy = vi.fn(transformOther);
+    const result = buildPromoAreaContentArea(
+      { items: [otherBlock({ label: "Click" })] },
+      spy,
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result?.items[0]).toEqual({
+      componentName: "OtherBlock",
+      label: "Click",
+    });
+  });
+
+  it("returns undefined when there are no items", () => {
+    expect(buildPromoAreaContentArea(null, transformOther)).toBeUndefined();
+    expect(
+      buildPromoAreaContentArea({ items: [] }, transformOther),
+    ).toBeUndefined();
+  });
+});
+
+describe("buildProviderContactInfo", () => {
+  it("returns the first contact block as a single view-model with the provider fallback", () => {
+    const result = buildProviderContactInfo(
+      {
+        items: [
+          contactBlock({ email: "first@toll.no" }),
+          contactBlock({ email: "second@toll.no" }),
+        ],
+      },
+      { name: "Tolletaten", imageUrl: "/img/toll.svg" },
+    );
+
+    expect(result?.email).toBe("first@toll.no");
+    expect(result?.pageName).toBe("Tolletaten");
+    expect(result?.providerIcon).toEqual({
+      name: "Tolletaten",
+      imageUrl: "/img/toll.svg",
+    });
+  });
+
+  it("returns undefined when there is no contact block", () => {
+    expect(
+      buildProviderContactInfo({ items: [otherBlock({})] }, { name: "X" }),
+    ).toBeUndefined();
+    expect(buildProviderContactInfo(null, { name: "X" })).toBeUndefined();
+  });
+});
+
+describe("resolvePromoAreaWithNbFallback", () => {
+  it("returns the localized promoArea untouched when it already has items", async () => {
+    const fetchNb = vi.fn();
+    const localized = { items: [contactBlock({})] };
+
+    const result = await resolvePromoAreaWithNbFallback(
+      "id-1",
+      localized,
+      "en",
+      fetchNb,
+    );
+
+    expect(result).toBe(localized);
+    expect(fetchNb).not.toHaveBeenCalled();
+  });
+
+  it("fetches the nb node and uses its promoArea when the localized value is empty", async () => {
+    const nbPromoArea = { items: [contactBlock({ email: "post@toll.no" })] };
+    const fetchNb = vi
+      .fn()
+      .mockResolvedValue({ properties: { promoArea: nbPromoArea } });
+
+    const result = await resolvePromoAreaWithNbFallback(
+      "id-1",
+      null,
+      "en",
+      fetchNb,
+    );
+
+    expect(fetchNb).toHaveBeenCalledWith("id-1");
+    expect(result).toBe(nbPromoArea);
+  });
+
+  it("does not fall back when the content locale is already nb", async () => {
+    const fetchNb = vi.fn();
+    const result = await resolvePromoAreaWithNbFallback(
+      "id-1",
+      null,
+      "nb",
+      fetchNb,
+    );
+
+    expect(result).toBeNull();
+    expect(fetchNb).not.toHaveBeenCalled();
+  });
+
+  it("keeps the empty localized value when the nb node also has no promoArea", async () => {
+    const fetchNb = vi.fn().mockResolvedValue({ properties: {} });
+    const result = await resolvePromoAreaWithNbFallback(
+      "id-1",
+      null,
+      "en",
+      fetchNb,
+    );
+
+    expect(result).toBeNull();
+  });
+});

--- a/astro-infoportal/src/transformers/promoAreaContact.ts
+++ b/astro-infoportal/src/transformers/promoAreaContact.ts
@@ -1,0 +1,128 @@
+// Shared handling for the `promoArea` Block List (editor label "Faglig
+// brukerstøtte"). The contact blocks (`formElementContactFreetext` and the
+// legacy `formElementContact`, which has no `heading` field) render as a
+// ProviderContactInformationBlock. This logic is used identically by
+// schemaPage, providerPage and schemaAttachmentPage so it lives here once.
+//
+// Localisation: the block is only authored on the NB content tree — EN/NN
+// variants come back with `promoArea: null` (issue #365). Because the page
+// itself exists in the requested locale, the whole-page NB fallback in
+// `client.ts` never fires, so we fall back at the field level instead.
+
+const CONTACT_BLOCK_TYPES = new Set([
+  "formElementContactFreetext",
+  "formElementContact",
+]);
+
+export function isContactBlock(contentType: string | undefined): boolean {
+  return !!contentType && CONTACT_BLOCK_TYPES.has(contentType);
+}
+
+/** True when a promoArea value carries no renderable blocks. */
+export function promoAreaIsEmpty(promoArea: any): boolean {
+  if (!promoArea) return true;
+  const items = Array.isArray(promoArea) ? promoArea : promoArea.items;
+  return !Array.isArray(items) || items.length === 0;
+}
+
+export interface ContactHeadingFallback {
+  name: string;
+  imageUrl?: string;
+}
+
+/**
+ * Maps one contact block's properties to a ProviderContactInformationBlock
+ * view-model. An editor-supplied `heading` always wins. When it's absent and a
+ * fallback (the provider) is given, the provider name + emblem are used instead
+ * — matching the providerPage behaviour. schemaPage passes no fallback, so an
+ * unset heading yields an empty title and no emblem.
+ */
+export function mapContactBlock(
+  blockProps: any,
+  fallback?: ContactHeadingFallback,
+) {
+  const heading = blockProps?.heading;
+  return {
+    componentName: "ProviderContactInformationBlock",
+    body: blockProps?.body ?? undefined,
+    bottomText: blockProps?.bottomText ?? undefined,
+    webpageLink: blockProps?.webpageLink ?? undefined,
+    telephone: blockProps?.telephone ?? "",
+    telephoneLabel: blockProps?.telephoneLabel ?? "",
+    email: blockProps?.email ?? "",
+    emailTitle: blockProps?.emailTitle ?? "",
+    pageName: heading || fallback?.name || "",
+    providerIcon:
+      !heading && fallback
+        ? { name: fallback.name, imageUrl: fallback.imageUrl }
+        : undefined,
+  };
+}
+
+function promoAreaItems(promoArea: any): any[] {
+  return Array.isArray(promoArea)
+    ? promoArea
+    : Array.isArray(promoArea?.items)
+      ? promoArea.items
+      : [];
+}
+
+/**
+ * Builds the ContentArea view-model rendered by schemaPage / schemaAttachmentPage.
+ * Contact blocks become a ProviderContactInformationBlock; every other block is
+ * delegated to `transformOther` (the caller's BlockTransformer adapter). Returns
+ * undefined when there's nothing to render.
+ */
+export function buildPromoAreaContentArea(
+  promoArea: any,
+  transformOther: (content: any) => any,
+) {
+  const items = promoAreaItems(promoArea)
+    .map((wrapper) => {
+      const content = wrapper?.content ?? wrapper;
+      if (isContactBlock(content?.contentType)) {
+        return mapContactBlock(content?.properties ?? {});
+      }
+      return transformOther(content);
+    })
+    .filter(Boolean);
+
+  return items.length ? { componentName: "ContentArea", items } : undefined;
+}
+
+/**
+ * Builds the single contactInfo view-model rendered in the providerPage header:
+ * the first contact block, with the provider name + emblem as heading fallback.
+ */
+export function buildProviderContactInfo(
+  promoArea: any,
+  fallback: ContactHeadingFallback,
+) {
+  for (const wrapper of promoAreaItems(promoArea)) {
+    const content = wrapper?.content ?? wrapper;
+    if (isContactBlock(content?.contentType)) {
+      return mapContactBlock(content?.properties ?? {}, fallback);
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Field-level NB fallback for promoArea. When the localised value is empty and
+ * we're not already on NB, fetch the NB node by id and use its promoArea. The
+ * contact details (phone/email/links) are locale-independent; only the heading
+ * and body text show in Norwegian — far better than the block disappearing.
+ */
+export async function resolvePromoAreaWithNbFallback(
+  contentId: string | undefined,
+  localizedPromoArea: any,
+  contentLocale: string | undefined,
+  fetchNbContentById: (id: string) => Promise<any>,
+): Promise<any> {
+  if (!promoAreaIsEmpty(localizedPromoArea)) return localizedPromoArea;
+  if (!contentId || !contentLocale || contentLocale === "nb") {
+    return localizedPromoArea;
+  }
+  const nb = await fetchNbContentById(contentId);
+  return nb?.properties?.promoArea ?? localizedPromoArea;
+}


### PR DESCRIPTION
Issue #365 – kontaktblokken «Faglig brukerstøtte» (logo, navn, e-post/telefon) manglet på engelske og nynorske sider.

## Årsak

Innholds-/migreringshull: `promoArea` er kun fylt ut på bokmål, mens `en`/`nn` returnerer `null` fra Umbraco. Sidens nb-fallback utløses kun ved HTTP 404, ikke ved tomt felt på en eksisterende side.

I tillegg en latent feil: `SchemaAttachmentPageTransformer` mappet kontaktblokken til en ikke-eksisterende `FormElementContact`-komponent, så blokken forsvant på vedleggssider **også på bokmål**.

## Endringer

- Ny `transformers/promoAreaContact.ts` – samler kontaktblokk-logikken (var duplisert) + `resolvePromoAreaWithNbFallback` (henter nb-innhold når lokalisert felt er tomt).
- `SchemaPageTransformer` / `ProviderPageTransformer` – uendret oppførsel + nb-fallback.
- `SchemaAttachmentPageTransformer` – bruker delt logikk → fikser latent feil + får fallback.
- Ny `promoAreaContact.test.ts` (17 tester, TDD).

## Kjent avveining

På `en`/`nn` vises teksten nå på **bokmål** (e-post/telefon er uansett språkuavhengig). Riktig oversettelse av innholdet bør følges opp i egen sak.