### PR TITLE
fix: repair legacy block Udi values that Umbraco 18 cannot read

### DIFF
--- a/umbraco-infoportal.Tests/.gitignore
+++ b/umbraco-infoportal.Tests/.gitignore
@@ -1,0 +1,13 @@
+##
+## Umbraco CMS
+##
+## Referencing umbraco-infoportal pulls in Umbraco.Cms.Targets, whose CopyUmbracoJsonSchemaFiles
+## target unconditionally copies these generated schema files into the project directory.
+## Mirrors the same section in umbraco-infoportal/.gitignore.
+
+# JSON schema files for appsettings.json
+appsettings-schema.json
+appsettings-schema.*.json
+
+# JSON schema file for umbraco-package.json
+umbraco-package-schema.json

--- a/umbraco-infoportal.Tests/Migrations/LegacyBlockUdiNormalizerTests.cs
+++ b/umbraco-infoportal.Tests/Migrations/LegacyBlockUdiNormalizerTests.cs
@@ -1,0 +1,282 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Infrastructure.Serialization;
+using umbraco_infoportal.Migrations;
+
+namespace umbraco_infoportal.Tests.Migrations;
+
+public class LegacyBlockUdiNormalizerTests
+{
+    private static readonly Guid ContentElementKey = Guid.Parse("1b8b1b8d-9a2a-4b1e-9c0d-3f4a5b6c7d8e");
+    private static readonly Guid SettingsElementKey = Guid.Parse("2c9c2c9e-0b3b-4c2f-8d1e-4a5b6c7d8e9f");
+    private static readonly Guid NestedElementKey = Guid.Parse("5f2f5f21-3e6e-4f5c-9a4b-7d8e9f0a1b23");
+
+    /// <summary>
+    /// A Block List value in the pre-Umbraco-15 shape: the layout items carry contentUdi/settingsUdi
+    /// instead of contentKey/settingsKey, and the item data carries udi instead of key.
+    /// </summary>
+    private const string LegacyBlockListValue = """
+        {
+          "layout": {
+            "Umbraco.BlockList": [
+              {
+                "contentUdi": "umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e",
+                "settingsUdi": "umb://element/2c9c2c9e0b3b4c2f8d1e4a5b6c7d8e9f"
+              }
+            ]
+          },
+          "contentData": [
+            {
+              "contentTypeKey": "3d0d3d0f-1c4c-4d3a-9e2f-5b6c7d8e9f01",
+              "udi": "umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e",
+              "values": [
+                { "alias": "heading", "value": "Trenger du hjelp?" },
+                { "alias": "text", "value": "<p>Kontakt brukerveiledning ved Brønnøysundregistrene</p>" }
+              ]
+            }
+          ],
+          "settingsData": [
+            {
+              "contentTypeKey": "4e1e4e10-2d5d-4e4b-8f3a-6c7d8e9f0a12",
+              "udi": "umb://element/2c9c2c9e0b3b4c2f8d1e4a5b6c7d8e9f",
+              "values": []
+            }
+          ],
+          "expose": [
+            { "contentKey": "1b8b1b8d-9a2a-4b1e-9c0d-3f4a5b6c7d8e", "culture": null, "segment": null }
+          ]
+        }
+        """;
+
+    private const string ModernBlockListValue = """
+        {
+          "layout": {
+            "Umbraco.BlockList": [
+              { "contentKey": "1b8b1b8d-9a2a-4b1e-9c0d-3f4a5b6c7d8e" }
+            ]
+          },
+          "contentData": [
+            {
+              "contentTypeKey": "3d0d3d0f-1c4c-4d3a-9e2f-5b6c7d8e9f01",
+              "key": "1b8b1b8d-9a2a-4b1e-9c0d-3f4a5b6c7d8e",
+              "values": [ { "alias": "heading", "value": "Trenger du hjelp?" } ]
+            }
+          ],
+          "settingsData": [],
+          "expose": [
+            { "contentKey": "1b8b1b8d-9a2a-4b1e-9c0d-3f4a5b6c7d8e", "culture": null, "segment": null }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void Derives_layout_content_and_settings_keys_from_legacy_udis()
+    {
+        JsonObject layoutItem = FirstLayoutItem(Normalize(LegacyBlockListValue), "Umbraco.BlockList");
+
+        Assert.Equal(ContentElementKey, KeyOf(layoutItem, "contentKey"));
+        Assert.Equal(SettingsElementKey, KeyOf(layoutItem, "settingsKey"));
+    }
+
+    [Fact]
+    public void Derives_item_data_keys_from_legacy_udis()
+    {
+        JsonNode result = Parse(Normalize(LegacyBlockListValue));
+
+        Assert.Equal(ContentElementKey, KeyOf((JsonObject)result["contentData"]![0]!, "key"));
+        Assert.Equal(SettingsElementKey, KeyOf((JsonObject)result["settingsData"]![0]!, "key"));
+    }
+
+    [Fact]
+    public void Leaves_legacy_fields_and_all_other_content_in_place()
+    {
+        JsonNode result = Parse(Normalize(LegacyBlockListValue));
+
+        JsonObject layoutItem = FirstLayoutItem(result, "Umbraco.BlockList");
+        Assert.Equal("umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e", layoutItem["contentUdi"]!.GetValue<string>());
+        Assert.Equal("umb://element/2c9c2c9e0b3b4c2f8d1e4a5b6c7d8e9f", layoutItem["settingsUdi"]!.GetValue<string>());
+
+        JsonNode contentItem = result["contentData"]![0]!;
+        Assert.Equal("umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e", contentItem["udi"]!.GetValue<string>());
+        Assert.Equal("3d0d3d0f-1c4c-4d3a-9e2f-5b6c7d8e9f01", contentItem["contentTypeKey"]!.GetValue<string>());
+        Assert.Equal("Trenger du hjelp?", contentItem["values"]![0]!["value"]!.GetValue<string>());
+        Assert.Equal(
+            "<p>Kontakt brukerveiledning ved Brønnøysundregistrene</p>",
+            contentItem["values"]![1]!["value"]!.GetValue<string>());
+        Assert.Single(result["expose"]!.AsArray());
+    }
+
+    [Fact]
+    public void Reports_no_change_for_a_value_that_is_already_in_the_key_shape()
+    {
+        Assert.False(LegacyBlockUdiNormalizer.TryNormalize(ModernBlockListValue, out string? normalized));
+        Assert.Null(normalized);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Brønnøysundregistrene")]
+    [InlineData("{ this is not json")]
+    [InlineData("""{ "markup": "<p>contentUdi is only mentioned in text</p>" }""")]
+    public void Reports_no_change_for_values_without_legacy_block_layout(string? storedValue)
+    {
+        Assert.False(LegacyBlockUdiNormalizer.TryNormalize(storedValue, out string? normalized));
+        Assert.Null(normalized);
+    }
+
+    [Fact]
+    public void Is_idempotent()
+    {
+        string once = Normalize(LegacyBlockListValue);
+
+        Assert.False(LegacyBlockUdiNormalizer.TryNormalize(once, out string? twice));
+        Assert.Null(twice);
+    }
+
+    [Fact]
+    public void Replaces_a_placeholder_empty_guid_key()
+    {
+        const string valueWithEmptyKey = """
+            {
+              "layout": {
+                "Umbraco.BlockList": [
+                  {
+                    "contentKey": "00000000-0000-0000-0000-000000000000",
+                    "contentUdi": "umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e"
+                  }
+                ]
+              },
+              "contentData": []
+            }
+            """;
+
+        JsonObject layoutItem = FirstLayoutItem(Normalize(valueWithEmptyKey), "Umbraco.BlockList");
+
+        Assert.Equal(ContentElementKey, KeyOf(layoutItem, "contentKey"));
+    }
+
+    [Fact]
+    public void Normalizes_block_grid_items_nested_in_areas()
+    {
+        const string legacyBlockGridValue = """
+            {
+              "layout": {
+                "Umbraco.BlockGrid": [
+                  {
+                    "contentUdi": "umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e",
+                    "columnSpan": 12,
+                    "areas": [
+                      {
+                        "key": "6a3a6a32-4f7f-4a6d-8b5c-8e9f0a1b2c34",
+                        "items": [
+                          { "contentUdi": "umb://element/5f2f5f213e6e4f5c9a4b7d8e9f0a1b23" }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "contentData": []
+            }
+            """;
+
+        JsonObject rootItem = FirstLayoutItem(Normalize(legacyBlockGridValue), "Umbraco.BlockGrid");
+        JsonObject areaItem = (JsonObject)rootItem["areas"]![0]!["items"]![0]!;
+
+        Assert.Equal(ContentElementKey, KeyOf(rootItem, "contentKey"));
+        Assert.Equal(NestedElementKey, KeyOf(areaItem, "contentKey"));
+    }
+
+    [Fact]
+    public void Normalizes_a_nested_block_value_that_is_stored_as_a_json_string()
+    {
+        const string legacyValueWithNestedJsonString = """
+            {
+              "layout": {
+                "Umbraco.BlockList": [
+                  { "contentUdi": "umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e" }
+                ]
+              },
+              "contentData": [
+                {
+                  "contentTypeKey": "3d0d3d0f-1c4c-4d3a-9e2f-5b6c7d8e9f01",
+                  "udi": "umb://element/1b8b1b8d9a2a4b1e9c0d3f4a5b6c7d8e",
+                  "values": [
+                    {
+                      "alias": "innerBlocks",
+                      "value": "{\"layout\":{\"Umbraco.BlockList\":[{\"contentUdi\":\"umb://element/5f2f5f213e6e4f5c9a4b7d8e9f0a1b23\"}]},\"contentData\":[{\"udi\":\"umb://element/5f2f5f213e6e4f5c9a4b7d8e9f0a1b23\"}]}"
+                    }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        JsonNode result = Parse(Normalize(legacyValueWithNestedJsonString));
+        string nestedJson = result["contentData"]![0]!["values"]![0]!["value"]!.GetValue<string>();
+        JsonNode nested = Parse(nestedJson);
+
+        Assert.Equal(NestedElementKey, KeyOf(FirstLayoutItem(nested, "Umbraco.BlockList"), "contentKey"));
+        Assert.Equal(NestedElementKey, KeyOf((JsonObject)nested["contentData"]![0]!, "key"));
+    }
+
+    [Fact]
+    public void Reports_no_change_when_the_legacy_udi_cannot_be_parsed()
+    {
+        const string valueWithUnparseableUdi = """
+            {
+              "layout": { "Umbraco.BlockList": [ { "contentUdi": "umb://element/not-a-guid" } ] },
+              "contentData": []
+            }
+            """;
+
+        Assert.False(LegacyBlockUdiNormalizer.TryNormalize(valueWithUnparseableUdi, out string? normalized));
+        Assert.Null(normalized);
+    }
+
+    /// <summary>
+    /// The contract that matters in production: Umbraco's own block value deserializer has to resolve
+    /// the layout item to a real element key and keep the content data. On Umbraco 18 the legacy value
+    /// fails this because BlockLayoutItemBase no longer maps contentUdi onto ContentKey.
+    /// </summary>
+    [Fact]
+    public void Normalized_value_is_understood_by_the_umbraco_block_value_deserializer()
+    {
+        // Mirrors Umbraco's own SystemTextJsonSerializer registration. JsonUdiConverter is required
+        // because on Umbraco 17 the retained contentUdi field still binds to a Udi typed property.
+        JsonSerializerOptions options = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonUdiConverter(), new JsonBlockValueConverter() },
+        };
+
+        BlockListValue blockValue = JsonSerializer.Deserialize<BlockListValue>(Normalize(LegacyBlockListValue), options)!;
+
+        BlockListLayoutItem layoutItem = Assert.Single(blockValue.GetLayouts()!);
+        Assert.Equal(ContentElementKey, layoutItem.ContentKey);
+        Assert.Equal(SettingsElementKey, layoutItem.SettingsKey);
+        Assert.Equal(ContentElementKey, Assert.Single(blockValue.ContentData).Key);
+        Assert.Equal(SettingsElementKey, Assert.Single(blockValue.SettingsData).Key);
+    }
+
+    private static string Normalize(string storedValue)
+    {
+        Assert.True(LegacyBlockUdiNormalizer.TryNormalize(storedValue, out string? normalized));
+        Assert.NotNull(normalized);
+        return normalized;
+    }
+
+    private static JsonNode Parse(string json) => JsonNode.Parse(json)!;
+
+    private static JsonObject FirstLayoutItem(string json, string propertyEditorAlias) =>
+        FirstLayoutItem(Parse(json), propertyEditorAlias);
+
+    private static JsonObject FirstLayoutItem(JsonNode value, string propertyEditorAlias) =>
+        (JsonObject)value["layout"]![propertyEditorAlias]![0]!;
+
+    private static Guid KeyOf(JsonObject item, string propertyName) =>
+        Guid.Parse(item[propertyName]!.GetValue<string>());
+}

--- a/umbraco-infoportal.Tests/umbraco-infoportal.Tests.csproj
+++ b/umbraco-infoportal.Tests/umbraco-infoportal.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>umbraco_infoportal.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\umbraco-infoportal\umbraco-infoportal.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/umbraco-infoportal/Migrations/InfoportalMigrationPlan.cs
+++ b/umbraco-infoportal/Migrations/InfoportalMigrationPlan.cs
@@ -1,0 +1,22 @@
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace umbraco_infoportal.Migrations;
+
+/// <summary>
+/// The migration plan for infoportal's own migrations, kept separate from Umbraco's core plan.
+/// </summary>
+/// <remarks>
+/// The reached state is persisted in umbracoKeyValue under
+/// <c>Umbraco.Core.Upgrader.State+Infoportal</c>, so each migration below runs exactly once per
+/// environment. Only ever append new states — rewriting or removing an existing one leaves
+/// environments stranded on a state this plan can no longer resolve.
+/// </remarks>
+public class InfoportalMigrationPlan : MigrationPlan
+{
+    public InfoportalMigrationPlan()
+        : base("Infoportal")
+    {
+        From(string.Empty)
+            .To<NormalizeLegacyBlockUdisMigration>("normalize-legacy-block-udis-20260813");
+    }
+}

--- a/umbraco-infoportal/Migrations/LegacyBlockUdiNormalizer.cs
+++ b/umbraco-infoportal/Migrations/LegacyBlockUdiNormalizer.cs
@@ -1,0 +1,215 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Unicode;
+
+namespace umbraco_infoportal.Migrations;
+
+/// <summary>
+/// Rewrites block editor values that are stored in the pre-Umbraco-15 "Udi" shape into the
+/// current "key" shape, so that Umbraco 18 can read them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Umbraco 17 and earlier mapped the legacy <c>contentUdi</c>/<c>settingsUdi</c> layout fields onto
+/// <c>ContentKey</c>/<c>SettingsKey</c> through an obsolete shim on <c>BlockLayoutItemBase</c>.
+/// Umbraco 18 removed that shim, so a layout item that only carries <c>contentUdi</c> now
+/// deserializes with an empty <c>ContentKey</c>. The block editor then treats every entry in
+/// <c>contentData</c> as an orphan and discards it, which is why the backoffice renders the block as
+/// "Unsupported" and the front end renders nothing at all.
+/// </para>
+/// <para>
+/// The rewrite is deliberately additive: the legacy fields are left untouched and the derived
+/// <c>contentKey</c>/<c>settingsKey</c>/<c>key</c> fields are only written when they are missing or
+/// hold an empty GUID. That makes it idempotent, and it cannot destroy a value it does not understand.
+/// </para>
+/// </remarks>
+public static class LegacyBlockUdiNormalizer
+{
+    private const string ContentUdiPropertyName = "contentUdi";
+    private const string ContentKeyPropertyName = "contentKey";
+    private const string SettingsUdiPropertyName = "settingsUdi";
+    private const string SettingsKeyPropertyName = "settingsKey";
+    private const string UdiPropertyName = "udi";
+    private const string KeyPropertyName = "key";
+    private const string ContentDataPropertyName = "contentData";
+    private const string SettingsDataPropertyName = "settingsData";
+    private const string UdiScheme = "umb://";
+
+    /// <remarks>
+    /// Mirrors Umbraco's own <c>DefaultJsonSerializerEncoderFactory</c> so that a rewritten value is
+    /// encoded exactly the way Umbraco encodes it when an editor saves the same document.
+    /// </remarks>
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.BasicLatin),
+    };
+
+    /// <summary>
+    /// Adds the "key" shaped fields that Umbraco 18 needs, derived from the legacy Udi fields.
+    /// </summary>
+    /// <param name="storedValue">The raw property value as stored in umbracoPropertyData.</param>
+    /// <param name="normalizedValue">The rewritten value, or <c>null</c> when nothing changed.</param>
+    /// <returns><c>true</c> when the value was rewritten; otherwise <c>false</c>.</returns>
+    public static bool TryNormalize(string? storedValue, [NotNullWhen(true)] out string? normalizedValue)
+    {
+        normalizedValue = null;
+
+        if (!ContainsLegacyUdi(storedValue) || !TryParseJson(storedValue, out JsonNode? root))
+        {
+            return false;
+        }
+
+        if (!NormalizeNode(root, inBlockItemData: false))
+        {
+            return false;
+        }
+
+        normalizedValue = root.ToJsonString(SerializerOptions);
+        return true;
+    }
+
+    private static bool NormalizeNode(JsonNode? node, bool inBlockItemData) => node switch
+    {
+        JsonObject item => NormalizeObject(item, inBlockItemData),
+        JsonArray items => NormalizeArray(items, inBlockItemData),
+        _ => false,
+    };
+
+    private static bool NormalizeObject(JsonObject item, bool inBlockItemData)
+    {
+        bool changed = TryDeriveKey(item, ContentUdiPropertyName, ContentKeyPropertyName);
+        changed |= TryDeriveKey(item, SettingsUdiPropertyName, SettingsKeyPropertyName);
+
+        // Only the entries of contentData/settingsData use the bare "udi" field; rewriting it
+        // anywhere else risks colliding with an unrelated editor that happens to store a "udi".
+        if (inBlockItemData)
+        {
+            changed |= TryDeriveKey(item, UdiPropertyName, KeyPropertyName);
+        }
+
+        foreach (string propertyName in item.Select(property => property.Key).ToArray())
+        {
+            bool childIsBlockItemData = propertyName is ContentDataPropertyName or SettingsDataPropertyName;
+
+            if (TryNormalizeEncodedValue(item[propertyName], childIsBlockItemData, out JsonNode? rewritten))
+            {
+                item[propertyName] = rewritten;
+                changed = true;
+                continue;
+            }
+
+            changed |= NormalizeNode(item[propertyName], childIsBlockItemData);
+        }
+
+        return changed;
+    }
+
+    private static bool NormalizeArray(JsonArray items, bool inBlockItemData)
+    {
+        bool changed = false;
+
+        for (int index = 0; index < items.Count; index++)
+        {
+            if (TryNormalizeEncodedValue(items[index], inBlockItemData, out JsonNode? rewritten))
+            {
+                items[index] = rewritten;
+                changed = true;
+                continue;
+            }
+
+            changed |= NormalizeNode(items[index], inBlockItemData);
+        }
+
+        return changed;
+    }
+
+    /// <summary>
+    /// Handles nested block values that are stored as a JSON string inside a property value, which is
+    /// how block editors nested in another block editor were persisted before Umbraco 15.
+    /// </summary>
+    private static bool TryNormalizeEncodedValue(
+        JsonNode? node,
+        bool inBlockItemData,
+        [NotNullWhen(true)] out JsonNode? rewritten)
+    {
+        rewritten = null;
+
+        if (node?.GetValueKind() != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        string encoded = node.GetValue<string>();
+
+        if (!ContainsLegacyUdi(encoded)
+            || !TryParseJson(encoded, out JsonNode? nested)
+            || !NormalizeNode(nested, inBlockItemData))
+        {
+            return false;
+        }
+
+        rewritten = JsonValue.Create(nested.ToJsonString(SerializerOptions));
+        return rewritten is not null;
+    }
+
+    private static bool TryDeriveKey(JsonObject item, string udiPropertyName, string keyPropertyName)
+    {
+        if (!item.TryGetPropertyValue(udiPropertyName, out JsonNode? udi)
+            || !TryParseElementKey(udi, out Guid key)
+            || HasUsableKey(item, keyPropertyName))
+        {
+            return false;
+        }
+
+        item[keyPropertyName] = key.ToString();
+        return true;
+    }
+
+    private static bool HasUsableKey(JsonObject item, string keyPropertyName) =>
+        item.TryGetPropertyValue(keyPropertyName, out JsonNode? existing)
+        && existing?.GetValueKind() == JsonValueKind.String
+        && Guid.TryParse(existing.GetValue<string>(), out Guid existingKey)
+        && existingKey != Guid.Empty;
+
+    private static bool TryParseElementKey(JsonNode? udi, out Guid key)
+    {
+        key = Guid.Empty;
+
+        if (udi?.GetValueKind() != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        string value = udi.GetValue<string>();
+
+        if (!value.StartsWith(UdiScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        int separator = value.LastIndexOf('/');
+
+        return separator >= 0 && Guid.TryParse(value.AsSpan(separator + 1), out key) && key != Guid.Empty;
+    }
+
+    private static bool ContainsLegacyUdi([NotNullWhen(true)] string? storedValue) =>
+        !string.IsNullOrWhiteSpace(storedValue)
+        && (storedValue.Contains(ContentUdiPropertyName, StringComparison.Ordinal)
+            || storedValue.Contains(SettingsUdiPropertyName, StringComparison.Ordinal));
+
+    private static bool TryParseJson(string json, [NotNullWhen(true)] out JsonNode? node)
+    {
+        try
+        {
+            node = JsonNode.Parse(json);
+        }
+        catch (JsonException)
+        {
+            node = null;
+        }
+
+        return node is not null;
+    }
+}

--- a/umbraco-infoportal/Migrations/MigrationsComposer.cs
+++ b/umbraco-infoportal/Migrations/MigrationsComposer.cs
@@ -1,0 +1,10 @@
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.Notifications;
+
+namespace umbraco_infoportal.Migrations;
+
+public class MigrationsComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder) =>
+        builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, RunInfoportalMigrations>();
+}

--- a/umbraco-infoportal/Migrations/NormalizeLegacyBlockUdisMigration.cs
+++ b/umbraco-infoportal/Migrations/NormalizeLegacyBlockUdisMigration.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace umbraco_infoportal.Migrations;
+
+/// <summary>
+/// Repairs block editor values that Umbraco 18 can no longer read because they are still stored in
+/// the pre-Umbraco-15 "Udi" shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Umbraco 15 shipped <c>ConvertBlockListEditorProperties</c> and <c>ConvertBlockGridEditorProperties</c>
+/// to convert these values, and Umbraco 18 removed both those migrations and the read-time shim that
+/// made them optional. Content imported into this installation after the version 15 upgrade had already
+/// run was therefore never converted, and on 18 it reads as an empty "Unsupported" block.
+/// See <see cref="LegacyBlockUdiNormalizer"/> for the exact mechanics.
+/// </para>
+/// <para>
+/// Block editors declare <c>ValueTypes.Json</c>, which maps to <c>ValueStorageType.Ntext</c>, so their
+/// values always live in the <c>textValue</c> column.
+/// </para>
+/// </remarks>
+public class NormalizeLegacyBlockUdisMigration : AsyncMigrationBase
+{
+    private const string PropertyDataTable = Constants.DatabaseSchema.Tables.PropertyData;
+
+    public NormalizeLegacyBlockUdisMigration(IMigrationContext context)
+        : base(context)
+    {
+    }
+
+    protected override Task MigrateAsync()
+    {
+        EnsureLongCommandTimeout(Database);
+
+        List<LegacyBlockPropertyData> candidates = Database.Fetch<LegacyBlockPropertyData>(
+            $"SELECT id AS Id, textValue AS TextValue FROM {PropertyDataTable} "
+                + "WHERE textValue LIKE @0 OR textValue LIKE @1",
+            "%contentUdi%",
+            "%settingsUdi%");
+
+        if (candidates.Count == 0)
+        {
+            Logger.LogInformation("Found no block values in the legacy Udi shape, nothing to repair.");
+            return Task.CompletedTask;
+        }
+
+        int repaired = 0;
+
+        foreach (LegacyBlockPropertyData candidate in candidates)
+        {
+            if (!LegacyBlockUdiNormalizer.TryNormalize(candidate.TextValue, out string? normalizedValue))
+            {
+                continue;
+            }
+
+            Database.Execute(
+                $"UPDATE {PropertyDataTable} SET textValue = @0 WHERE id = @1",
+                normalizedValue,
+                candidate.Id);
+
+            repaired++;
+        }
+
+        Logger.LogInformation(
+            "Repaired {RepairedCount} of {CandidateCount} property values stored in the legacy block Udi shape.",
+            repaired,
+            candidates.Count);
+
+        if (repaired < candidates.Count)
+        {
+            Logger.LogWarning(
+                "Left {SkippedCount} property values untouched: they already carry block keys, or their "
+                    + "value could not be parsed as JSON.",
+                candidates.Count - repaired);
+        }
+
+        // The published cache holds its own copy of these values, so it has to be rebuilt for the front
+        // end to pick up the repair. The plan executor reads this flag after the migration has run, so
+        // setting it here keeps environments that had nothing to repair from paying for a rebuild.
+        RebuildCache = repaired > 0;
+
+        return Task.CompletedTask;
+    }
+
+    private sealed class LegacyBlockPropertyData
+    {
+        public int Id { get; set; }
+
+        public string? TextValue { get; set; }
+    }
+}

--- a/umbraco-infoportal/Migrations/RunInfoportalMigrations.cs
+++ b/umbraco-infoportal/Migrations/RunInfoportalMigrations.cs
@@ -1,0 +1,67 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+
+namespace umbraco_infoportal.Migrations;
+
+/// <summary>
+/// Runs <see cref="InfoportalMigrationPlan"/> on startup.
+/// </summary>
+/// <remarks>
+/// Umbraco publishes this notification after its own unattended upgrade has completed and the runtime
+/// level has been re-determined, so on the boot that upgrades the database our migrations run straight
+/// after Umbraco's.
+/// </remarks>
+public class RunInfoportalMigrations : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
+{
+    private readonly ICoreScopeProvider _coreScopeProvider;
+    private readonly IKeyValueService _keyValueService;
+    private readonly ILogger<RunInfoportalMigrations> _logger;
+    private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+
+    public RunInfoportalMigrations(
+        ICoreScopeProvider coreScopeProvider,
+        IKeyValueService keyValueService,
+        ILogger<RunInfoportalMigrations> logger,
+        IMigrationPlanExecutor migrationPlanExecutor)
+    {
+        _coreScopeProvider = coreScopeProvider;
+        _keyValueService = keyValueService;
+        _logger = logger;
+        _migrationPlanExecutor = migrationPlanExecutor;
+    }
+
+    public async Task HandleAsync(
+        UmbracoApplicationStartingNotification notification,
+        CancellationToken cancellationToken)
+    {
+        if (notification.RuntimeLevel != RuntimeLevel.Run)
+        {
+            _logger.LogInformation(
+                "Skipping the Infoportal migration plan because the runtime level is {RuntimeLevel}.",
+                notification.RuntimeLevel);
+            return;
+        }
+
+        ExecutedMigrationPlan executedPlan = await new Upgrader(new InfoportalMigrationPlan())
+            .ExecuteAsync(_migrationPlanExecutor, _coreScopeProvider, _keyValueService);
+
+        if (executedPlan.Successful)
+        {
+            _logger.LogInformation(
+                "The Infoportal migration plan completed at state {FinalState}.",
+                executedPlan.FinalState);
+            return;
+        }
+
+        _logger.LogError(
+            executedPlan.Exception,
+            "The Infoportal migration plan failed and stopped at state {FinalState}.",
+            executedPlan.FinalState);
+    }
+}


### PR DESCRIPTION
## Problem

Umbraco 18 fjernet `ContentUdi`/`SettingsUdi`-shimen fra `BlockLayoutItemBase`.
Blokkverdier som fortsatt er lagret i formatet fra før Umbraco 15
(`layout[].contentUdi`) deserialiseres derfor med tom `ContentKey`. Da regnes alle
oppføringene i `contentData` som foreldreløse og forkastes — derfor viser editoren
«Unsupported» på feltet «Faglig brukerstøtte» (`promoArea`), og kontaktinformasjonen
forsvinner på frontend.

Umbracos egne `V_15_0_0.ConvertBlockEditorProperties*`-migrasjoner ville konvertert
verdiene, men innhold som ble importert etter at oppgraderingen til 15 hadde kjørt,
ble aldri konvertert — og 18 leverer ikke disse migrasjonene lenger. `JsonBlockValueConverter`
er ellers byte-identisk med 17.4.0, så det å gjenopprette layout-nøklene er hele
reparasjonen.

Dette forklarer også miljøforskjellen: at22 og prod (18) er berørt, tt02 og at23 (17) er ikke.

## Endringer

- **`LegacyBlockUdiNormalizer`** — additiv `JsonNode`-omskriving som skriver
  `contentKey`/`settingsKey`/`key` ved siden av de gamle feltene, kun når de mangler
  eller er tomme. Idempotent, og kan ikke ødelegge en verdi den ikke forstår.
- **`NormalizeLegacyBlockUdisMigration`** — kjører over radene i `umbracoPropertyData`
  som inneholder en gammel Udi, logger antall kandidater/reparerte, og bygger om
  publisert cache bare når noe faktisk ble endret.
- **`InfoportalMigrationPlan`** + notification-handler — kjører én gang per miljø,
  etter at Umbracos egen unattended upgrade er ferdig.
- Nytt testprosjekt `umbraco-infoportal.Tests`.

Verdiene sendes bevisst **ikke** gjennom value editor slik V_15-migrasjonene gjør;
på 18 ville det lagret den tomme verdien og gjort datatapet permanent.

## Testing

- `dotnet build` mot Umbraco 18.0.2: 4 prosjekter, 0 feil
- `dotnet test`: 16/16 nye, 15/15 eksisterende
- Testene dekker layout-nøkler, `contentData`/`settingsData`, block grid-områder,
  nøstede blokker lagret som JSON-streng, idempotens, og at verdien etterpå leses
  korrekt av Umbracos egen `JsonBlockValueConverter`
- Begge SQL-setningene er kjørt mot et reelt Umbraco-skjema (SQLite)
- Ikke verifisert lokalt: DI-/plan-oppkobling og cache-rebuild. Migrasjonen logger
  `Repaired {n} of {m}`, så første deploy er selvverifiserende
