### PR TITLE
feat: migrate Optimizely article export to Umbraco

### DIFF
--- a/umbraco-infoportal/App_Plugins/ArticleExport/dashboard.js
+++ b/umbraco-infoportal/App_Plugins/ArticleExport/dashboard.js
@@ -1,0 +1,229 @@
+import { html, css, LitElement, nothing } from "@umbraco-cms/backoffice/external/lit";
+import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
+import { UMB_AUTH_CONTEXT } from "@umbraco-cms/backoffice/auth";
+import { UMB_NOTIFICATION_CONTEXT } from "@umbraco-cms/backoffice/notification";
+
+const BASE_URL = "/umbraco/management/api/v1/article-export";
+const FILTERS_URL = `${BASE_URL}/filters`;
+const EXPORT_URL = `${BASE_URL}/export`;
+
+class AltinnArticleExportElement extends UmbElementMixin(LitElement) {
+  static properties = {
+    _providers: { state: true },
+    _authors: { state: true },
+    _languages: { state: true },
+    _loading: { state: true },
+    _busy: { state: true },
+    _error: { state: true },
+  };
+
+  constructor() {
+    super();
+    this._providers = [];
+    this._authors = [];
+    this._languages = [];
+    this._loading = true;
+    this._busy = false;
+    this._error = null;
+    this._auth = null;
+    this._notifications = null;
+    this._selection = { language: "", provider: "", author: "", fromDate: "", toDate: "" };
+    this.consumeContext(UMB_AUTH_CONTEXT, (ctx) => {
+      this._auth = ctx;
+    });
+    this.consumeContext(UMB_NOTIFICATION_CONTEXT, (ctx) => {
+      this._notifications = ctx;
+    });
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.#loadFilters();
+  }
+
+  async #authHeader() {
+    const token = await this._auth?.getLatestToken?.();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }
+
+  async #loadFilters() {
+    this._loading = true;
+    this._error = null;
+    try {
+      const headers = await this.#authHeader();
+      const url = this._selection.language
+        ? `${FILTERS_URL}?language=${encodeURIComponent(this._selection.language)}`
+        : FILTERS_URL;
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        this._error = `Kunne ikke hente filtervalg (status ${res.status}).`;
+        return;
+      }
+      const data = await res.json();
+      this._providers = data?.providers ?? [];
+      this._authors = data?.authors ?? [];
+      this._languages = data?.languages ?? [];
+    } catch (e) {
+      this._error = e?.message ?? "Kunne ikke hente filtervalg.";
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  #onLanguageChange(e) {
+    this._selection = { ...this._selection, language: e.target.value };
+    // Providers/authors are language-variant — refresh them for the chosen language.
+    this.#loadFilters();
+  }
+
+  #onFieldChange(field, e) {
+    this._selection = { ...this._selection, [field]: e.target.value };
+  }
+
+  async #onGenerate() {
+    this._busy = true;
+    this._error = null;
+    try {
+      const headers = await this.#authHeader();
+      const params = new URLSearchParams();
+      const { language, provider, author, fromDate, toDate } = this._selection;
+      if (language) params.set("language", language);
+      if (provider) params.set("provider", provider);
+      if (author) params.set("author", author);
+      if (fromDate) params.set("fromDate", fromDate);
+      if (toDate) params.set("toDate", toDate);
+
+      const res = await fetch(`${EXPORT_URL}?${params.toString()}`, { headers });
+      if (!res.ok) {
+        let message = `Status ${res.status}`;
+        try {
+          const body = await res.json();
+          message = body?.detail ?? body?.title ?? message;
+        } catch {
+          // Non-JSON error body — keep the status message.
+        }
+        this._notifications?.peek("danger", {
+          data: { headline: "Eksport feilet", message },
+        });
+        return;
+      }
+
+      const blob = await res.blob();
+      const filename = this.#filenameFromResponse(res) ?? "article-export.docx";
+      this.#triggerDownload(blob, filename);
+      this._notifications?.peek("positive", { data: { message: "Dokument generert" } });
+    } catch (e) {
+      this._notifications?.peek("danger", {
+        data: { headline: "Eksport feilet", message: e?.message ?? "Ukjent feil" },
+      });
+    } finally {
+      this._busy = false;
+    }
+  }
+
+  #filenameFromResponse(res) {
+    const header = res.headers.get("content-disposition");
+    if (!header) return null;
+    const utf8 = header.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utf8) {
+      try {
+        return decodeURIComponent(utf8[1]);
+      } catch {
+        // Fall through to the plain filename form.
+      }
+    }
+    const plain = header.match(/filename="?([^";]+)"?/i);
+    return plain ? plain[1] : null;
+  }
+
+  #triggerDownload(blob, filename) {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    // Do NOT attach the anchor to the document: the Umbraco backoffice has a global
+    // click/router interceptor that would try to pushState() to the blob: URL and throw a
+    // SecurityError. A detached anchor still triggers the download but is invisible to it.
+    anchor.click();
+    // Revoke after a delay so the download has time to start (early revoke can cancel it).
+    setTimeout(() => URL.revokeObjectURL(url), 30000);
+  }
+
+  render() {
+    return html`
+      <uui-box headline="Artikkel eksport">
+        <p>Generer et Word-dokument med artikler, skjema og tilskudd, filtrert på tjenesteeier, koordinator, språk og dato.</p>
+
+        ${this._error
+          ? html`<uui-toast-notification color="danger" open>
+              <uui-toast-notification-layout headline="Feil">${this._error}</uui-toast-notification-layout>
+            </uui-toast-notification>`
+          : nothing}
+
+        ${this._loading
+          ? html`<p><em>Laster filtervalg…</em></p>`
+          : html`
+              <div class="grid">
+                <label for="language">Språk</label>
+                <select id="language" @change=${(e) => this.#onLanguageChange(e)}>
+                  ${this._languages.map(
+                    (l) => html`<option value=${l.isoCode}>${l.name}</option>`,
+                  )}
+                </select>
+
+                <label for="provider">Tjenesteeier</label>
+                <select id="provider" @change=${(e) => this.#onFieldChange("provider", e)}>
+                  <option value="">Alle</option>
+                  ${this._providers.map((p) => html`<option value=${p}>${p}</option>`)}
+                </select>
+
+                <label for="author">Koordinator</label>
+                <select id="author" @change=${(e) => this.#onFieldChange("author", e)}>
+                  <option value="">Alle</option>
+                  ${this._authors.map((a) => html`<option value=${a}>${a}</option>`)}
+                </select>
+
+                <label for="fromDate">Fra dato</label>
+                <input id="fromDate" type="date" @change=${(e) => this.#onFieldChange("fromDate", e)} />
+
+                <label for="toDate">Til dato</label>
+                <input id="toDate" type="date" @change=${(e) => this.#onFieldChange("toDate", e)} />
+              </div>
+
+              <uui-button
+                look="primary"
+                color="default"
+                ?disabled=${this._busy}
+                @click=${() => this.#onGenerate()}>
+                ${this._busy ? "Genererer…" : "Generer"}
+              </uui-button>
+            `}
+      </uui-box>
+    `;
+  }
+
+  static styles = css`
+    :host { display: block; padding: 24px; }
+    uui-box { display: block; max-width: 720px; }
+    p { margin: 0 0 16px; }
+    .grid {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      gap: 12px 16px;
+      align-items: center;
+      margin-bottom: 24px;
+      max-width: 480px;
+    }
+    .grid label { font-weight: 600; }
+    .grid select,
+    .grid input {
+      padding: 6px 8px;
+      border: 1px solid var(--uui-color-border, #d8d7d9);
+      border-radius: 3px;
+      font: inherit;
+    }
+  `;
+}
+
+customElements.define("altinn-article-export", AltinnArticleExportElement);
+export default AltinnArticleExportElement;

--- a/umbraco-infoportal/App_Plugins/ArticleExport/umbraco-package.json
+++ b/umbraco-infoportal/App_Plugins/ArticleExport/umbraco-package.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../umbraco-package-schema.json",
+  "name": "Altinn.ArticleExport",
+  "version": "0.1.0",
+  "extensions": [
+    {
+      "type": "dashboard",
+      "alias": "Altinn.Dashboard.ArticleExport",
+      "name": "Article Export",
+      "element": "/App_Plugins/ArticleExport/dashboard.js",
+      "elementName": "altinn-article-export",
+      "weight": 20,
+      "meta": {
+        "label": "Artikkel eksport",
+        "pathname": "article-export"
+      },
+      "conditions": [
+        { "alias": "Umb.Condition.SectionAlias", "match": "Umb.Section.Settings" },
+        { "alias": "Umb.Condition.CurrentUser.IsAdmin" }
+      ]
+    }
+  ]
+}

--- a/umbraco-infoportal/ArticleExport/ArticleExportComposer.cs
+++ b/umbraco-infoportal/ArticleExport/ArticleExportComposer.cs
@@ -1,0 +1,12 @@
+using umbraco_infoportal.ArticleExport.Services;
+using Umbraco.Cms.Core.Composing;
+
+namespace umbraco_infoportal.ArticleExport;
+
+public class ArticleExportComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddScoped<ArticleReportGenerator>();
+    }
+}

--- a/umbraco-infoportal/ArticleExport/Controllers/ArticleExportController.cs
+++ b/umbraco-infoportal/ArticleExport/Controllers/ArticleExportController.cs
@@ -1,0 +1,73 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using umbraco_infoportal.ArticleExport.Models;
+using umbraco_infoportal.ArticleExport.Services;
+using Umbraco.Cms.Api.Management.Controllers;
+using Umbraco.Cms.Api.Management.Routing;
+using Umbraco.Cms.Web.Common.Authorization;
+
+namespace umbraco_infoportal.ArticleExport.Controllers;
+
+[ApiVersion("1.0")]
+[VersionedApiBackOfficeRoute("article-export")]
+[ApiExplorerSettings(GroupName = "Article Export")]
+[Authorize(Policy = AuthorizationPolicies.RequireAdminAccess)]
+public class ArticleExportController : ManagementApiControllerBase
+{
+    private readonly ArticleReportGenerator _generator;
+    private readonly ILogger<ArticleExportController> _logger;
+
+    public ArticleExportController(ArticleReportGenerator generator, ILogger<ArticleExportController> logger)
+    {
+        _generator = generator;
+        _logger = logger;
+    }
+
+    [HttpGet("filters")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(typeof(FilterOptionsResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [EndpointSummary("Filter options (providers, authors, languages) for the article export form.")]
+    public async Task<IActionResult> Filters([FromQuery] string? language, CancellationToken cancellationToken)
+    {
+        string? culture = await _generator.ResolveCultureAsync(language);
+        if (culture is null)
+        {
+            return BadRequest(UnknownLanguageProblem());
+        }
+
+        FilterOptionsResponse options = await _generator.GetFilterOptionsAsync(culture, cancellationToken);
+        return Ok(options);
+    }
+
+    [HttpGet("export")]
+    [MapToApiVersion("1.0")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [EndpointSummary("Generate a Word (.docx) report of the pages matching the filters.")]
+    public async Task<IActionResult> Export([FromQuery] ExportFilters filters, CancellationToken cancellationToken)
+    {
+        string? culture = await _generator.ResolveCultureAsync(filters.Language);
+        if (culture is null)
+        {
+            return BadRequest(UnknownLanguageProblem());
+        }
+
+        ArticleReport report = await _generator.BuildReportAsync(filters, culture, cancellationToken);
+        _logger.LogInformation(
+            "Article export generated {PageCount} pages for {User}",
+            report.PageCount,
+            User.Identity?.Name);
+
+        return File(report.Content, ArticleReportGenerator.DocxContentType, report.FileName);
+    }
+
+    private static ProblemDetails UnknownLanguageProblem() => new()
+    {
+        Title = "Unknown language",
+        Detail = "The requested language code is not a known, enabled language.",
+        Status = StatusCodes.Status400BadRequest,
+    };
+}

--- a/umbraco-infoportal/ArticleExport/Models/ArticleExportModels.cs
+++ b/umbraco-infoportal/ArticleExport/Models/ArticleExportModels.cs
@@ -1,0 +1,19 @@
+namespace umbraco_infoportal.ArticleExport.Models;
+
+public sealed record FilterOptionsResponse(
+    IReadOnlyList<string> Providers,
+    IReadOnlyList<string> Authors,
+    IReadOnlyList<LanguageOption> Languages);
+
+public sealed record LanguageOption(string IsoCode, string Name);
+
+public sealed class ExportFilters
+{
+    public DateTime? FromDate { get; init; }
+    public DateTime? ToDate { get; init; }
+    public string? Provider { get; init; }
+    public string? Author { get; init; }
+    public string? Language { get; init; }
+}
+
+public sealed record ArticleReport(byte[] Content, string FileName, int PageCount);

--- a/umbraco-infoportal/ArticleExport/Services/ArticleReportGenerator.cs
+++ b/umbraco-infoportal/ArticleExport/Services/ArticleReportGenerator.cs
@@ -1,0 +1,599 @@
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using HtmlAgilityPack;
+using umbraco_infoportal.ArticleExport.Models;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PublishedCache;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common;
+using Umbraco.Extensions;
+
+namespace umbraco_infoportal.ArticleExport.Services;
+
+// Faithful port of the Optimizely ArticleGenerateReportController logic onto the
+// Umbraco 17 content model. Selects published article/schema/subsidy pages by
+// provider/author/language/date, renders them to an HTML table, and packages the
+// result as a Word .docx via an AltChunk (Word converts the embedded HTML on open).
+public sealed class ArticleReportGenerator(
+    UmbracoHelper umbracoHelper,
+    IUmbracoContextFactory umbracoContextFactory,
+    ICoreScopeProvider coreScopeProvider,
+    IDocumentCacheService documentCacheService,
+    IPublishedContentTypeCache publishedContentTypeCache,
+    IPublishedValueFallback publishedValueFallback,
+    ILanguageService languageService)
+{
+    private const string DocxMime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+    private const string StartPageAlias = "startPage";
+    private const string SchemaPageAlias = "schemaPage";
+    private const string SubsidyPageAlias = "subsidyPage";
+    private const string ProviderPageAlias = "providerPage";
+
+    private static readonly string[] ExportPageAliases =
+    [
+        "newsArticlePage",
+        "sectionArticlePage",
+        "articlePage",
+        SchemaPageAlias,
+        SubsidyPageAlias,
+    ];
+
+    // Tjenesteeier (agency): contentOwner picker (Innholdseiere) on article/subsidy types +
+    // the legacy schemaPage `providers` picker (providerPage) + subsidy `agency` free text.
+    private const string ContentOwnersAlias = "contentOwners";   // article/subsidy picker → contentOwner
+    private const string ContentOwnerAlias = "contentOwner";     // agency nodes (dropdown source)
+    private const string ProvidersAlias = "providers";           // schemaPage picker → providerPage
+    private const string AgencyAlias = "agency";                 // subsidyPage — string
+    // Koordinator (author): subjectMatterExpert picker (Fageksperter) + subsidy `coordinator` free text.
+    private const string SubjectExpertsAlias = "subjectMatterExperts"; // article/subsidy picker → subjectMatterExpert
+    private const string SubjectExpertAlias = "subjectMatterExpert";    // expert nodes (dropdown source)
+    private const string CoordinatorAlias = "coordinator";       // subsidyPage — string
+    private const string LastChangedAlias = "lastChanged";
+    private const string MainIntroAlias = "mainIntro";
+    private const string MainBodyAlias = "mainBody";
+    private const string AccordianListAlias = "accordianList";
+    private const string HeadingAlias = "heading";
+    private const string TranslatedHeadingAlias = "translatedHeading";
+    private const string DescriptionAlias = "description";
+
+    // Resolves a request's language to a concrete enabled ISO code. Empty/blank input
+    // falls back to the default language; an unknown non-blank code returns null so the
+    // controller can reject it with 400.
+    public async Task<string?> ResolveCultureAsync(string? language)
+    {
+        IEnumerable<Umbraco.Cms.Core.Models.ILanguage> all = await languageService.GetAllAsync();
+        List<Umbraco.Cms.Core.Models.ILanguage> languages = all.ToList();
+
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            return languages
+                .FirstOrDefault(l => l.IsoCode.Equals(language, StringComparison.OrdinalIgnoreCase))
+                ?.IsoCode;
+        }
+
+        return (languages.FirstOrDefault(l => l.IsDefault) ?? languages.FirstOrDefault())?.IsoCode;
+    }
+
+    public async Task<FilterOptionsResponse> GetFilterOptionsAsync(string culture, CancellationToken cancellationToken)
+    {
+        var providers = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        var authors = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Reading published content via the HybridCache needs an UmbracoContext + an ambient
+        // scope; a backoffice Management API request does not open one automatically.
+        using (umbracoContextFactory.EnsureUmbracoContext())
+        using (coreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            // Tjenesteeier list = the Innholdseiere (contentOwner) tree + the legacy schema
+            // providerPage tree, so the dropdown lists every agency like Optimizely's category.
+            AddNodeNames(ContentOwnerAlias, culture, providers, cancellationToken);
+            AddNodeNames(ProviderPageAlias, culture, providers, cancellationToken);
+
+            // Koordinator list = the Fageksperter (subjectMatterExpert) tree.
+            AddNodeNames(SubjectExpertAlias, culture, authors, cancellationToken);
+
+            // Subsidy also carries agency/coordinator as free text — fold those in.
+            foreach (IPublishedContent page in GetByType(SubsidyPageAlias, culture))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (string provider in GetProviderNames(page, culture))
+                {
+                    providers.Add(provider);
+                }
+
+                foreach (string author in GetAuthorNames(page, culture))
+                {
+                    authors.Add(author);
+                }
+            }
+        }
+
+        List<LanguageOption> languages = (await languageService.GetAllAsync())
+            .Select(l => new LanguageOption(l.IsoCode, l.CultureName))
+            .ToList();
+
+        return new FilterOptionsResponse(providers.ToList(), authors.ToList(), languages);
+    }
+
+    public async Task<ArticleReport> BuildReportAsync(ExportFilters filters, string culture, CancellationToken cancellationToken)
+    {
+        string? provider = NormalizeFilter(filters.Provider);
+        string? author = NormalizeFilter(filters.Author);
+
+        var selected = new List<IPublishedContent>();
+        string html;
+
+        // Reading published content + generating page URLs needs an UmbracoContext + an ambient
+        // scope; a backoffice Management API request does not open one automatically.
+        using (umbracoContextFactory.EnsureUmbracoContext())
+        using (coreScopeProvider.CreateCoreScope(autoComplete: true))
+        {
+            foreach (IPublishedContent page in GetExportPages(culture))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (Matches(page, filters, provider, author, culture))
+                {
+                    selected.Add(page);
+                }
+            }
+
+            // Optimizely emits pages in content-tree order (GetDescendents). Our content-type
+            // index returns them grouped by type, so re-order on the tree path to restore the
+            // depth-first, structure-based order Optimizely produces.
+            selected = selected.OrderBy(TreeOrderKey, StringComparer.Ordinal).ToList();
+            html = BuildHtml(selected, culture, GetStartPage(culture));
+        }
+
+        byte[] bytes = await HtmlToDocxAsync(html);
+        return new ArticleReport(bytes, BuildFileName(filters, culture), selected.Count);
+    }
+
+    // Mirrors the legacy four-case combine: both / provider-only / author-only / neither.
+    private bool Matches(IPublishedContent page, ExportFilters filters, string? provider, string? author, string culture)
+    {
+        DateTime changed = GetChangedDate(page, culture);
+        if (filters.FromDate is { } from && changed < from)
+        {
+            return false;
+        }
+
+        if (filters.ToDate is { } to && changed > to)
+        {
+            return false;
+        }
+
+        bool matchesProvider = provider is not null
+            && GetProviderNames(page, culture).Contains(provider, StringComparer.OrdinalIgnoreCase);
+        bool matchesAuthor = author is not null
+            && GetAuthorNames(page, culture).Contains(author, StringComparer.OrdinalIgnoreCase);
+
+        return (provider, author) switch
+        {
+            (not null, not null) => matchesProvider && matchesAuthor,
+            (not null, null) => matchesProvider,
+            (null, not null) => matchesAuthor,
+            (null, null) => true,
+        };
+    }
+
+    public static string DocxContentType => DocxMime;
+
+    private IPublishedContent? GetStartPage(string culture)
+    {
+        IEnumerable<IPublishedContent> roots = umbracoHelper.ContentAtRoot();
+        return roots.FirstOrDefault(x =>
+                   x.ContentType.Alias.Equals(StartPageAlias, StringComparison.OrdinalIgnoreCase)
+                   && (string.IsNullOrEmpty(culture) || x.Cultures.ContainsKey(culture)))
+               ?? roots.FirstOrDefault(x => x.ContentType.Alias.Equals(StartPageAlias, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private IEnumerable<IPublishedContent> GetExportPages(string culture) =>
+        ExportPageAliases.SelectMany(alias => GetByType(alias, culture));
+
+    // Pulls published content of a single type straight from the content-type index
+    // instead of recursively walking the whole tree (much faster on a large site).
+    private List<IPublishedContent> GetByType(string alias, string culture)
+    {
+        IPublishedContentType? type = publishedContentTypeCache.Get(PublishedItemType.Content, alias);
+        if (type is null)
+        {
+            return [];
+        }
+
+        // Materialize the cache query FIRST: per-item property/picker resolution (e.g. a
+        // Multi-Node Tree Picker) opens its own DataReader on the same scoped connection, and
+        // there is no MARS — a still-open enumeration reader collides ("already an open
+        // DataReader"). Filtering by culture happens after the reader is closed.
+        List<IPublishedContent> pages = documentCacheService.GetByContentType(type).ToList();
+        return pages.Where(page => IsAvailableInCulture(page, culture)).ToList();
+    }
+
+    private static bool IsAvailableInCulture(IPublishedContent page, string culture) =>
+        string.IsNullOrEmpty(culture)
+        || !page.ContentType.Variations.VariesByCulture()
+        || page.Cultures.ContainsKey(culture);
+
+    private static bool IsSchema(IPublishedContent page) =>
+        page.ContentType.Alias.Equals(SchemaPageAlias, StringComparison.OrdinalIgnoreCase);
+
+    private DateTime GetChangedDate(IPublishedContent page, string culture)
+    {
+        if (page.HasProperty(LastChangedAlias))
+        {
+            DateTime? lastChanged = page.Value<DateTime?>(publishedValueFallback, LastChangedAlias, culture);
+            if (lastChanged is { } value && value != default)
+            {
+                return value;
+            }
+        }
+
+        return page.Cultures.TryGetValue(culture, out PublishedCultureInfo? info) ? info.Date : page.UpdateDate;
+    }
+
+    private IEnumerable<string> GetProviderNames(IPublishedContent page, string culture)
+    {
+        // contentOwner (Innholdseiere) on article/subsidy types + legacy schema providerPage picker.
+        foreach (string name in GetPickerNames(page, culture, ContentOwnersAlias, ProvidersAlias))
+        {
+            yield return name;
+        }
+
+        // Subsidy free-text agency.
+        if (page.HasProperty(AgencyAlias))
+        {
+            foreach (string value in SplitValues(page.Value<string>(publishedValueFallback, AgencyAlias, culture)))
+            {
+                yield return value;
+            }
+        }
+    }
+
+    private IEnumerable<string> GetAuthorNames(IPublishedContent page, string culture)
+    {
+        // subjectMatterExpert (Fageksperter) picker on article/subsidy types.
+        foreach (string name in GetPickerNames(page, culture, SubjectExpertsAlias))
+        {
+            yield return name;
+        }
+
+        // Legacy subsidy free-text coordinator.
+        if (page.HasProperty(CoordinatorAlias))
+        {
+            foreach (string value in SplitValues(page.Value<string>(publishedValueFallback, CoordinatorAlias, culture)))
+            {
+                yield return value;
+            }
+        }
+    }
+
+    // Reads one or more Content/Multi-Node Tree Picker properties and yields the referenced
+    // nodes' names. Missing properties are skipped (safe before the content model exists).
+    private IEnumerable<string> GetPickerNames(IPublishedContent page, string culture, params string[] aliases)
+    {
+        foreach (string alias in aliases)
+        {
+            if (!page.HasProperty(alias))
+            {
+                continue;
+            }
+
+            IEnumerable<IPublishedContent>? refs =
+                page.Value<IEnumerable<IPublishedContent>>(publishedValueFallback, alias, culture);
+            if (refs is null)
+            {
+                continue;
+            }
+
+            foreach (IPublishedContent node in refs)
+            {
+                if (!string.IsNullOrWhiteSpace(node?.Name))
+                {
+                    yield return node.Name.Trim();
+                }
+            }
+        }
+    }
+
+    // Adds every node name of a content type (the Innholdseiere / Fageksperter trees) to a
+    // dropdown set, so the filter lists the full taxonomy like Optimizely's category.
+    private void AddNodeNames(string typeAlias, string culture, ISet<string> target, CancellationToken cancellationToken)
+    {
+        foreach (IPublishedContent node in GetByType(typeAlias, culture))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!string.IsNullOrWhiteSpace(node.Name))
+            {
+                target.Add(node.Name.Trim());
+            }
+        }
+    }
+
+    private IEnumerable<string> GetCategoryNames(IPublishedContent page, string culture) =>
+        GetProviderNames(page, culture).Concat(GetAuthorNames(page, culture));
+
+    private static IEnumerable<string> SplitValues(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield break;
+        }
+
+        foreach (string part in value.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            yield return part;
+        }
+    }
+
+    private static string? NormalizeFilter(string? value)
+    {
+        // The dashboard sends "" for the "Alle" (no-filter) option, so ONLY empty means no
+        // filter. Do not also treat the literal "Alle"/"ALLE" as no-filter: there is a real
+        // Tjenesteeier node named "ALLE", and a case-insensitive match silently disabled the
+        // filter (returning all 2109 pages instead of the ALLE-tagged subset). Optimizely
+        // compared "Alle" case-sensitively for exactly this reason.
+        string? trimmed = value?.Trim();
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    // A lexically-sortable key from the content path ("-1,1050,2109") with each id zero-padded,
+    // so OrderBy yields content-tree (depth-first) order rather than content-type-grouped order.
+    private static string TreeOrderKey(IPublishedContent page) =>
+        string.Join(",", page.Path.Split(',').Select(s => int.TryParse(s, out int id) ? id.ToString("D10") : s));
+
+    private string BuildHtml(IReadOnlyList<IPublishedContent> pages, string culture, IPublishedContent? start)
+    {
+        string? publicBase = GetPublicBase(start, culture);
+
+        var sb = new StringBuilder();
+        sb.Append("<html><head><title></title><style>a{color:blue;}</style></head><body>");
+        sb.Append("<table style='border:1px solid #000000;border-collapse:collapse'>");
+        sb.Append("<tr><th style='border:1px solid #000000;'>Eier(e)</th><th style='border:1px solid #000000;'>Innhold</th></tr>");
+
+        foreach (IPublishedContent page in pages)
+        {
+            string owner = string.Join(", ", GetCategoryNames(page, culture));
+            string url = page.Url(culture, UrlMode.Absolute);
+
+            sb.Append("<tr>");
+            sb.Append("<td style='border:1px solid #000000;vertical-align:top;'>")
+              .Append(WebUtility.HtmlEncode(string.IsNullOrEmpty(owner) ? "Coordinator" : owner))
+              .Append("</td>");
+            sb.Append("<td style='border:1px solid #000000;padding-left:25px;'>");
+            sb.Append("<h2><a href='").Append(WebUtility.HtmlEncode(url)).Append("'>")
+              .Append(WebUtility.HtmlEncode(page.Name)).Append("</a></h2>");
+
+            if (IsSchema(page))
+            {
+                AppendSchemaBody(sb, page, culture);
+            }
+            else
+            {
+                AppendArticleBody(sb, page, culture);
+            }
+
+            sb.Append("</td></tr>");
+        }
+
+        sb.Append("</table></body></html>");
+
+        string html = AbsolutizeUrls(sb.ToString(), publicBase);
+        return PreMailer.Net.PreMailer.MoveCssInline(html).Html;
+    }
+
+    private void AppendArticleBody(StringBuilder sb, IPublishedContent page, string culture)
+    {
+        string intro = GetRichTextHtml(page, MainIntroAlias, culture);
+        if (!string.IsNullOrWhiteSpace(intro))
+        {
+            sb.Append("<p><b>").Append(intro).Append("</b></p>");
+        }
+
+        string body = GetRichTextHtml(page, MainBodyAlias, culture);
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            sb.Append("<p>").Append(body).Append("</p>");
+        }
+    }
+
+    private void AppendSchemaBody(StringBuilder sb, IPublishedContent page, string culture)
+    {
+        string intro = GetRichTextHtml(page, MainIntroAlias, culture);
+        if (!string.IsNullOrWhiteSpace(intro))
+        {
+            sb.Append("<p><b>").Append(intro).Append("</b></p>");
+        }
+
+        BlockListModel? accordions = page.HasProperty(AccordianListAlias)
+            ? page.Value<BlockListModel>(publishedValueFallback, AccordianListAlias, culture)
+            : null;
+        if (accordions is not { Count: > 0 })
+        {
+            return;
+        }
+
+        sb.Append("<h2>").Append(WebUtility.HtmlEncode(SchemaAccordionLabels.AboutHeading(culture))).Append("</h2>");
+
+        foreach (BlockListItem item in accordions)
+        {
+            IPublishedElement content = item.Content;
+            string? translatedKey = content.Value<string>(publishedValueFallback, TranslatedHeadingAlias, culture);
+            string? heading = SchemaAccordionLabels.TranslateHeading(translatedKey, culture)
+                ?? content.Value<string>(publishedValueFallback, HeadingAlias, culture);
+            if (!string.IsNullOrWhiteSpace(heading))
+            {
+                sb.Append("<h3>").Append(WebUtility.HtmlEncode(heading)).Append("</h3>");
+            }
+
+            string description = GetRichTextHtml(content, DescriptionAlias, culture);
+            if (!string.IsNullOrWhiteSpace(description))
+            {
+                sb.Append(description);
+            }
+        }
+    }
+
+    // RichText is stored as a JsonObject ({ items: [{ html, componentName }] }) by this repo's
+    // RichTextPropertyConverter, so Value<string> returns null and would silently drop the body.
+    // Read the JsonObject and concatenate the already-resolved item HTML (localLinks/media already
+    // filtered); fall back to Value<string> for plain-text properties (e.g. article mainIntro).
+    // Accepts IPublishedElement so it works for both pages and block elements (accordion items).
+    private string GetRichTextHtml(IPublishedElement content, string alias, string culture)
+    {
+        if (!content.HasProperty(alias))
+        {
+            return string.Empty;
+        }
+
+        JsonObject? json = content.Value<JsonObject>(publishedValueFallback, alias, culture);
+        if (json is null)
+        {
+            return content.Value<string>(publishedValueFallback, alias, culture) ?? string.Empty;
+        }
+
+        if (json["items"] is not JsonArray items)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        foreach (JsonNode? item in items)
+        {
+            string? html = item?["html"]?.GetValue<string>();
+            if (!string.IsNullOrWhiteSpace(html))
+            {
+                sb.Append(html);
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string? GetPublicBase(IPublishedContent? start, string culture)
+    {
+        string? absolute = start?.Url(culture, UrlMode.Absolute);
+        return Uri.TryCreate(absolute, UriKind.Absolute, out Uri? uri) ? uri.GetLeftPart(UriPartial.Authority) : null;
+    }
+
+    // Rewrites relative href/src to absolute against the public site base (NOT the
+    // backoffice request) so links and images resolve when the document is opened.
+    private static string AbsolutizeUrls(string html, string? publicBase)
+    {
+        if (string.IsNullOrEmpty(publicBase) || !Uri.TryCreate(publicBase, UriKind.Absolute, out Uri? baseUri))
+        {
+            return html;
+        }
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        foreach (HtmlNode node in doc.DocumentNode.Descendants().Where(n => n.Name is "a" or "img" or "link"))
+        {
+            string attribute = node.Name == "img" ? "src" : "href";
+            string value = node.GetAttributeValue(attribute, string.Empty);
+            if (!string.IsNullOrEmpty(value) && Uri.TryCreate(baseUri, value, out Uri? absolute))
+            {
+                node.SetAttributeValue(attribute, absolute.AbsoluteUri);
+            }
+        }
+
+        using var writer = new StringWriter();
+        doc.Save(writer);
+        return writer.ToString();
+    }
+
+    // Converts the HTML into NATIVE Word elements via HtmlToOpenXml (the same library the
+    // Optimizely report used) so the .docx carries a real table + styles, instead of an
+    // AltChunk that Word must convert on open. Mirrors the legacy heading cleanup so the
+    // converter doesn't choke on empty or digit-leading headings.
+    private static async Task<byte[]> HtmlToDocxAsync(string html)
+    {
+        var document = new HtmlDocument();
+        document.LoadHtml(html);
+        RemoveEmptyNodes(document.DocumentNode);
+        AddInvisibleCharacter(document.DocumentNode);
+        string cleaned = document.DocumentNode.OuterHtml;
+
+        using var ms = new MemoryStream();
+        using (WordprocessingDocument package = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            MainDocumentPart mainPart = package.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body());
+
+            var converter = new HtmlToOpenXml.HtmlConverter(mainPart);
+            await converter.ParseBody(cleaned);
+
+            mainPart.Document.Save();
+        }
+
+        return ms.ToArray();
+    }
+
+    // HtmlToOpenXml crashes converting empty headings/anchors; drop them first (legacy workaround).
+    private static void RemoveEmptyNodes(HtmlNode containerNode)
+    {
+        var nodesToRemove = new HashSet<string> { "a", "h1", "h2", "h3", "h4", "h5", "h6", "p" };
+        if (nodesToRemove.Contains(containerNode.Name) && string.IsNullOrEmpty(containerNode.InnerText))
+        {
+            containerNode.Remove();
+            return;
+        }
+
+        for (int i = containerNode.ChildNodes.Count - 1; i >= 0; i--)
+        {
+            RemoveEmptyNodes(containerNode.ChildNodes[i]);
+        }
+    }
+
+    // HtmlToOpenXml mishandles headings that start with a digit; NBSP-prefix them (legacy workaround).
+    private static void AddInvisibleCharacter(HtmlNode containerNode)
+    {
+        var headingTags = new HashSet<string> { "h1", "h2", "h3", "h4", "h5", "h6" };
+        if (headingTags.Contains(containerNode.Name)
+            && !string.IsNullOrEmpty(containerNode.InnerText)
+            && char.IsDigit(containerNode.InnerText[0]))
+        {
+            containerNode.ParentNode.ReplaceChild(
+                HtmlNode.CreateNode("<h2> " + containerNode.InnerText + "</h2>"), containerNode);
+            return;
+        }
+
+        for (int i = containerNode.ChildNodes.Count - 1; i >= 0; i--)
+        {
+            AddInvisibleCharacter(containerNode.ChildNodes[i]);
+        }
+    }
+
+    private static string BuildFileName(ExportFilters filters, string culture)
+    {
+        // Mirror Optimizely's "Provider-Author-Language" name; blank filters read as "Alle" and a
+        // blank language falls back to the resolved culture (e.g. "Articles ALLE-Alle-nb.docx").
+        string provider = string.IsNullOrWhiteSpace(filters.Provider) ? "Alle" : filters.Provider;
+        string author = string.IsNullOrWhiteSpace(filters.Author) ? "Alle" : filters.Author;
+        string language = string.IsNullOrWhiteSpace(filters.Language) ? culture : filters.Language;
+        return $"Articles {Sanitize($"{provider}-{author}-{language}")}.docx";
+    }
+
+    // Strips CR/LF, other control chars, and path-invalid characters so the value is
+    // safe inside the Content-Disposition header; File() applies RFC 6266 encoding for
+    // any remaining non-ASCII characters.
+    private static string Sanitize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        char[] invalid = Path.GetInvalidFileNameChars();
+        string cleaned = new([.. value.Where(c => !char.IsControl(c) && !invalid.Contains(c))]);
+        cleaned = cleaned.Trim();
+        return cleaned.Length > 80 ? cleaned[..80] : cleaned;
+    }
+}

--- a/umbraco-infoportal/ArticleExport/Services/SchemaAccordionLabels.cs
+++ b/umbraco-infoportal/ArticleExport/Services/SchemaAccordionLabels.cs
@@ -1,0 +1,61 @@
+namespace umbraco_infoportal.ArticleExport.Services;
+
+// Mirror of the frontend schema i18n keys (astro-infoportal/src/i18n/locales/*.json).
+// A schemaAccordianBlock's `translatedHeading` holds one of these keys; the backend
+// has no Umbraco dictionary, so we resolve them here to keep the export in step with
+// the live site. Keyed by 2-letter ISO prefix (nb/nn/en).
+internal static class SchemaAccordionLabels
+{
+    private static readonly Dictionary<string, string> AboutThisSchema = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["nb"] = "Om denne tjenesten",
+        ["nn"] = "Om denne tenesta",
+        ["en"] = "About this form",
+    };
+
+    private static readonly Dictionary<string, Dictionary<string, string>> Headings = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["schema.accordions.whenToUse"] = new() { ["nb"] = "Når skal jeg bruke denne tjenesten?", ["nn"] = "Når skal eg bruke denne tenesta?", ["en"] = "When should I use this service?" },
+        ["schema.accordions.summary"] = new() { ["nb"] = "Kort om tjenesten", ["nn"] = "Kort om tenesta", ["en"] = "About the service" },
+        ["schema.accordions.requirements"] = new() { ["nb"] = "Krav til innsender", ["nn"] = "Krav til innsendar", ["en"] = "Requirements" },
+        ["schema.accordions.submission"] = new() { ["nb"] = "Innlevering", ["nn"] = "Innlevering", ["en"] = "Submission" },
+        ["schema.accordions.whoShouldSend"] = new() { ["nb"] = "Hvem skal levere?", ["nn"] = "Kven skal levere?", ["en"] = "Who should complete this?" },
+        ["schema.accordions.submissionBySystem"] = new() { ["nb"] = "Innsending fra datasystem", ["nn"] = "Innsending frå datasystem", ["en"] = "Reporting through a computer system" },
+        ["schema.accordions.rules"] = new() { ["nb"] = "Lovhjemmel", ["nn"] = "Lovheimel", ["en"] = "Legal basis" },
+        ["schema.accordions.category"] = new() { ["nb"] = "Kategori", ["nn"] = "Kategori", ["en"] = "Category" },
+        ["schema.accordions.agency"] = new() { ["nb"] = "Etater", ["nn"] = "Etatar", ["en"] = "Agency" },
+        ["schema.accordions.whatAttachments"] = new() { ["nb"] = "Hvilke vedleggsskjema finnes for dette skjemaet?", ["nn"] = "Kva vedleggsskjema finst for dette skjemaet?", ["en"] = "What attachment forms exist for this form?" },
+        ["schema.accordions.whoNeedsToSend"] = new() { ["nb"] = "Hvem må sende", ["nn"] = "Kven må sende", ["en"] = "Who has to complete" },
+        ["schema.accordions.whoDoesntNeedToSend"] = new() { ["nb"] = "Hvem må ikke sende", ["nn"] = "Kven må ikkje sende", ["en"] = "Who is exempt" },
+        ["schema.accordions.ifYouDontSend"] = new() { ["nb"] = "Hvis du ikke leverer", ["nn"] = "Om du ikkje leverer", ["en"] = "What if I don't complete" },
+        ["schema.importAccordions.a"] = new() { ["nb"] = "Hva skal jeg legge ved?", ["nn"] = "Kva skal eg leggje ved?", ["en"] = "What should I attach?" },
+        ["schema.importAccordions.b"] = new() { ["nb"] = "Når skal skjemaet brukes?", ["nn"] = "Når skal skjemaet brukast?", ["en"] = "When should I use this form?" },
+        ["schema.importAccordions.c"] = new() { ["nb"] = "Hvem skal bruke skjemaet?", ["nn"] = "Kven skal bruke skjemaet?", ["en"] = "Who should use this form?" },
+        ["schema.importAccordions.d"] = new() { ["nb"] = "Hvorfor skal skjemaet brukes?", ["nn"] = "Kvifor skal skjemaet brukast?", ["en"] = "Why should I use this form?" },
+        ["schema.importAccordions.e"] = new() { ["nb"] = "Mer om skjemaet", ["nn"] = "Meir om skjemaet", ["en"] = "More about the form" },
+        ["schema.importAccordions.f"] = new() { ["nb"] = "Gamle versjoner av skjemaet", ["nn"] = "Gamle versjonar av skjemaet", ["en"] = "Old versions of the form" },
+    };
+
+    public static string AboutHeading(string? isoCode) =>
+        Lookup(AboutThisSchema, isoCode) ?? AboutThisSchema["nb"];
+
+    // Returns null when the key is empty or unknown so the caller can fall back to the
+    // editor-typed `heading` field.
+    public static string? TranslateHeading(string? key, string? isoCode)
+    {
+        if (string.IsNullOrWhiteSpace(key) || !Headings.TryGetValue(key, out Dictionary<string, string>? byLang))
+        {
+            return null;
+        }
+
+        return Lookup(byLang, isoCode) ?? Lookup(byLang, "nb");
+    }
+
+    private static string? Lookup(Dictionary<string, string> map, string? isoCode)
+    {
+        string prefix = string.IsNullOrEmpty(isoCode)
+            ? string.Empty
+            : isoCode[..Math.Min(2, isoCode.Length)];
+        return map.TryGetValue(prefix, out string? value) ? value : null;
+    }
+}

--- a/umbraco-infoportal/appsettings.Development.json
+++ b/umbraco-infoportal/appsettings.Development.json
@@ -27,6 +27,9 @@
       },
       "BasicAuth": {
         "RedirectToLoginPage": true
+      },
+      "WebRouting": {
+        "UmbracoApplicationUrl": "https://localhost:44391/"
       }
     },
     "Storage": {
@@ -42,8 +45,8 @@
     "Enabled": false
   },
   "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+    "umbracoDbDSN": "Server=localhost;Database=;Integrated Security=true;TrustServerCertificate=true;Encrypt=false;MultipleActiveResultSets=true",
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
   }
 }
 

--- a/umbraco-infoportal/appsettings.Development.json
+++ b/umbraco-infoportal/appsettings.Development.json
@@ -45,7 +45,7 @@
     "Enabled": false
   },
   "ConnectionStrings": {
-    "umbracoDbDSN": "Server=localhost;Database=;Integrated Security=true;TrustServerCertificate=true;Encrypt=false;MultipleActiveResultSets=true",
+    "umbracoDbDSN": "Server=;Database=;Integrated Security=true;TrustServerCertificate=true;Encrypt=false;MultipleActiveResultSets=true",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.SqlClient"
   }
 }

--- a/umbraco-infoportal/umbraco-infoportal.csproj
+++ b/umbraco-infoportal/umbraco-infoportal.csproj
@@ -10,7 +10,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
+    <PackageReference Include="HtmlToOpenXml.dll" Version="3.4.1" />
     <PackageReference Include="MimeKit" Version="4.16.0" />
+    <PackageReference Include="PreMailer.Net" Version="2.7.2" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
     <PackageReference Include="Umbraco.Cms" Version="17.4.0" />
     <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.3.5" />


### PR DESCRIPTION
Migrated the "Artikkel eksport" admin report to Umbraco 17. From **Settings → Artikkel eksport**, an admin filters articles, schemas, and subsidies by service owner (tjenesteeier), coordinator (koordinator), language, and date range, then downloads a Word document.

## Description
- Same filters and the same four-case service-owner/coordinator combine logic.
- Case-sensitive `"Alle"` all-option, kept distinct from the real `"ALLE` service owner. Working like in `Optimizely`
- `Eier(e) | Innhold` table rendered to native Word via HtmlToOpenXml (same library as before); `Articles {Owner}-{Coordinator}-{Language}.docx` filename; content-tree page order.
- Owner/coordinator data read from the migrated `contentOwner` (Innholdseiere) / `subjectMatterExpert` (Fageksperter) pickers, plus the schema `providers` picker and subsidy `agency`/`coordinator` fields.
- Owner column shows full node names (`Innovasjon Norge (IN)`); `Optimizely` used short codes, and there's no short-code field to map

Backoffice tool (Settings > Artikkel eksport) that filters articles, schemas, and subsidies by service owner, coordinator, language, and date and downloads a Word document. Management API endpoint + Lit dashboard; reads the contentOwner/subjectMatterExpert pickers; .docx via HtmlToOpenXml.

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/284

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
