### PR TITLE
fix: align infobanner with logged-in banner

### DIFF
--- a/astro-infoportal/src/Components/Blocks/BannerBlock/BannerBlock.scss
+++ b/astro-infoportal/src/Components/Blocks/BannerBlock/BannerBlock.scss
@@ -1,5 +1,7 @@
 // Banner component inspired by @altinn/altinn-components Banner
 
+// Inline CMS content block: editor-chosen color (light tinted surface), custom
+// close button, no leading icon.
 .banner-block {
   background-color: var(--ds-color-base-default);
   color: var(--ds-color-base-contrast-default);
@@ -90,6 +92,47 @@
   }
 
   // Hide banner when header menu/account drawer is open on phones
+  @media (max-width: 1023px) {
+    &:has(~ * [data-current-id="menu"]),
+    &:has(~ * [data-current-id="account"]) {
+      display: none;
+    }
+  }
+}
+
+// Global top banner (#571): thin wrapper around the @altinn/altinn-components
+// Banner ("Strong Company": variant="strong" inside data-color="company" →
+// dark-navy surface, white text, native info icon — matching the logged-in
+// banner). The library owns colors/icon/close button; this wrapper provides the
+// company color context and styles the RichText/Badge injected into the title
+// slot, and hides the banner behind the mobile menu.
+.banner-block-strong {
+  // The Banner lays out its leading icon inline. RichText renders a block
+  // <div class="rich-text"><p>…</p></div>, which would otherwise wrap onto the
+  // line below the icon. Render it inline so the message sits beside the icon.
+  .rich-text,
+  .rich-text > * {
+    display: inline;
+    margin: 0;
+  }
+
+  // Keep the injected link readable and underlined, inheriting the Banner's
+  // (white) text color via currentColor.
+  a {
+    color: currentColor;
+    text-decoration: underline;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  // Badge: white background (doubled class beats library specificity).
+  .altinn-badge.altinn-badge {
+    background-color: #FFFFFF;
+  }
+
+  // Hide the banner when the header menu/account drawer is open on phones.
   @media (max-width: 1023px) {
     &:has(~ * [data-current-id="menu"]),
     &:has(~ * [data-current-id="account"]) {

--- a/astro-infoportal/src/Components/Blocks/BannerBlock/BannerBlock.tsx
+++ b/astro-infoportal/src/Components/Blocks/BannerBlock/BannerBlock.tsx
@@ -1,4 +1,4 @@
-import {Badge} from '@altinn/altinn-components';
+import {Badge, Banner} from '@altinn/altinn-components';
 import {XMarkIcon} from '@navikt/aksel-icons';
 import {useEffect, useState} from 'react';
 import {RichTextArea} from '/App.Components';
@@ -11,6 +11,7 @@ const BannerBlock = ({
   isActive,
   badgeText,
   colorTheme,
+  variant,
   closeButtonText,
   contentHash,
   localStoragePrefix,
@@ -36,6 +37,46 @@ const BannerBlock = ({
     }
   }, [contentHash, localStoragePrefix]);
 
+  const handleClose = () => {
+    const storageKey = `${localStoragePrefix}-${contentHash}`;
+    localStorage.setItem(storageKey, 'true');
+    setIsDismissed(true);
+  };
+
+  if (!isActive || isDismissed) {
+    return null;
+  }
+
+  // Global top banner (#571): the altinn-components "Strong Company" banner —
+  // dark-navy surface + white text + white info icon, matching the logged-in
+  // (AF/Tilgangsstyring) banner. variant="strong" inherits its color from the
+  // parent's data-color context, so the wrapper sets data-color="company" to
+  // resolve the company navy ("company" is not a valid Banner `color` value).
+  // No custom icon — the library renders its native one. `buildBanner` sets
+  // variant="strong"; the inline content-block path never sets it.
+  if (variant === 'strong') {
+    return (
+      <div className="banner-block-strong" data-color="company">
+        <Banner
+          variant="strong"
+          sticky={false}
+          closeTitle={closeButtonText || 'Close'}
+          onClose={handleClose}
+          title={
+            <>
+              {badgeText && (
+                <Badge label={badgeText} size="sm" className="altinn-badge" />
+              )}
+              <RichTextArea {...message} />
+            </>
+          }
+        />
+      </div>
+    );
+  }
+
+  // Inline CMS content block: editor-chosen color (light tinted surface),
+  // no leading icon. This is the original BannerBlock rendering.
   const validColors = [
     'accent',
     'success',
@@ -48,16 +89,6 @@ const BannerBlock = ({
   )
     ? (colorTheme as (typeof validColors)[number])
     : 'accent';
-
-  const handleClose = () => {
-    const storageKey = `${localStoragePrefix}-${contentHash}`;
-    localStorage.setItem(storageKey, 'true');
-    setIsDismissed(true);
-  };
-
-  if (!isActive || isDismissed) {
-    return null;
-  }
 
   return (
     <section

--- a/astro-infoportal/src/Constants/startPageLinks.test.ts
+++ b/astro-infoportal/src/Constants/startPageLinks.test.ts
@@ -1,0 +1,65 @@
+import {describe, expect, it} from "vitest";
+import {buildBanner} from "./startPageLinks";
+
+const makeBanner = (overrides: Record<string, unknown> = {}) => [
+  {
+    properties: {
+      isActive: true,
+      badgeText: "Nyhet",
+      colorTheme: "lyseblå",
+      message: {
+        items: [{html: "<p>Altinn er fornyet. <a href='/x'>Les mer</a></p>"}],
+      },
+      ...overrides,
+    },
+  },
+];
+
+describe("buildBanner", () => {
+  it("returns null when there is no banner value", () => {
+    expect(buildBanner(null, "Lukk")).toBeNull();
+    expect(buildBanner(undefined, "Lukk")).toBeNull();
+    expect(buildBanner([], "Lukk")).toBeNull();
+  });
+
+  it("returns null when the message has no items", () => {
+    expect(buildBanner(makeBanner({message: {items: []}}), "Lukk")).toBeNull();
+  });
+
+  it("maps a valid banner to the BannerBlock view model", () => {
+    const result = buildBanner(makeBanner(), "Lukk");
+    expect(result).toMatchObject({
+      isActive: true,
+      badgeText: "Nyhet",
+      variant: "strong",
+      closeButtonText: "Lukk",
+      localStoragePrefix: "infoportal-banner-dismissed",
+      componentName: "BannerBlock",
+      message: {componentName: "RichTextArea"},
+    });
+    expect(result?.message.items).toHaveLength(1);
+    expect(result?.contentHash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("does not emit a colorTheme (banner color is fixed to the strong variant)", () => {
+    expect(buildBanner(makeBanner(), "Lukk")).not.toHaveProperty("colorTheme");
+  });
+
+  it("coerces isActive to a boolean and defaults badgeText to empty string", () => {
+    const result = buildBanner(
+      makeBanner({isActive: undefined, badgeText: undefined}),
+      "Lukk",
+    );
+    expect(result?.isActive).toBe(false);
+    expect(result?.badgeText).toBe("");
+  });
+
+  it("produces a different contentHash when the message changes", () => {
+    const a = buildBanner(makeBanner(), "Lukk");
+    const b = buildBanner(
+      makeBanner({message: {items: [{html: "<p>Annen melding</p>"}]}}),
+      "Lukk",
+    );
+    expect(a?.contentHash).not.toEqual(b?.contentHash);
+  });
+});

--- a/astro-infoportal/src/Constants/startPageLinks.ts
+++ b/astro-infoportal/src/Constants/startPageLinks.ts
@@ -41,15 +41,6 @@ function hashMessage(html: string): string {
   return h.toString(16).padStart(16, "0");
 }
 
-// "Banner Color" dropdown labels → Designsystemet roles (BannerBlock.scss keys on these).
-const BANNER_COLOR_BY_LABEL: Record<string, string> = {
-  "blå": "accent",
-  "lyseblå": "info",
-  "grønn": "success",
-  gul: "warning",
-  "rød": "danger",
-};
-
 // `message` arrives pre-shaped as { items: [...] } from the backend RichText converter.
 export function buildBanner(bannerValue: unknown, closeButtonText: string) {
   const first = Array.isArray(bannerValue) ? bannerValue[0] : bannerValue;
@@ -69,10 +60,7 @@ export function buildBanner(bannerValue: unknown, closeButtonText: string) {
     message: { items: messageItems, componentName: "RichTextArea" },
     isActive: Boolean(props.isActive),
     badgeText: (props.badgeText as string) ?? "",
-    colorTheme:
-      BANNER_COLOR_BY_LABEL[
-        ((props.colorTheme as string) ?? "").trim().toLowerCase()
-      ] ?? "accent",
+    variant: "strong",
     closeButtonText,
     contentHash: hashMessage(html),
     localStoragePrefix: "infoportal-banner-dismissed",


### PR DESCRIPTION
Tittel:
Juster infobanner slik at det matcher banneret etter innlogging (#571)

Beskrivelse:
Justerer det globale infobanneret slik at det matcher banneret etter
innlogging (AF/Tilgangsstyring): mørk marineblå bakgrunn, hvit tekst og
hvitt info-ikon.

Banneret rendres nå med `Banner` fra `@altinn/altinn-components`
(`variant="strong"` inni `data-color="company"`) i stedet for egen styling.
Endringen er avgrenset til det globale banneret, slik at innholdsblokker
(BannerBlock i CMS) beholder sine egne farger. Fjernet ubrukt
`colorTheme`-mapping i `buildBanner` og la til en enhetstest.

Verifisert visuelt mot designet i altinn-components ("Strong Company").