### PR TITLE
feat: add coockie banner

### DIFF
--- a/astro-infoportal/src/Components/Blocks/ConsentBanner/ConsentBanner.scss
+++ b/astro-infoportal/src/Components/Blocks/ConsentBanner/ConsentBanner.scss
@@ -1,0 +1,101 @@
+// Samtykkebanner.
+// The surface colour #0062b8 is the bespoke "Design på tvers" brand blue
+// (Figma 5939-26559) — it is NOT a Designsystemet token, so it stays literal.
+// White text on it ≈ 5.95:1 (WCAG AA pass); white here is a brand-on-brand-surface
+// choice, not a scheme token, so it stays literal too.
+// Spacing uses --ds-size-* tokens (unit = 4px → size-3=12, size-4=16, size-6=24,
+// size-12=48).
+$consent-bg: #0062b8;
+
+.consent-banner {
+  background-color: $consent-bg;
+  color: #fff;
+  padding: var(--ds-size-6) var(--ds-size-12); // 24px / 48px (Figma)
+  font-family: var(--ds-font-family, "Inter", sans-serif);
+  // Match Figma's text rendering (grayscale antialiasing). macOS browsers default
+  // to subpixel antialiasing, which renders Inter noticeably heavier than the
+  // design. Mirrors the smoothing other components in this repo already apply.
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  // Receives programmatic focus on reopen (tabindex -1) to announce itself; it
+  // isn't keyboard-tabbable, so suppress the container's focus ring.
+  &:focus {
+    outline: none;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ds-size-3); // 12px (Figma)
+  }
+
+  &__heading,
+  &__body {
+    color: #fff; // inherited from .consent-banner; explicit for clarity
+    margin: 0;
+  }
+
+  // Figma heading: 32px Inter Regular, line-height 1.2, letter-spacing -0.02em
+  // (-0.64px @ 32px). 32px is not on the DS font-size scale (size-7=30, size-8=36),
+  // so it stays literal. The doubled-specificity selector overrides Designsystemet's
+  // .ds-heading defaults (weight 500, 36px at size="lg") without !important.
+  & &__heading {
+    font-size: 2rem;
+    font-weight: var(--ds-font-weight-regular);
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+  }
+
+  // Figma shows 75% opacity here (≈ 4.0:1 on the brand blue → FAILS AA).
+  // 0.85 ≈ 4.7:1 passes AA while keeping the softer look. Do not go below 0.82
+  // (the ~4.5:1 AA floor on this background).
+  // Constrain only the running text to a readable measure (Figma: the body and
+  // necessary blocks are ~710px wide while the heading spans full width, so the
+  // heading stays on one line instead of wrapping).
+  &__body,
+  &__necessary {
+    max-width: 48rem;
+  }
+
+  &__necessary {
+    color: #fff;
+    opacity: 0.85;
+    margin: 0;
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--ds-size-6); // 24px (Figma)
+    flex-wrap: wrap;
+
+    // Figma uses white buttons with dark labels on the blue banner. Re-point the
+    // Designsystemet button's own custom properties at the neutral tokens (white
+    // background / dark text in the normal colour scheme). This wins over
+    // .ds-button's defaults on specificity, so no !important is needed.
+    button {
+      --dsc-button-background: var(--ds-color-neutral-background-default);
+      --dsc-button-background--hover: var(--ds-color-neutral-surface-hover);
+      --dsc-button-background--active: var(--ds-color-neutral-surface-active);
+      --dsc-button-color: var(--ds-color-neutral-text-default);
+    }
+  }
+
+  a {
+    color: currentColor;
+    text-decoration: underline;
+    // Figma uses text-underline-position: from-font with a visible gap between the
+    // text and the line. Offset the underline lower and take its thickness from the
+    // font (thin, like the design).
+    text-decoration-thickness: from-font;
+    text-underline-offset: 0.2em;
+
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+
+  @media (max-width: 768px) {
+    padding: var(--ds-size-6) var(--ds-size-4); // 24px / 16px
+  }
+}

--- a/astro-infoportal/src/Components/Blocks/ConsentBanner/ConsentBanner.tsx
+++ b/astro-infoportal/src/Components/Blocks/ConsentBanner/ConsentBanner.tsx
@@ -1,0 +1,154 @@
+import { Button, Heading, Paragraph } from "@digdir/designsystemet-react";
+import { useEffect, useId, useRef, useState } from "react";
+import {
+  CONSENT_REOPEN_HASH,
+  loadSiteimprove,
+  needsPrompt,
+  readConsent,
+  writeConsent,
+} from "/utils/consent";
+import type { ConsentBannerViewModel } from "@constants/globalData";
+import "./ConsentBanner.scss";
+
+// A trailing inline link after running text; renders only when both the label
+// and the target are present (the optional CMS link fields).
+const TrailingLink = ({ text, url }: { text?: string; url?: string }) =>
+  text && url ? (
+    <>
+      {" "}
+      <a href={url}>{text}</a>
+    </>
+  ) : null;
+
+const ConsentBanner = ({
+  heading,
+  bodyText,
+  acceptLabel,
+  rejectLabel,
+  necessaryText,
+  changeLinkText,
+  changeLinkUrl,
+  necessaryLinkText,
+  necessaryLinkUrl,
+}: ConsentBannerViewModel) => {
+  const [visible, setVisible] = useState(false);
+  const headingId = useId();
+  const sectionRef = useRef<HTMLElement>(null);
+  // Set by open() so the focus effect only fires on an explicit reopen
+  // (footer / personvern / programmatic), not when the banner first appears.
+  const focusOnOpenRef = useRef(false);
+
+  // Client-only: the page is edge-cached per URL, so visibility must never be
+  // decided at SSR. Show only when a (re)decision is needed.
+  useEffect(() => {
+    setVisible(needsPrompt(readConsent()));
+  }, []);
+
+  // Reopen hook for the footer link, the personvern-page link/button
+  // (href ending in #informasjonskapsler or [data-consent-reopen]), a direct
+  // hash visit, and window.altinnConsent.open().
+  useEffect(() => {
+    const open = () => {
+      setVisible(true);
+      focusOnOpenRef.current = true; // move focus to the banner once it renders
+      // The banner sits at the top of the page, so when it's reopened from the
+      // footer (or anywhere below the fold) scroll up to it — otherwise nothing
+      // appears to happen.
+      window.scrollTo({ top: 0, behavior: "smooth" });
+      // Strip the reopen hash so a refresh doesn't re-open the banner for a user
+      // who has already made a choice.
+      if (window.location.hash === `#${CONSENT_REOPEN_HASH}`) {
+        window.history.replaceState(
+          null,
+          "",
+          window.location.pathname + window.location.search,
+        );
+      }
+    };
+    const onClick = (event: MouseEvent) => {
+      const trigger = (event.target as HTMLElement | null)?.closest(
+        `a[href$="#${CONSENT_REOPEN_HASH}"], [data-consent-reopen]`,
+      );
+      if (trigger) {
+        event.preventDefault();
+        open();
+      }
+    };
+    document.addEventListener("click", onClick);
+    if (window.location.hash === `#${CONSENT_REOPEN_HASH}`) open();
+    const win = window as unknown as { altinnConsent?: unknown };
+    win.altinnConsent = {
+      open,
+      get: readConsent,
+      // Mirror the banner's accept flow: persist the choice, then let
+      // loadSiteimprove() decide (it self-gates on consent), so a programmatic
+      // grant takes effect immediately rather than only on the next navigation.
+      set: (statistics: boolean) => {
+        writeConsent(statistics);
+        loadSiteimprove();
+      },
+    };
+    return () => {
+      document.removeEventListener("click", onClick);
+      delete win.altinnConsent;
+    };
+  }, []);
+
+  // After an explicit reopen, move focus to the banner so keyboard and
+  // screen-reader users land on it (announced via aria-labelledby).
+  useEffect(() => {
+    if (visible && focusOnOpenRef.current) {
+      focusOnOpenRef.current = false;
+      sectionRef.current?.focus();
+    }
+  }, [visible]);
+
+  if (!visible) return null;
+
+  const accept = () => {
+    writeConsent(true);
+    loadSiteimprove();
+    setVisible(false);
+  };
+  const reject = () => {
+    writeConsent(false);
+    setVisible(false);
+  };
+
+  return (
+    <section
+      ref={sectionRef}
+      className="consent-banner"
+      aria-labelledby={headingId}
+      tabIndex={-1}
+    >
+      <div className="consent-banner__content">
+        <Heading
+          id={headingId}
+          level={2}
+          className="consent-banner__heading"
+        >
+          {heading}
+        </Heading>
+        <Paragraph variant="long" className="consent-banner__body">
+          {bodyText}
+          <TrailingLink text={changeLinkText} url={changeLinkUrl} />
+        </Paragraph>
+        <div className="consent-banner__actions">
+          <Button variant="primary" type="button" onClick={accept}>
+            {acceptLabel}
+          </Button>
+          <Button variant="primary" type="button" onClick={reject}>
+            {rejectLabel}
+          </Button>
+        </div>
+        <Paragraph variant="long" className="consent-banner__necessary">
+          {necessaryText}
+          <TrailingLink text={necessaryLinkText} url={necessaryLinkUrl} />
+        </Paragraph>
+      </div>
+    </section>
+  );
+};
+
+export default ConsentBanner;

--- a/astro-infoportal/src/Components/Layout/Footer/useFooterConfig.ts
+++ b/astro-infoportal/src/Components/Layout/Footer/useFooterConfig.ts
@@ -7,14 +7,40 @@ const useFooterConfig = ({
   helpPage,
   privacyReference,
   accessibilityLocation,
-  operationalMessagesReference
+  operationalMessagesReference,
+  cookieConsent,
 }: any): FooterProps => {
   const menuItems = [
-    helpPage && { id: "1", title: helpPage.text || "", href: helpPage.url || "" },
-    aboutAltinnReference && { id: "2", title: aboutAltinnReference.text || "", href: aboutAltinnReference.url || "" },
-    operationalMessagesReference && { id: "3", title: operationalMessagesReference.text || "", href: operationalMessagesReference.url || "" },
-    privacyReference && { id: "4", title: privacyReference.text || "", href: privacyReference.url || "" },
-    accessibilityLocation && { id: "5", title: accessibilityLocation.text || "", href: accessibilityLocation.url || "" },
+    helpPage && {
+      id: "1",
+      title: helpPage.text || "",
+      href: helpPage.url || "",
+    },
+    aboutAltinnReference && {
+      id: "2",
+      title: aboutAltinnReference.text || "",
+      href: aboutAltinnReference.url || "",
+    },
+    operationalMessagesReference && {
+      id: "3",
+      title: operationalMessagesReference.text || "",
+      href: operationalMessagesReference.url || "",
+    },
+    privacyReference && {
+      id: "4",
+      title: privacyReference.text || "",
+      href: privacyReference.url || "",
+    },
+    accessibilityLocation && {
+      id: "5",
+      title: accessibilityLocation.text || "",
+      href: accessibilityLocation.url || "",
+    },
+    cookieConsent && {
+      id: "6",
+      title: cookieConsent.text || "",
+      href: cookieConsent.url || "",
+    },
   ].filter((item): item is NonNullable<typeof item> => item != null);
 
   const footerProps: FooterProps = {

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
@@ -1,17 +1,18 @@
-import {Layout, RootProvider} from '@altinn/altinn-components';
-import * as Components from '../../../App.Components';
-import '@altinn/altinn-components/dist/global.css';
-import '@digdir/designsystemet-theme';
-import '@digdir/designsystemet-css';
-import type {SiteLayoutProps} from './SiteLayout.types';
-import useSidebarConfig from '../../Shared/PageSidebar/useSidebarConfig';
-import useFooterConfig from '../Footer/useFooterConfig';
-import useHeaderConfig from '../Header/useHeaderConfig';
-import {useLanguagePreference} from '../Header/hooks/useLanguagePreference';
-import {useHashScroll} from './useHashScroll';
-import './SiteLayout.scss';
-import {SkipLink} from '@digdir/designsystemet-react';
-import BannerBlock from '../../../Components/Blocks/BannerBlock/BannerBlock';
+import { Layout, RootProvider } from "@altinn/altinn-components";
+import * as Components from "../../../App.Components";
+import "@altinn/altinn-components/dist/global.css";
+import "@digdir/designsystemet-theme";
+import "@digdir/designsystemet-css";
+import type { SiteLayoutProps } from "./SiteLayout.types";
+import useSidebarConfig from "../../Shared/PageSidebar/useSidebarConfig";
+import useFooterConfig from "../Footer/useFooterConfig";
+import useHeaderConfig from "../Header/useHeaderConfig";
+import { useLanguagePreference } from "../Header/hooks/useLanguagePreference";
+import { useHashScroll } from "./useHashScroll";
+import "./SiteLayout.scss";
+import { SkipLink } from "@digdir/designsystemet-react";
+import BannerBlock from "../../../Components/Blocks/BannerBlock/BannerBlock";
+import ConsentBanner from "../../../Components/Blocks/ConsentBanner/ConsentBanner";
 
 const SiteLayout = ({
   child,
@@ -19,6 +20,7 @@ const SiteLayout = ({
   footerViewModel,
   pageSidebarViewModel,
   skipLinkText,
+  consentBanner,
 }: SiteLayoutProps) => {
   const Comp = child ? (Components as any)[child.componentName] : null;
 
@@ -30,36 +32,36 @@ const SiteLayout = ({
   )?.languageName;
 
   const normalize = (s?: string) =>
-    (s || '')
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
+    (s || "")
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
       .toLowerCase();
-  const getLanguageCode = (langName?: string): 'nb' | 'nn' | 'en' => {
+  const getLanguageCode = (langName?: string): "nb" | "nn" | "en" => {
     const v = normalize(langName);
-    if (!v) return 'nb';
+    if (!v) return "nb";
     if (
-      v === 'nn' ||
-      v === 'nnno' ||
-      v.startsWith('nn-') ||
-      v.includes('nynorsk')
+      v === "nn" ||
+      v === "nnno" ||
+      v.startsWith("nn-") ||
+      v.includes("nynorsk")
     )
-      return 'nn';
-    if (v === 'en' || v.startsWith('en-') || v.includes('english')) return 'en';
+      return "nn";
+    if (v === "en" || v.startsWith("en-") || v.includes("english")) return "en";
     if (
-      v === 'no' ||
-      v === 'nonb' ||
-      v.startsWith('no-') ||
-      v.includes('norsk') ||
-      v.includes('bokmal')
+      v === "no" ||
+      v === "nonb" ||
+      v.startsWith("no-") ||
+      v.includes("norsk") ||
+      v.includes("bokmal")
     )
-      return 'nb';
-    return 'nb';
+      return "nb";
+    return "nb";
   };
 
   const languageCode = getLanguageCode(currentLanguage);
 
   // Config from hooks
-  const {headerProps, color} = useHeaderConfig(
+  const { headerProps, color } = useHeaderConfig(
     headerViewModel || ({} as any),
     languageCode,
   );
@@ -71,40 +73,38 @@ const SiteLayout = ({
 
   // Pages that have their own width constraints and should not be constrained by layout
   const exludedPages = [
-    'StartPage',
-    'SchemaOverviewPage',
-    'SectionPage',
-    'ThemePage',
-    'SubsidyOverviewPage',
-    'ProviderPage',
+    "StartPage",
+    "SchemaOverviewPage",
+    "SectionPage",
+    "ThemePage",
+    "SubsidyOverviewPage",
+    "ProviderPage",
   ];
   const shouldConstrainWidth =
     child && !exludedPages.includes(child.componentName);
   const hasSidebar = !!sidebarConfig;
 
-  const contentColor: 'company' = 'company';
+  const contentColor: "company" = "company";
 
   return (
     <RootProvider languageCode={languageCode}>
-      <SkipLink
-        className="site-layout__skip-link"
-        href="#main-content"
-      >
+      <SkipLink className="site-layout__skip-link" href="#main-content">
         {skipLinkText}
       </SkipLink>
+      {consentBanner && <ConsentBanner {...consentBanner} />}
       {headerViewModel?.banner && <BannerBlock {...headerViewModel.banner} />}
       <Layout
         color={color}
         header={headerViewModel ? headerProps : undefined}
         footer={footerProps}
-        content={{color: contentColor}}
-        {...(sidebarConfig ? {sidebar: sidebarConfig} : {})}
+        content={{ color: contentColor }}
+        {...(sidebarConfig ? { sidebar: sidebarConfig } : {})}
         theme="default"
       >
         {shouldConstrainWidth ? (
           <div
             className={`layout-content-constrained${
-              hasSidebar ? ' layout-content-constrained--sidebar' : ''
+              hasSidebar ? " layout-content-constrained--sidebar" : ""
             }`}
           >
             <Comp {...child} />

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.types.ts
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.types.ts
@@ -1,7 +1,10 @@
+import type { ConsentBannerViewModel } from "@constants/globalData";
+
 export interface SiteLayoutProps {
   headerViewModel?: any;
   footerViewModel?: any;
   pageSidebarViewModel?: any;
   child?: { componentName: string; [key: string]: any };
   skipLinkText?: string;
+  consentBanner?: ConsentBannerViewModel | null;
 }

--- a/astro-infoportal/src/Constants/globalData.test.ts
+++ b/astro-infoportal/src/Constants/globalData.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildConsentBanner } from "./globalData";
+
+const full = {
+  properties: {
+    heading: "Får vi samle informasjon om hvordan du bruker nettsiden?",
+    bodyText:
+      "Hvis du svarer ja, lagrer vi informasjon til statistikk og analyse.",
+    acceptLabel: "Ja",
+    rejectLabel: "Nei",
+    necessaryText: "Vi lagrer også nødvendig informasjon.",
+    footerLinkText: "Informasjonskapsler",
+    changeLinkText: "Du kan endre valget ditt når som helst.",
+    changeLink: [{ route: { path: "/om-altinn/personvern/" } }],
+    necessaryLinkText: "Se oversikt over nødvendig informasjon.",
+    necessaryLink: [{ route: { path: "/om-altinn/personvern/" } }],
+  },
+};
+
+describe("buildConsentBanner", () => {
+  it("returns null when the value is missing", () => {
+    expect(buildConsentBanner(null)).toBeNull();
+    expect(buildConsentBanner(undefined)).toBeNull();
+    expect(buildConsentBanner({})).toBeNull();
+  });
+
+  it("returns null when a mandatory field is empty (no fallback)", () => {
+    const noHeading = { properties: { ...full.properties, heading: "" } };
+    expect(buildConsentBanner(noHeading)).toBeNull();
+    const noAccept = { properties: { ...full.properties, acceptLabel: "  " } };
+    expect(buildConsentBanner(noAccept)).toBeNull();
+    const noFooter = { properties: { ...full.properties, footerLinkText: "" } };
+    expect(buildConsentBanner(noFooter)).toBeNull();
+  });
+
+  it("maps a complete CMS node to a view model and resolves link urls", () => {
+    const vm = buildConsentBanner(full);
+    expect(vm).not.toBeNull();
+    expect(vm?.heading).toBe(full.properties.heading);
+    expect(vm?.acceptLabel).toBe("Ja");
+    expect(vm?.footerLinkText).toBe("Informasjonskapsler");
+    expect(vm?.changeLinkUrl).toBe("/om-altinn/personvern/");
+    expect(vm?.necessaryLinkUrl).toBe("/om-altinn/personvern/");
+  });
+
+  it("accepts the value wrapped in an array (Delivery API shape)", () => {
+    expect(buildConsentBanner([full])?.heading).toBe(full.properties.heading);
+  });
+
+  it("omits optional links when their url is absent", () => {
+    const noLinks = {
+      properties: {
+        heading: full.properties.heading,
+        bodyText: full.properties.bodyText,
+        acceptLabel: "Ja",
+        rejectLabel: "Nei",
+        necessaryText: full.properties.necessaryText,
+        footerLinkText: "Informasjonskapsler",
+      },
+    };
+    const vm = buildConsentBanner(noLinks);
+    expect(vm?.changeLinkUrl).toBeUndefined();
+    expect(vm?.necessaryLinkUrl).toBeUndefined();
+  });
+});

--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -5,6 +5,7 @@ import {
   type CultureRoutes,
 } from "@constants/languages";
 import { SearchContext } from "@constants/searchContext";
+import { CONSENT_REOPEN_HASH } from "@utils/consent";
 import {
   buildBanner,
   buildLink,
@@ -12,6 +13,69 @@ import {
   resolvePickerUrl,
 } from "@constants/startPageLinks";
 import { type Locale, t } from "@i18n/index";
+
+export type ConsentBannerViewModel = {
+  heading: string;
+  bodyText: string;
+  acceptLabel: string;
+  rejectLabel: string;
+  necessaryText: string;
+  footerLinkText: string;
+  changeLinkText?: string;
+  changeLinkUrl?: string;
+  necessaryLinkText?: string;
+  necessaryLinkUrl?: string;
+};
+
+const asText = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+// Build the consent banner view model from the editor-controlled CMS property.
+// Single source of truth: returns null (banner does not render) when the
+// property is missing or any mandatory field is empty. There is no fallback.
+// Mirrors buildBanner's handling of the Delivery API value shape.
+export function buildConsentBanner(
+  value: unknown,
+): ConsentBannerViewModel | null {
+  const first = Array.isArray(value) ? value[0] : value;
+  const props = (
+    first as { properties?: Record<string, unknown> } | null | undefined
+  )?.properties;
+  if (!props) return null;
+
+  const heading = asText(props.heading);
+  const bodyText = asText(props.bodyText);
+  const acceptLabel = asText(props.acceptLabel);
+  const rejectLabel = asText(props.rejectLabel);
+  const necessaryText = asText(props.necessaryText);
+  const footerLinkText = asText(props.footerLinkText);
+
+  if (
+    !heading ||
+    !bodyText ||
+    !acceptLabel ||
+    !rejectLabel ||
+    !necessaryText ||
+    !footerLinkText
+  ) {
+    return null;
+  }
+
+  const changeLinkUrl = resolvePickerUrl(props.changeLink) ?? undefined;
+  const necessaryLinkUrl = resolvePickerUrl(props.necessaryLink) ?? undefined;
+
+  return {
+    heading,
+    bodyText,
+    acceptLabel,
+    rejectLabel,
+    necessaryText,
+    footerLinkText,
+    changeLinkText: asText(props.changeLinkText) || undefined,
+    changeLinkUrl,
+    necessaryLinkText: asText(props.necessaryLinkText) || undefined,
+    necessaryLinkUrl,
+  };
+}
 
 export function getGlobalData(
   locale: Locale = "nb",
@@ -27,6 +91,7 @@ export function getGlobalData(
   const amUiBase = endpoints.amUiBaseUrl.replace(/\/$/, "");
   const platformBase = endpoints.platformBaseUrl.replace(/\/$/, "");
   const p = startPage?.properties;
+  const consentBanner = buildConsentBanner(p?.consentBanner);
 
   return {
     headerViewModel: {
@@ -97,6 +162,9 @@ export function getGlobalData(
         p?.accessibilityLocation,
         t("footer.accessibility", locale),
       ),
+      cookieConsent: consentBanner
+        ? { text: consentBanner.footerLinkText, url: `#${CONSENT_REOPEN_HASH}` }
+        : null,
       searchContext:
         currentPageContentType === "schemaOverviewPage"
           ? SearchContext.Schema
@@ -107,6 +175,7 @@ export function getGlobalData(
         : searchPageUrl,
     },
     skipLinkText: t("common.skipToContent", locale),
+    consentBanner,
     locale,
     contentLocale,
   };

--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -3,6 +3,11 @@ import { env } from "cloudflare:workers";
 export const UMBRACO_API_URL =
   env.UMBRACO_API_URL || "https://infoportal.at22.dis-core.altinn.cloud/";
 
+// Expand the banner + consentBanner pickers so their view models get the picked
+// node's properties inline. Shared by the start-page fetches (front page, locale
+// roots, sub-pages, 404, search) so the expand list lives in one place.
+export const START_PAGE_EXPAND = "properties[banner,consentBanner]";
+
 const CULTURE_MAP: Record<string, string> = {
   nb: "nb",
   nn: "nn",
@@ -332,8 +337,8 @@ export async function fetchUmbracoStartPage(locale?: string) {
   const params = new URLSearchParams({
     filter: "contentType:startPage",
     take: "1",
-    // expand the banner picker so buildBanner gets the node's properties inline
-    expand: "properties[banner]",
+    // expand the banner and consentBanner pickers so the view models get the node's properties inline
+    expand: START_PAGE_EXPAND,
   });
   const url = deliveryUrl("/umbraco/delivery/api/v2/content", params.toString());
 

--- a/astro-infoportal/src/bundles/SiteimproveAnalytics.astro
+++ b/astro-infoportal/src/bundles/SiteimproveAnalytics.astro
@@ -1,18 +1,8 @@
 <script>
-    // Skip loading Siteimprove when the URL query string looks like it carries
-    // personal data (emails, long digit sequences such as fødselsnummer or
-    // organisasjonsnummer). The check mirrors the rule used on the legacy portal.
-    function checkPageParametersForPersonalData() {
-        const search = decodeURIComponent(window.location.search);
-        const longNumbersRegEx = /\d(?:\d|\D\d){5,}/g;
-        const emailRegEx = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
-        return !search.match(emailRegEx) && !search.match(longNumbersRegEx);
-    }
+    import { loadSiteimprove } from "../utils/consent.ts";
 
-    if (checkPageParametersForPersonalData()) {
-        const scriptTag = document.createElement('script');
-        scriptTag.src = 'https://siteimproveanalytics.com/js/siteanalyze_6255470.js';
-        scriptTag.defer = true;
-        document.head.appendChild(scriptTag);
-    }
+    // loadSiteimprove() self-gates on consent AND the personal-data URL check,
+    // so there's nothing to decide here — call it on every page load; it no-ops
+    // unless statistics consent has been granted.
+    loadSiteimprove();
 </script>

--- a/astro-infoportal/src/pages/[...slug].astro
+++ b/astro-infoportal/src/pages/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 
-import { fetchUmbracoContentWithLocaleFallback, fetchUmbracoErrorPage, fetchUmbracoStartPage, fetchUmbracoMedia } from '@api/umbraco/client';
+import { fetchUmbracoContentWithLocaleFallback, fetchUmbracoErrorPage, fetchUmbracoStartPage, fetchUmbracoMedia, START_PAGE_EXPAND } from '@api/umbraco/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
 import { getGlobalData } from '@constants/globalData';
@@ -76,7 +76,7 @@ const umbracoPath = isNorwegianStartRoot ? "/" : path;
 const pagePromise = fetchUmbracoContentWithLocaleFallback(
   umbracoPath,
   locale,
-  isLocaleRoot ? "properties[banner]" : undefined,
+  isLocaleRoot ? START_PAGE_EXPAND : undefined,
 );
 const startPagePromise = isLocaleRoot ? pagePromise : fetchUmbracoStartPage(locale);
 

--- a/astro-infoportal/src/pages/index.astro
+++ b/astro-infoportal/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { fetchUmbracoContent } from '@api/umbraco/client';
+import { fetchUmbracoContent, START_PAGE_EXPAND } from '@api/umbraco/client';
 import AstroSiteLayout from '@layouts/AstroSiteLayout.astro';
 import { JSONTransformer } from '@transformers/JSONTransformer';
 import { getGlobalData } from '@constants/globalData';
@@ -15,8 +15,8 @@ let umbracoPageData: any = null;
 // Fetch the correct Umbraco path for the locale
 const umbracoPath = locale === "en" ? "/en/" : "/";
 const [pageResult] = await Promise.allSettled([
-  // expand the banner picker so buildBanner gets the node's properties (see fetchUmbracoStartPage)
-  fetchUmbracoContent(umbracoPath, locale, "properties[banner]"),
+  // expand the banner and consentBanner pickers so the view models get the node's properties (see fetchUmbracoStartPage)
+  fetchUmbracoContent(umbracoPath, locale, START_PAGE_EXPAND),
 ]);
 
 if (pageResult.status === 'rejected') {

--- a/astro-infoportal/src/transformers/JSONTransformer.ts
+++ b/astro-infoportal/src/transformers/JSONTransformer.ts
@@ -31,12 +31,28 @@ import { hydrateNestedContactFormPageData } from "./contactFormData";
 export class JSONTransformer implements IJSONTransformer {
   public async Transform(umbracoPageData: any, globalData?: any): Promise<any> {
     const data: any = {
-      headerViewModel: globalData?.properties?.headerViewModel || globalData?.headerViewModel || null,
-      footerViewModel: globalData?.properties?.footerViewModel || globalData?.footerViewModel || null,
-      pageSidebarViewModel: globalData?.properties?.pageSidebarViewModel || globalData?.pageSidebarViewModel || null,
-      skipLinkText: globalData?.properties?.skipLinkText || globalData?.skipLinkText || t("common.skipToContent", globalData?.locale),
+      headerViewModel:
+        globalData?.properties?.headerViewModel ||
+        globalData?.headerViewModel ||
+        null,
+      footerViewModel:
+        globalData?.properties?.footerViewModel ||
+        globalData?.footerViewModel ||
+        null,
+      pageSidebarViewModel:
+        globalData?.properties?.pageSidebarViewModel ||
+        globalData?.pageSidebarViewModel ||
+        null,
+      skipLinkText:
+        globalData?.properties?.skipLinkText ||
+        globalData?.skipLinkText ||
+        t("common.skipToContent", globalData?.locale),
+      consentBanner:
+        globalData?.properties?.consentBanner ??
+        globalData?.consentBanner ??
+        null,
       componentName: "SiteLayout",
-      child: null
+      child: null,
     };
 
     const bodyDataTransformer: IJSONTransformer | null = this.GetTransformer(
@@ -44,7 +60,10 @@ export class JSONTransformer implements IJSONTransformer {
     );
 
     if (bodyDataTransformer != null) {
-      data.child = await bodyDataTransformer.Transform(umbracoPageData, globalData);
+      data.child = await bodyDataTransformer.Transform(
+        umbracoPageData,
+        globalData,
+      );
     }
 
     if (data.child) {

--- a/astro-infoportal/src/utils/consent.test.ts
+++ b/astro-infoportal/src/utils/consent.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONSENT_VERSION,
+  needsPrompt,
+  parseConsent,
+  searchHasNoPersonalData,
+  serializeConsentValue,
+  shouldLoadSiteimprove,
+} from "./consent";
+
+describe("searchHasNoPersonalData", () => {
+  it("is true for a clean query string", () => {
+    expect(searchHasNoPersonalData("?q=skatt")).toBe(true);
+    expect(searchHasNoPersonalData("")).toBe(true);
+  });
+
+  it("is false when the query contains an email", () => {
+    expect(searchHasNoPersonalData("?email=ola%40example.com")).toBe(false);
+  });
+
+  it("is false when the query contains a long digit run (fødselsnummer)", () => {
+    expect(searchHasNoPersonalData("?q=12345678901")).toBe(false);
+  });
+
+  it("is false for a malformed query that cannot be decoded", () => {
+    expect(searchHasNoPersonalData("?q=%E0%A4%A")).toBe(false);
+  });
+});
+
+describe("parseConsent", () => {
+  it("returns an undecided state when the cookie is absent", () => {
+    const s = parseConsent("other=1; foo=bar");
+    expect(s.decided).toBe(false);
+    expect(s.statistics).toBe(false);
+  });
+
+  it("parses a granted decision", () => {
+    const s = parseConsent(`infoportal-consent=v=1%26statistics%3Dgranted`);
+    expect(s).toEqual({ decided: true, statistics: true, version: 1 });
+  });
+
+  it("parses a denied decision", () => {
+    const s = parseConsent(`infoportal-consent=v=1%26statistics%3Ddenied`);
+    expect(s).toEqual({ decided: true, statistics: false, version: 1 });
+  });
+
+  it("treats a malformed value as undecided", () => {
+    expect(parseConsent("infoportal-consent=garbage").decided).toBe(false);
+  });
+
+  it("does not throw on a value with invalid percent-encoding", () => {
+    expect(parseConsent("infoportal-consent=%E0%A4%A").decided).toBe(false);
+  });
+});
+
+describe("serializeConsentValue", () => {
+  it("encodes the current version and the grant flag", () => {
+    expect(serializeConsentValue(true)).toBe(
+      `v=${CONSENT_VERSION}&statistics=granted`,
+    );
+    expect(serializeConsentValue(false)).toBe(
+      `v=${CONSENT_VERSION}&statistics=denied`,
+    );
+  });
+});
+
+describe("shouldLoadSiteimprove", () => {
+  it("is true only for a current-version granted decision", () => {
+    expect(
+      shouldLoadSiteimprove({
+        decided: true,
+        statistics: true,
+        version: CONSENT_VERSION,
+      }),
+    ).toBe(true);
+    expect(
+      shouldLoadSiteimprove({
+        decided: true,
+        statistics: false,
+        version: CONSENT_VERSION,
+      }),
+    ).toBe(false);
+    expect(
+      shouldLoadSiteimprove({ decided: false, statistics: false, version: 0 }),
+    ).toBe(false);
+    expect(
+      shouldLoadSiteimprove({
+        decided: true,
+        statistics: true,
+        version: CONSENT_VERSION - 1,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("needsPrompt", () => {
+  it("prompts when undecided or on an older version", () => {
+    expect(needsPrompt({ decided: false, statistics: false, version: 0 })).toBe(
+      true,
+    );
+    expect(
+      needsPrompt({
+        decided: true,
+        statistics: false,
+        version: CONSENT_VERSION - 1,
+      }),
+    ).toBe(true);
+    expect(
+      needsPrompt({
+        decided: true,
+        statistics: true,
+        version: CONSENT_VERSION,
+      }),
+    ).toBe(false);
+    expect(
+      needsPrompt({
+        decided: true,
+        statistics: false,
+        version: CONSENT_VERSION,
+      }),
+    ).toBe(false);
+  });
+});

--- a/astro-infoportal/src/utils/consent.ts
+++ b/astro-infoportal/src/utils/consent.ts
@@ -1,0 +1,138 @@
+// Consent for non-essential storage on the info portal. Statistics = Siteimprove.
+// Bump CONSENT_VERSION only when the SCOPE of consent changes (e.g. a new
+// category) — never for wording fixes — so users are re-prompted only when the
+// thing they consented to actually changed.
+export const CONSENT_COOKIE = "infoportal-consent";
+export const CONSENT_VERSION = 1;
+
+// URL hash that reopens the banner (footer link / personvern page / any
+// [data-consent-reopen] element). Shared so the click-listener, the hash-on-load
+// check, and the footer link all reference one value.
+export const CONSENT_REOPEN_HASH = "informasjonskapsler";
+
+const SITEIMPROVE_SRC =
+  "https://siteimproveanalytics.com/js/siteanalyze_6255470.js";
+
+export type ConsentState = {
+  decided: boolean;
+  statistics: boolean;
+  version: number;
+};
+
+// Frozen so a caller that mutates a returned state can't corrupt the shared singleton.
+const UNDECIDED: ConsentState = Object.freeze({
+  decided: false,
+  statistics: false,
+  version: 0,
+});
+
+function readRawCookie(cookieString: string, name: string): string | null {
+  for (const part of cookieString ? cookieString.split(";") : []) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      try {
+        return decodeURIComponent(part.slice(eq + 1).trim());
+      } catch {
+        return null; // malformed percent-encoding → treat as no decision
+      }
+    }
+  }
+  return null;
+}
+
+/** Pure: derive consent state from a raw `document.cookie` string. */
+export function parseConsent(cookieString: string): ConsentState {
+  const raw = readRawCookie(cookieString, CONSENT_COOKIE);
+  if (!raw) return UNDECIDED;
+  const params = new URLSearchParams(raw);
+  const version = Number.parseInt(params.get("v") ?? "", 10);
+  const statistics = params.get("statistics");
+  if (
+    !Number.isFinite(version) ||
+    (statistics !== "granted" && statistics !== "denied")
+  ) {
+    return UNDECIDED;
+  }
+  return { decided: true, statistics: statistics === "granted", version };
+}
+
+/** Pure: the cookie value for a decision. */
+export function serializeConsentValue(statistics: boolean): string {
+  return `v=${CONSENT_VERSION}&statistics=${statistics ? "granted" : "denied"}`;
+}
+
+/** Pure: may Siteimprove load? Only a current-version granted decision. */
+export function shouldLoadSiteimprove(state: ConsentState): boolean {
+  return state.decided && state.statistics && state.version === CONSENT_VERSION;
+}
+
+/** Pure: should the banner be shown (no decision yet, or scope changed)? */
+export function needsPrompt(state: ConsentState): boolean {
+  return !state.decided || state.version < CONSENT_VERSION;
+}
+
+/** Browser: current consent from the document cookie. */
+export function readConsent(): ConsentState {
+  if (typeof document === "undefined") return UNDECIDED;
+  return parseConsent(document.cookie);
+}
+
+/** Browser: persist a decision for 12 months on the info host. */
+export function writeConsent(statistics: boolean): void {
+  if (typeof document === "undefined") return;
+  const secure =
+    typeof location !== "undefined" && location.protocol === "https:"
+      ? "; Secure"
+      : "";
+  document.cookie =
+    `${CONSENT_COOKIE}=${encodeURIComponent(serializeConsentValue(statistics))}` +
+    `; Path=/; Max-Age=31536000; SameSite=Lax${secure}`;
+}
+
+// Personal-data patterns for the Siteimprove URL guard: emails and long digit
+// runs (fødselsnummer / organisasjonsnummer). Module-scope so they compile once;
+// no /g flag — we only test for presence, so a stateful lastIndex never applies.
+const PERSONAL_DATA_EMAIL = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
+const PERSONAL_DATA_LONG_NUMBER = /\d(?:\d|\D\d){5,}/;
+
+/**
+ * Pure: does the query string look free of personal data? Mirrors the legacy
+ * portal rule — never report a URL whose query carries emails or long digit runs
+ * (fødselsnummer / organisasjonsnummer) to Siteimprove. Returns true when safe.
+ */
+export function searchHasNoPersonalData(search: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(search);
+  } catch {
+    return false; // malformed query — be safe and skip analytics
+  }
+  return (
+    !PERSONAL_DATA_EMAIL.test(decoded) && !PERSONAL_DATA_LONG_NUMBER.test(decoded)
+  );
+}
+
+/**
+ * Browser: inject the Siteimprove tag once (idempotent). Self-gates on BOTH
+ * consent and the personal-data URL check, so no caller (head bundle, banner
+ * accept handler, or any future one) can load analytics without a current-version
+ * granted decision, and never on a URL whose query looks like it carries PII.
+ */
+export function loadSiteimprove(): void {
+  if (typeof document === "undefined") return;
+  // Consent gate (defense-in-depth) — independent of how this is called.
+  if (!shouldLoadSiteimprove(readConsent())) return;
+  if (
+    typeof window !== "undefined" &&
+    !searchHasNoPersonalData(window.location.search)
+  ) {
+    return;
+  }
+  if (document.querySelector("script[data-siteimprove]")) return;
+  const tag = document.createElement("script");
+  tag.src = SITEIMPROVE_SRC;
+  tag.defer = true;
+  tag.dataset.siteimprove = "true";
+  document.head.appendChild(tag);
+}

--- a/astro-infoportal/vitest.config.ts
+++ b/astro-infoportal/vitest.config.ts
@@ -1,6 +1,22 @@
 import { defineConfig } from "vitest/config";
+import { resolve } from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@components": resolve(__dirname, "src/Components"),
+      "@layouts": resolve(__dirname, "src/layouts"),
+      "@pages": resolve(__dirname, "src/pages"),
+      "@styles": resolve(__dirname, "src/styles"),
+      "@utils": resolve(__dirname, "src/utils"),
+      "@api": resolve(__dirname, "src/api"),
+      "@constants": resolve(__dirname, "src/Constants"),
+      "@services": resolve(__dirname, "src/Services"),
+      "@models": resolve(__dirname, "src/Models"),
+      "@transformers": resolve(__dirname, "src/transformers"),
+      "@i18n": resolve(__dirname, "src/i18n"),
+    },
+  },
   test: {
     // Pure-TS unit tests (e.g. rich-text HTML transforms) run in Node.
     environment: "node",


### PR DESCRIPTION
Samtykkebanner for informasjonsportalen (#409)

### Hva

Samtykkebanner som ber om samtykke før vi laster bruksstatistikk (Siteimprove), i tråd med skjerpede krav i ekomloven. Banner-teksten er redaktørstyrt fra Umbraco.

### Endringer

- Samtykkestyrt statistikk: Siteimprove lastes kun når brukeren har sagt ja. Uten samtykke lastes ingenting — og aldri på URL-er som ser ut til å inneholde personopplysninger (fødselsnummer/e-post i query-streng).
- Redaktørstyrt tekst, én kilde: all tekst hentes fra Umbraco (consentBanner på forsiden). Ingen hardkodet fallback — mangler innholdet, vises ikke banneret.
- Banner: enkel Ja/Nei-variant (Designsystemet). Valget lagres i førsteparts-cookie infoportal-consent (12 mnd).
- Nullstilling: lenke i footer + på personvernsiden (#informasjonskapsler) åpner banneret igjen — siden ruller til toppen og fokus flyttes til banneret.
- Kun informasjonsportalen (ikke etter innlogging).
- Universell utforming: WCAG AA-kontrast, tastatur og skjermleser.

<img width="2055" height="1168" alt="Screenshot 2026-06-23 at 20 56 34" src="https://github.com/user-attachments/assets/f136e5de-36e1-4d71-9166-525d8c327747" />
