### PR TITLE
fix: keep global menu visible when actor selector opens

### DIFF
--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.scss
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.scss
@@ -35,3 +35,14 @@ body {
   font-weight: 400;
   line-height: 1.25;
 }
+
+/* Issue #576: feed the infoportal banner-stack height into
+   @altinn/altinn-components. The library positions the actor-selector
+   drawer/backdrop at `top: calc(4.5rem + var(--altinn-banner-height))` and
+   defaults the variable to 0 on the layout base. useBannerHeight publishes the
+   measured height as `--infoportal-banner-height` on <html>; this rule maps it
+   onto the library variable. `div[data-theme]` targets only the layout base,
+   and its specificity (0,1,1) beats the library's class rule (0,1,0). */
+div[data-theme] {
+  --altinn-banner-height: var(--infoportal-banner-height, 0px);
+}

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
@@ -3,11 +3,12 @@ import * as Components from "../../../App.Components";
 import "@altinn/altinn-components/dist/global.css";
 import "@digdir/designsystemet-theme";
 import "@digdir/designsystemet-css";
-import type { SiteLayoutProps } from "./SiteLayout.types";
 import useSidebarConfig from "../../Shared/PageSidebar/useSidebarConfig";
 import useFooterConfig from "../Footer/useFooterConfig";
-import useHeaderConfig from "../Header/useHeaderConfig";
 import { useLanguagePreference } from "../Header/hooks/useLanguagePreference";
+import useHeaderConfig from "../Header/useHeaderConfig";
+import type { SiteLayoutProps } from "./SiteLayout.types";
+import { useBannerHeight } from "./useBannerHeight";
 import { useHashScroll } from "./useHashScroll";
 import "./SiteLayout.scss";
 import { SkipLink } from "@digdir/designsystemet-react";
@@ -26,6 +27,10 @@ const SiteLayout = ({
 
   // Scroll to a #section target on cold loads once layout has settled.
   useHashScroll();
+
+  // Issue #576: keep --altinn-banner-height in sync so the actor-selector drawer
+  // offsets below the banner instead of hiding the global-menu row.
+  useBannerHeight();
 
   const currentLanguage = headerViewModel?.menuLanguageList?.find(
     (l: any) => l.selected,

--- a/astro-infoportal/src/Components/Layout/SiteLayout/bannerHeight.test.ts
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/bannerHeight.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { sumOffsetHeights } from "./bannerHeight";
+
+describe("sumOffsetHeights", () => {
+  it("returns 0 when no banners are present", () => {
+    expect(sumOffsetHeights([null, null, null])).toBe(0);
+  });
+
+  it("sums the heights of present banners", () => {
+    expect(
+      sumOffsetHeights([{ offsetHeight: 56 }, null, { offsetHeight: 80 }]),
+    ).toBe(136);
+  });
+
+  it("ignores hidden banners (offsetHeight 0)", () => {
+    expect(sumOffsetHeights([{ offsetHeight: 0 }, { offsetHeight: 64 }])).toBe(
+      64,
+    );
+  });
+});

--- a/astro-infoportal/src/Components/Layout/SiteLayout/bannerHeight.ts
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/bannerHeight.ts
@@ -1,0 +1,10 @@
+/**
+ * Sum the rendered heights of the banner elements stacked above the layout.
+ * A missing banner (null) or a hidden one (display:none → offsetHeight 0)
+ * contributes nothing, so the total reflects only what is actually visible.
+ */
+export function sumOffsetHeights(
+  elements: ReadonlyArray<Pick<HTMLElement, "offsetHeight"> | null>,
+): number {
+  return elements.reduce((total, el) => total + (el?.offsetHeight ?? 0), 0);
+}

--- a/astro-infoportal/src/Components/Layout/SiteLayout/useBannerHeight.ts
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/useBannerHeight.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import { sumOffsetHeights } from "./bannerHeight";
+
+// The infoportal banners stacked above the altinn-components <Layout>. Matched
+// by class (never wrapped) so BannerBlock.scss's `:has(~ * [data-current-id])`
+// sibling rule keeps working.
+const BANNER_SELECTORS = [
+  ".consent-banner",
+  ".banner-block-strong",
+  ".banner-block",
+] as const;
+
+/**
+ * Issue #576. The altinn-components <Layout> positions the actor-selector drawer
+ * and its backdrop at `top: calc(4.5rem + var(--altinn-banner-height))`,
+ * defaulting the variable to 0 on the layout base. The infoportal renders its
+ * banners *above* <Layout> (not through the library's banner slot), so the
+ * variable is never set and the drawer/backdrop cover the banner-displaced
+ * global-menu row.
+ *
+ * This hook measures the visible banner stack and publishes its height as
+ * `--infoportal-banner-height` on <html>. A rule in SiteLayout.scss maps that
+ * onto `--altinn-banner-height` on the layout base, so the drawer offsets below
+ * the banner and the menu row stays visible. A hidden banner reports
+ * offsetHeight 0, so the value shrinks to match (keeping it consistent with the
+ * mobile drawer-open hide rule).
+ */
+export function useBannerHeight(): void {
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    const root = document.documentElement;
+
+    const measure = () => {
+      const elements = BANNER_SELECTORS.map((sel) =>
+        document.querySelector<HTMLElement>(sel),
+      );
+      root.style.setProperty(
+        "--infoportal-banner-height",
+        `${sumOffsetHeights(elements)}px`,
+      );
+    };
+
+    // Coalesce bursts of observer callbacks into a single layout read.
+    let frame = 0;
+    const update = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(measure);
+    };
+
+    // Size changes of any present banner: content reflow, viewport media-query
+    // changes, and display:none toggling (offsetHeight → 0).
+    const resizeObserver = new ResizeObserver(update);
+    const observeBanners = () => {
+      resizeObserver.disconnect();
+      for (const sel of BANNER_SELECTORS) {
+        const el = document.querySelector(sel);
+        if (el) resizeObserver.observe(el);
+      }
+    };
+
+    // Banners are decided client-side (consent / dismissal), so they mount and
+    // unmount after hydration. Re-bind the size observer and re-measure.
+    const mutationObserver = new MutationObserver(() => {
+      observeBanners();
+      update();
+    });
+    mutationObserver.observe(document.body, { childList: true, subtree: true });
+
+    observeBanners();
+    measure();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      root.style.removeProperty("--infoportal-banner-height");
+    };
+  }, []);
+}


### PR DESCRIPTION
### Problem https://github.com/Altinn/altinn-tests/issues/576
I infoportalen forsvinner hele den globale menyraden (Altinn-logo, valgt aktør og «Meny») når aktørvelgeren åpnes. På de andre flatene (innboks, profil, tilgangsstyring) forblir raden synlig.

### Årsak
Den globale menyen kommer fra `@altinn/altinn-components` (`<Layout>`), som plasserer aktørvelgeren og backdrop på `top: calc(4.5rem + var(--altinn-banner-height))`. Infoportalen rendrer bannerne over `<Layout>` uten å sette `--altinn-banner-height`, så variabelen er `0px`. Dermed legger panelet og backdrop seg oppå menyraden som banneret har skjøvet nedover. (De andre flatene mater banneret gjennom bibliotekets eget banner-slot, så der settes variabelen.)

### Løsning
- Ny hook `useBannerHeight` måler høyden på den synlige bannerstabelen og publiserer den som `--infoportal-banner-height` på `<html>` (re-måler via ResizeObserver/MutationObserver).
- En CSS-regel (`div[data-theme]`) mapper verdien til bibliotekets `--altinn-banner-height`.
- Banner og menyrad blir nå begge synlige, med aktørvelgeren under – likt de andre flatene.
