### PR TITLE
fix: stop horizontal scrollbar on schema overview tabs

### DIFF
--- a/astro-infoportal/src/Components/Pages/SchemaOverviewPage/SchemaOverviewPage.scss
+++ b/astro-infoportal/src/Components/Pages/SchemaOverviewPage/SchemaOverviewPage.scss
@@ -45,9 +45,16 @@
   &__tab {
     gap: 0.5rem;
     padding: var(--ds-size-3) var(--ds-size-4);
-    width: 100%;
+    // Designsystemet 1.16 sets flex-shrink:0 on the tabs and overflow-x:auto on
+    // the tablist, so the old width:100% made the two tabs total 200% of the
+    // tablist and show a horizontal scrollbar. Growing from a 0 flex-basis splits
+    // the row evenly and sidesteps DS's flex-shrink:0 (a (0,3,0) rule our
+    // single-class selector can't override).
+    flex: 1 1 0;
+    min-width: 0;
     font-size: var(--ds-font-size-3);
     @media (min-width: 768px) {
+      flex: 0 1 auto; // content-width tabs on desktop (match prod, no stretch)
       width: auto;
       font-size: var(--ds-font-size-body);
       padding: var(--ds-size-4) var(--ds-size-5);


### PR DESCRIPTION
Før
<img width="915" height="730" alt="image" src="https://github.com/user-attachments/assets/6c81f180-d5dc-435c-b5bf-db8b7d6d317a" />

Etter
<img width="728" height="870" alt="Screenshot 2026-06-30 at 12 41 28" src="https://github.com/user-attachments/assets/ae8b6186-4b83-4aed-86a5-ba76d50e568f" />

