### PR TITLE
fix: remove paragraph margin inside rich-text list items

### DIFF
--- a/astro-infoportal/src/Components/Shared/RichText/RichText.scss
+++ b/astro-infoportal/src/Components/Shared/RichText/RichText.scss
@@ -6,6 +6,15 @@
     margin-bottom: 1.5rem;
   }
 
+  /* Umbraco's RTE re-wraps "<li>Text</li>" as "<li><p>Text</p></li>" when an
+     editor re-saves a page (issue #493). The wrapping <p> would otherwise
+     inherit the paragraph margin above — adding a gap between bullets and
+     pushing the text off its marker. Reset it so a re-saved list matches a
+     freshly-imported one. */
+  li > p {
+    margin: 0;
+  }
+
   /* Wrapper added around tables in htmlTransforms.ts so a wide table scrolls
      horizontally instead of overflowing the page on narrow screens (issue
      #359). It's keyboard-focusable (tabindex="0"), so it needs a visible


### PR DESCRIPTION
Retter #493: punktlister fikk for mye luft mellom kulepunktene etter at en redaktør lagret en side på nytt i Umbraco.

Når en side lagres på nytt, pakker Umbracos rikteksteditor (TinyMCE) innholdet i hvert `<li>` inn i en `<p>` (`<li>Tekst</li>` → `<li><p>Tekst</p></li>`). Denne `<p>`-en arvet `margin-bottom: 1.5rem` fra regelen `.rich-text p`, noe som ga ekstra mellomrom mellom kulepunktene og forskjøv teksten i forhold til kulepunkt-/nummermarkøren.

## Endring

La til en CSS-regel i `RichText.scss` som nullstiller margin på `<p>` som er direkte barn av `<li>` innenfor `.rich-text`:

```scss
li > p {
  margin: 0;
}
```

- Regelen treffer bare `<p>` inni `<li>`. Lister uten `<p>`-innpakning (`<li>Tekst</li>`) påvirkes ikke, så nyimporterte og nylagrede lister vises nå likt.
- Nøstede lister berøres ikke, siden `> p` kun treffer direkte barn.

## Testplan

- [x] Åpne en side med en nylagret liste (f.eks. `/hjelp/ny-tilgangsstyring/steg-for-steg-guider/`) og bekreft at avstanden mellom kulepunktene er stram, og at teksten ligger på linje med markøren.