### PR TITLE
feat: add external link class for tracking with siteimprove

### DIFF
--- a/astro-infoportal/src/Components/Pages/SchemaPage/SchemaPage.tsx
+++ b/astro-infoportal/src/Components/Pages/SchemaPage/SchemaPage.tsx
@@ -76,7 +76,9 @@ const SchemaPage = ({
     ) : null;
 
   const shallowLinkButton = shallowLink ? (
-    <DsLink href={shallowLink}>{shallowLinkText}</DsLink>
+    <DsLink href={shallowLink} className="external-skjema-link">
+      {shallowLinkText}
+    </DsLink>
   ) : null;
 
   const owners: ProviderInlineItem[] = (providerPages || [])


### PR DESCRIPTION
Issue: https://github.com/Altinn/team-portal-private/issues/30

Beskrivelse:
### Hva
Legger til CSS-klassen `external-skjema-link` på lenken som genereres fra feltet
«Link til skjema hos tjenesteeier» (`shallowLink`) på skjemasider.

### Hvorfor
Gjør det mulig å spore klikk på eksterne skjemalenker i Siteimprove, slik at vi får
reelle tall på hvor mange som går videre til eksterne skjema.

### Detaljer
- Klassen har ingen styling – den er kun en sporingskrok. Ingen visuell endring.
- Endringen er kun i `astro-infoportal` (`SchemaPage.tsx`).
- Kun den eksterne lenken er merket. Intern Altinn/SBL-knapp er ikke endret.
- Tester: 44/44 grønne.

### Oppfølging
Ola setter opp sporing i Siteimprove på selektoren `a.external-skjema-link`
(se kommentar i https://github.com/Altinn/team-portal-private/issues/30).