### PR TITLE
chore: run Terraform workflows on self-hosted runners

### DIFF
--- a/.github/workflows/elastic-cloud-org.yml
+++ b/.github/workflows/elastic-cloud-org.yml
@@ -47,7 +47,7 @@ jobs:
   plan:
     name: Plan
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -69,7 +69,7 @@ jobs:
     environment: prod
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-elasticsearch-at22.yml
+++ b/.github/workflows/infoportal-elasticsearch-at22.yml
@@ -52,7 +52,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -74,7 +74,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-elasticsearch-prod.yml
+++ b/.github/workflows/infoportal-elasticsearch-prod.yml
@@ -52,7 +52,7 @@ jobs:
   plan:
     name: Plan
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -74,7 +74,7 @@ jobs:
     environment: prod
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-elasticsearch-test.yml
+++ b/.github/workflows/infoportal-elasticsearch-test.yml
@@ -52,7 +52,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -74,7 +74,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-media-sa-at22.yml
+++ b/.github/workflows/infoportal-media-sa-at22.yml
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,7 +73,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-media-sa-at23.yml
+++ b/.github/workflows/infoportal-media-sa-at23.yml
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,7 +73,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-media-sa-prod.yml
+++ b/.github/workflows/infoportal-media-sa-prod.yml
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,7 +73,7 @@ jobs:
     environment: prod
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/infoportal-media-sa-tt02.yml
+++ b/.github/workflows/infoportal-media-sa-tt02.yml
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,7 +73,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/kinorgeportal-elasticsearch-tt02.yml
+++ b/.github/workflows/kinorgeportal-elasticsearch-tt02.yml
@@ -50,7 +50,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -72,7 +72,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/kinorgeportal-media-sa-prod.yml
+++ b/.github/workflows/kinorgeportal-media-sa-prod.yml
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,7 +73,7 @@ jobs:
     environment: prod
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/kinorgeportal-media-sa-tt02.yml
+++ b/.github/workflows/kinorgeportal-media-sa-tt02.yml
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,7 +73,7 @@ jobs:
     environment: test
     if: github.ref == 'refs/heads/main'
     needs: plan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Moves the Terraform workflows in this repo onto the self-hosted runners that team Portaler already has provisioned, so these jobs stop queueing behind shared GitHub-hosted runners.

Refs #642, Altinn/altinn-platform#3838

## Background

`Altinn/altinn-platform` already provisions ephemeral Container App Job runners for this repo in [`infrastructure/gh-runners/info.altinn.no.tf`](https://github.com/Altinn/altinn-platform/blob/main/infrastructure/gh-runners/info.altinn.no.tf) (prefix `infoportal`, VNet `172.17.135.0/24`). They register per-repo under the default `self-hosted` label — so no extra setup was needed here, just the `runs-on` change.

## Changed — 22 jobs across 11 workflows

`ubuntu-latest` → `self-hosted` for the Terraform plan/apply workflows:

- `elastic-cloud-org`
- `infoportal-elasticsearch-{at22,test,prod}`
- `infoportal-media-sa-{at22,at23,prod,tt02}`
- `kinorgeportal-elasticsearch-tt02`
- `kinorgeportal-media-sa-{prod,tt02}`

These all use `Altinn/altinn-platform/actions/terraform/{plan,apply}`, which `altinn-platform` itself already runs on `self-hosted` (e.g. `altinn-monitor-test-rg-deploy.yml`, `syncroot-deployment.yml`). Same actions, same runner image — an established combination rather than a new one.

## Not changed — including both workflows named in the issue

Issue #3838 names *"Docker build and publish"* and *"Publish Syncroot artifacts"* as the team's most important workflows. Neither runs on the current runner image as written, so both are left on `ubuntu-latest` here and need a follow-up decision:

**`docker-publish.yaml` — blocked.** Needs a Docker daemon and Buildx; the Container App Job runners provide neither, and `cache-from/to: type=gha` would also stop working. Options:
1. Keep on `ubuntu-latest`.
2. Switch to `az acr build` — needs no local Docker daemon and the runner image already has Azure CLI. Note this moves the image from `ghcr.io` to ACR, which is a real architectural change, not a drop-in swap.
3. Ask the platform team for a runner variant with Docker available.

**`publish-syncroot-main.yaml` — small gap.** The only blocker is bare `yq` in the three "Update ..." steps; `yq` is preinstalled on GitHub-hosted runners but absent from the [gh-runner image](https://github.com/Altinn/altinn-platform/blob/main/infrastructure/images/gh-runner/Dockerfile). Either add an install step here, or ask the platform team to add `yq` to the base image (probably preferable — it benefits every team). Worth noting that *every* `flux/build-push-image` workflow in `altinn-platform` currently runs on `ubuntu-latest`, so that path is unproven on self-hosted.

**`update-cloudflare-ips-elasticsearch.yml`** uses `python3`, also not in the runner image. Low value to move — it only talks to the public internet and opens a PR.

## Testing notes

Each workflow's `pull_request` path filter includes its own file, so all 11 `Plan` jobs run on this PR — on the self-hosted runners. **This PR verifies itself**; the checks below are the real signal, and the `Deploy` jobs stay gated on `github.ref == 'refs/heads/main'` as before.

Verified locally beforehand: all 14 workflow files still parse, and `runs-on` resolves as intended in each.

**Result: 11/11 `Plan` jobs pass on the self-hosted runners**, each on its own ephemeral runner, with the `Deploy` jobs correctly skipped. Getting there needed a fix outside this repo — the GH runners App had to be granted access to `info.altinn.no` before any runner could register; see the comment below for the diagnosis.

One thing to confirm: these workflows trigger on `pull_request` in a public repo, and [RFC 0002](https://github.com/Altinn/altinn-platform/blob/main/rfcs/0002-self-hosted-github-runners.md) explicitly flags fork-PR execution on self-hosted runners as the primary security risk. `altinn-platform` is also public and already does this, which implies org-level "require approval for all outside collaborators" is set — worth verifying rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


