### PR TITLE
fix: purge search result pages by prefix on indexable content changes

### DIFF
--- a/Adapters/Infoportal.Adapters.Cloudflare/Services/CloudflareCachePurgeService.cs
+++ b/Adapters/Infoportal.Adapters.Cloudflare/Services/CloudflareCachePurgeService.cs
@@ -68,6 +68,23 @@ public class CloudflareCachePurgeService : ICloudflareCachePurgeService
         return $"{uri.Scheme}://{uri.Authority}{newPath}{uri.Query}";
     }
 
+    public async Task PurgePrefixesAsync(IEnumerable<string> prefixes, CancellationToken ct = default)
+    {
+        CloudflareOptions opts = _options.CurrentValue;
+        if (!IsConfigured(opts)) return;
+
+        string[] items = (prefixes ?? [])
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (items.Length == 0) return;
+
+        foreach (string[] batch in Chunk(items, Math.Max(1, opts.MaxUrlsPerRequest)))
+        {
+            await PostPurgeAsync(opts, new { prefixes = batch }, ct);
+        }
+    }
+
     public Task PurgeEverythingAsync(CancellationToken ct = default)
     {
         CloudflareOptions opts = _options.CurrentValue;

--- a/Adapters/Infoportal.Adapters.Cloudflare/Services/ICloudflareCachePurgeService.cs
+++ b/Adapters/Infoportal.Adapters.Cloudflare/Services/ICloudflareCachePurgeService.cs
@@ -3,5 +3,8 @@ namespace Infoportal.Adapters.Cloudflare.Services;
 public interface ICloudflareCachePurgeService
 {
     Task PurgeUrlsAsync(IEnumerable<string> absoluteUrls, CancellationToken ct = default);
+
+    Task PurgePrefixesAsync(IEnumerable<string> prefixes, CancellationToken ct = default);
+
     Task PurgeEverythingAsync(CancellationToken ct = default);
 }

--- a/umbraco-infoportal/CachePurge/CachePurgeDispatcher.cs
+++ b/umbraco-infoportal/CachePurge/CachePurgeDispatcher.cs
@@ -2,6 +2,7 @@ using Infoportal.Adapters.Cloudflare;
 using Infoportal.Adapters.Cloudflare.Services;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Models;
+using umbraco_infoportal.Search;
 
 namespace umbraco_infoportal.CachePurge;
 
@@ -14,22 +15,25 @@ public enum CachePurgeReason
     Sort,
 }
 
-// Fire-and-forget: a purge can take seconds and would otherwise freeze the backoffice
-// "Saving…" spinner. If the pod recycles mid-purge it's lost, but s-maxage covers it.
 public class CachePurgeDispatcher
 {
+    private static readonly string[] SearchPaths = ["/sok/", "/nn/sok/", "/en/search/"];
+
     private readonly AffectedUrlResolver _resolver;
+    private readonly EnvironmentResolver _envResolver;
     private readonly IOptionsMonitor<CloudflareOptions> _options;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<CachePurgeDispatcher> _logger;
 
     public CachePurgeDispatcher(
         AffectedUrlResolver resolver,
+        EnvironmentResolver envResolver,
         IOptionsMonitor<CloudflareOptions> options,
         IServiceScopeFactory scopeFactory,
         ILogger<CachePurgeDispatcher> logger)
     {
         _resolver = resolver;
+        _envResolver = envResolver;
         _options = options;
         _scopeFactory = scopeFactory;
         _logger = logger;
@@ -39,11 +43,13 @@ public class CachePurgeDispatcher
     {
         HashSet<string> urls = new(StringComparer.Ordinal);
         bool forcePurgeEverything = false;
+        bool anyIndexable = false;
         List<int> contentIds = [];
 
         foreach (IContent content in entities)
         {
             contentIds.Add(content.Id);
+            if (ContentTextExtractor.IsIndexable(content.ContentType.Alias)) anyIndexable = true;
             try
             {
                 AffectedUrlSet result = _resolver.Resolve(content, reason);
@@ -56,17 +62,33 @@ public class CachePurgeDispatcher
             }
         }
 
-        if (urls.Count == 0 && !forcePurgeEverything) return;
+        string[] searchPrefixes =
+            anyIndexable && reason is CachePurgeReason.Publish or CachePurgeReason.Unpublish or CachePurgeReason.Trash
+                ? BuildSearchPrefixes()
+                : [];
 
-        SchedulePurge(urls.ToArray(), forcePurgeEverything, contentIds.ToArray(), reason);
+        if (urls.Count == 0 && !forcePurgeEverything && searchPrefixes.Length == 0) return;
+
+        SchedulePurge(urls.ToArray(), forcePurgeEverything, searchPrefixes, contentIds.ToArray(), reason);
     }
 
     public void DispatchPurgeEverything(CachePurgeReason reason)
     {
-        SchedulePurge([], forcePurgeEverything: true, contentIds: [], reason);
+        SchedulePurge([], forcePurgeEverything: true, searchPrefixes: [], contentIds: [], reason);
     }
 
-    private void SchedulePurge(string[] urls, bool forcePurgeEverything, int[] contentIds, CachePurgeReason reason)
+    private string[] BuildSearchPrefixes()
+    {
+        string siteBaseUrl = _envResolver.ResolveForCurrentEnvironment(_options.CurrentValue.SiteBaseUrls);
+        if (string.IsNullOrWhiteSpace(siteBaseUrl) || !Uri.TryCreate(siteBaseUrl, UriKind.Absolute, out Uri? uri))
+            return [];
+
+        // Host + path, no scheme — Cloudflare prefix format. Matches the per-env host the
+        // URL purge already targets, so only the configured env host is purged.
+        return SearchPaths.Select(p => $"{uri.Authority}{p}").ToArray();
+    }
+
+    private void SchedulePurge(string[] urls, bool forcePurgeEverything, string[] searchPrefixes, int[] contentIds, CachePurgeReason reason)
     {
         int threshold = _options.CurrentValue.AffectedUrlThreshold;
 
@@ -88,14 +110,21 @@ public class CachePurgeDispatcher
                 }
                 else
                 {
-                    logger.LogInformation("Cache purge ({Reason}): purging {Count} URLs", reason, urls.Length);
-                    await purge.PurgeUrlsAsync(urls);
+                    if (urls.Length > 0)
+                    {
+                        logger.LogInformation("Cache purge ({Reason}): purging {Count} URLs", reason, urls.Length);
+                        await purge.PurgeUrlsAsync(urls);
+                    }
+                    if (searchPrefixes.Length > 0)
+                    {
+                        logger.LogInformation("Cache purge ({Reason}): purging {Count} search prefixes", reason, searchPrefixes.Length);
+                        await purge.PurgePrefixesAsync(searchPrefixes);
+                    }
                 }
             }
             catch (Exception ex)
             {
-                // SECURITY: log content IDs only, not URLs — they'd land in Loki and could
-                // leak draft slugs / future unlisted paths.
+                // SECURITY: log content IDs only, not URLs — they'd land in Loki and could leak draft slugs / future unlisted paths.
                 logger.LogError(ex,
                     "Cloudflare cache purge failed ({Reason}): {Count} URLs, contentIds=[{Ids}]",
                     reason, urls.Length, string.Join(",", contentIds));

--- a/umbraco-infoportal/Search/ContentTextExtractor.cs
+++ b/umbraco-infoportal/Search/ContentTextExtractor.cs
@@ -48,6 +48,9 @@ public class ContentTextExtractor
         "Umbraco.TextArea"
     ];
 
+    public static bool IsIndexable(string contentTypeAlias) =>
+        IndexableContentTypes.Contains(contentTypeAlias);
+
     public ContentTextExtractor(
         IContentTypeService contentTypeService,
         IDataTypeService dataTypeService,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Search result pages (/sok/, /nn/sok/, /en/search/) are SSR-rendered with live Elasticsearch results baked into the HTML, then edge-cached per query string. Because search URLs are unbounded (?q=...), they were never part of the publish/unpublish purge set, so unpublished pages in search results.

Add Cloudflare purge-by-prefix and fire it on publish/unpublish/trash of search-indexed content, clearing every query-string variant of all three language search pages in one batched call.

- Adapters/Infoportal.Adapters.Cloudflare: new PurgePrefixesAsync (posts { prefixes }, host+path without scheme), reuses the existing per-request token path.
- Search/ContentTextExtractor: expose IsIndexable as the single source of truth for "appears in search".
- CachePurge/CachePurgeDispatcher: build the search prefixes from the per-env host and purge them alongside the URL purge; gated on indexable content + publish/unpublish/trash. purge_everything already covers search, so no double purge.

## Related Issue(s)
- https://github.com/Altinn/info.altinn.no/issues/586

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
