### PR TITLE
fix: wrap tables in a responsive, accessible scroll container

### DIFF
--- a/astro-infoportal/src/Components/Shared/RichText/RichText.scss
+++ b/astro-infoportal/src/Components/Shared/RichText/RichText.scss
@@ -6,6 +6,20 @@
     margin-bottom: 1.5rem;
   }
 
+  /* Wrapper added around tables in htmlTransforms.ts so a wide table scrolls
+     horizontally instead of overflowing the page on narrow screens (issue
+     #359). It's keyboard-focusable (tabindex="0"), so it needs a visible
+     focus ring (WCAG 2.4.7). */
+  .rich-text-table {
+    overflow-x: auto;
+    margin-bottom: 1.5rem;
+
+    &:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 2px;
+    }
+  }
+
   h2 {
     position: relative;
 

--- a/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.test.ts
+++ b/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { transformRichTextHtml } from "./htmlTransforms";
+import {
+  transformRichTextHtml,
+  walkAndTransformRichText,
+} from "./htmlTransforms";
 
 const transform = (html: string) =>
   transformRichTextHtml(html, {
@@ -97,5 +100,60 @@ describe("accessible heading section anchors (issue #533)", () => {
     const out = transformWithAnchors("<h2>Skatt</h2><h2>Skatt</h2>");
     expect(out).toContain('id="skatt"');
     expect(out).toContain('id="skatt-2"');
+  });
+});
+
+describe("rewriteTables: responsive scroll wrapper (issue #359)", () => {
+  it("wraps the table in a focusable horizontal-scroll container", () => {
+    const out = transform(
+      "<table><tbody>" +
+        "<tr><td>A</td><td>B</td></tr>" +
+        "<tr><td>1</td><td>2</td></tr>" +
+        "</tbody></table>",
+    );
+    // the table is wrapped so wide tables can scroll instead of overflowing,
+    // and the wrapper is keyboard-focusable so it can be scrolled without a mouse
+    expect(out).toMatch(/<div class="rich-text-table"[^>]*>\s*<table/);
+    expect(out).toContain('tabindex="0"');
+    // the table itself is preserved inside the wrapper
+    expect(out).toContain("ds-table");
+  });
+
+  it("does not double-wrap when run again on already-transformed HTML", () => {
+    const once = transform(
+      "<table><tbody><tr><td>A</td></tr><tr><td>1</td></tr></tbody></table>",
+    );
+    const twice = transform(once);
+    expect(count(twice, /class="rich-text-table"/g)).toBe(1);
+  });
+
+  it("makes the wrapper a labelled region only when a table label is given", () => {
+    const withLabel = transformRichTextHtml(
+      "<table><tbody><tr><td>A</td></tr><tr><td>1</td></tr></tbody></table>",
+      { usedIds: new Set<string>(), addAnchors: false, tableLabel: "Tabell" },
+    );
+    expect(withLabel).toContain('role="region"');
+    expect(withLabel).toContain('aria-label="Tabell"');
+
+    // Without a label, don't emit an unnamed region (landmark noise / WCAG).
+    const noLabel = transform(
+      "<table><tbody><tr><td>A</td></tr><tr><td>1</td></tr></tbody></table>",
+    );
+    expect(noLabel).not.toContain('role="region"');
+  });
+
+  it("threads the table label through walkAndTransformRichText to nested items", () => {
+    const data = {
+      items: [
+        {
+          componentName: "RichText",
+          html: "<table><tbody><tr><td>A</td></tr><tr><td>1</td></tr></tbody></table>",
+        },
+      ],
+    };
+    walkAndTransformRichText(data, { tableLabel: "Tabell" });
+    expect((data.items[0] as { html: string }).html).toContain(
+      'aria-label="Tabell"',
+    );
   });
 });

--- a/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.ts
+++ b/astro-infoportal/src/Components/Shared/RichText/htmlTransforms.ts
@@ -9,6 +9,10 @@ export interface RichTextTransformOptions {
   // Localized prefix for the heading permalink's accessible name, e.g.
   // "Lenke til seksjonen" → aria-label "Lenke til seksjonen {heading}".
   anchorLabel?: string;
+  // Localized accessible name for the table scroll container, e.g. "Tabell".
+  // When set, the wrapper becomes a labelled `role="region"`; when omitted it
+  // stays an unnamed (but still keyboard-scrollable) container.
+  tableLabel?: string;
 }
 
 export function transformRichTextHtml(
@@ -22,7 +26,7 @@ export function transformRichTextHtml(
   if (options.addAnchors) {
     addHeadingAnchors(root, options.usedIds, options.anchorLabel ?? "");
   }
-  rewriteTables(root);
+  rewriteTables(root, options.tableLabel);
   rewriteLinks(root);
 
   return root.toString();
@@ -36,9 +40,12 @@ export function transformRichTextHtml(
  * different string due to environment-specific `node-html-parser` behavior,
  * which is exactly the React hydration mismatch this is here to prevent.
  */
-export function walkAndTransformRichText(node: unknown): void {
+export function walkAndTransformRichText(
+  node: unknown,
+  options?: { tableLabel?: string },
+): void {
   if (Array.isArray(node)) {
-    for (const item of node) walkAndTransformRichText(item);
+    for (const item of node) walkAndTransformRichText(item, options);
     return;
   }
   if (typeof node !== "object" || node === null) return;
@@ -58,13 +65,14 @@ export function walkAndTransformRichText(node: unknown): void {
           usedIds,
           addAnchors,
           anchorLabel,
+          tableLabel: options?.tableLabel,
         });
       }
     }
   }
 
   for (const value of Object.values(node)) {
-    walkAndTransformRichText(value);
+    walkAndTransformRichText(value, options);
   }
 }
 
@@ -115,7 +123,7 @@ function addHeadingAnchors(
   }
 }
 
-function rewriteTables(root: HTMLElement): void {
+function rewriteTables(root: HTMLElement, tableLabel?: string): void {
   const tables = root.querySelectorAll("table");
   for (const table of tables) {
     const classes = splitClasses(table.getAttribute("class"));
@@ -133,6 +141,27 @@ function rewriteTables(root: HTMLElement): void {
 
     promoteFirstRowToHeader(table);
     downgradeEmptyHeaders(table);
+
+    // Wrap the table so a wide table scrolls horizontally instead of
+    // overflowing the page on narrow screens (issue #359). `tabindex="0"`
+    // makes the scroll container reachable by keyboard (WCAG 2.1.1). Guard
+    // against double-wrapping if the transform runs on already-rewritten HTML.
+    const parent = table.parentNode as HTMLElement | null;
+    const alreadyWrapped = splitClasses(parent?.getAttribute?.("class")).some(
+      (c) => c === "rich-text-table",
+    );
+    if (!alreadyWrapped) {
+      // A named region helps screen-reader users find/scroll the table; skip
+      // the name (no `role="region"`) when none is supplied to avoid an
+      // unnamed landmark.
+      const region = tableLabel
+        ? ` role="region" aria-label="${escapeAttr(tableLabel)}"`
+        : "";
+      const wrapper = parse(
+        `<div class="rich-text-table" tabindex="0"${region}>${table.toString()}</div>`,
+      ).firstChild as HTMLElement;
+      table.replaceWith(wrapper);
+    }
   }
 }
 

--- a/astro-infoportal/src/i18n/locales/en.json
+++ b/astro-infoportal/src/i18n/locales/en.json
@@ -6,6 +6,7 @@
   "common.clickHere": "Click here",
   "common.lastUpdated": "Last updated",
   "common.linkToSection": "Link to section",
+  "common.table": "Table",
   "common.and": "and",
   "common.to": "To",
   "common.from": "From",

--- a/astro-infoportal/src/i18n/locales/nb.json
+++ b/astro-infoportal/src/i18n/locales/nb.json
@@ -6,6 +6,7 @@
   "common.clickHere": "Klikk her",
   "common.lastUpdated": "Sist oppdatert",
   "common.linkToSection": "Lenke til seksjonen",
+  "common.table": "Tabell",
   "common.and": "og",
   "common.to": "Til",
   "common.from": "Fra",

--- a/astro-infoportal/src/i18n/locales/nn.json
+++ b/astro-infoportal/src/i18n/locales/nn.json
@@ -6,6 +6,7 @@
   "common.clickHere": "Klikk her",
   "common.lastUpdated": "Sist oppdatert",
   "common.linkToSection": "Lenke til seksjonen",
+  "common.table": "Tabell",
   "common.and": "og",
   "common.to": "Til",
   "common.from": "Frå",

--- a/astro-infoportal/src/transformers/JSONTransformer.ts
+++ b/astro-infoportal/src/transformers/JSONTransformer.ts
@@ -81,7 +81,9 @@ export class JSONTransformer implements IJSONTransformer {
 
     // Pre-transform RichText HTML once, server-side, so it ships identical
     // to SSR output and the client doesn't re-parse during hydration.
-    walkAndTransformRichText(data);
+    walkAndTransformRichText(data, {
+      tableLabel: t("common.table", globalData?.locale),
+    });
 
     return data;
   }


### PR DESCRIPTION
Issue #359.

### Hva er endret
Tabeller i riktekst-felt (migrert fra gammel portal) pakkes nå inn i en
responsiv og mer tilgjengelig beholder. Selve utseendet er uendret – på brede
skjermer ser tabellen lik ut som før (Designsystemets `ds-table` med vekslende
radfarger).

- Hver tabell pakkes i `<div class="rich-text-table">` med `overflow-x: auto`,
  slik at brede tabeller kan scrolles horisontalt på smale skjermer i stedet for
  å bli klemt sammen eller tvinge hele siden til å scrolle sidelengs.
- Beholderen er tastaturfokuserbar (`tabindex="0"`, WCAG 2.1.1) og merkes som et
  navngitt `role="region"` med oversatt `aria-label` for skjermlesere.
- Ny oversettelsesnøkkel `common.table` (nb/nn/en), sendt inn via `JSONTransformer`.
- CSS for `.rich-text-table` med synlig fokusmarkering.

Dekket av enhetstester (innpakking, idempotens, og at regionen bare merkes når
den har en ledetekst).

