### PR TITLE
fix: guard null page data in JSONTransformer to prevent 404 crash

### DIFF
--- a/astro-infoportal/src/transformers/JSONTransformer.ts
+++ b/astro-infoportal/src/transformers/JSONTransformer.ts
@@ -39,8 +39,12 @@ export class JSONTransformer implements IJSONTransformer {
       child: null
     };
 
+    // umbracoPageData is null when the Umbraco error-page fetch fails (404.astro
+    // and the [...slug].astro fallback both pass it through). Optional-chain so
+    // GetTransformer gets undefined -> returns null -> we render the layout shell
+    // instead of throwing on .contentType.
     const bodyDataTransformer: IJSONTransformer | null = this.GetTransformer(
-      umbracoPageData.contentType,
+      umbracoPageData?.contentType,
     );
 
     if (bodyDataTransformer != null) {


### PR DESCRIPTION
## Problem

`JSONTransformer.Transform` reads `umbracoPageData.contentType` with no null guard. `404.astro` (and the `[...slug].astro` error fallback) pass `null` when `fetchUmbracoErrorPage` rejects or returns null — e.g. when the `error404Page` content is unavailable in the target Umbraco — producing a 500:

```
[vite] Internal server error: Cannot read properties of null (reading 'contentType')
  at JSONTransformer.Transform (.../JSONTransformer.ts:43)
  at 404.astro:37
```

## Fix

Optional-chain the content-type lookup:

```diff
- this.GetTransformer(umbracoPageData.contentType)
+ this.GetTransformer(umbracoPageData?.contentType)
```

`GetTransformer(undefined)` returns `null` via its `default` case, so `data.child` stays null and the page renders the `SiteLayout` shell instead of throwing. Hardens both `404.astro` and the `[...slug].astro` error fallback, matching the optional chaining already used for `umbracoPageData` elsewhere (e.g. `[...slug].astro`).
