### PR TITLE
fix: surface untranslated driftsmeldinger and flag bokmål fallback

### DIFF
--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.scss
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.scss
@@ -30,6 +30,16 @@ body {
   }
 }
 
+/* Missing-translation notice (issue #672): borrows .layout-content-constrained
+   so it lines up with the page body, including the sidebar variant. It is
+   applied even on the pages that opt out of that class and manage their own
+   width — a one-line notice spanning the full viewport reads badly. Vertical
+   rhythm is margin, not padding, so it never competes with the
+   `padding: 0 16px` shorthand above. */
+.site-layout__missing-translation {
+  margin-block: var(--ds-size-4);
+}
+
 .site-layout__skip-link {
   font-size: 0.875rem;
   font-weight: 400;

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.tsx
@@ -1,4 +1,4 @@
-import { Layout, RootProvider } from "@altinn/altinn-components";
+import { DsAlert, Layout, RootProvider } from "@altinn/altinn-components";
 import * as Components from "../../../App.Components";
 import "@altinn/altinn-components/dist/global.css";
 import "@digdir/designsystemet-theme";
@@ -22,6 +22,7 @@ const SiteLayout = ({
   pageSidebarViewModel,
   skipLinkText,
   consentBanner,
+  missingTranslationText,
 }: SiteLayoutProps) => {
   const Comp = child ? (Components as any)[child.componentName] : null;
 
@@ -106,6 +107,20 @@ const SiteLayout = ({
         {...(sidebarConfig ? { sidebar: sidebarConfig } : {})}
         theme="default"
       >
+        {missingTranslationText && (
+          <div
+            className={`layout-content-constrained${
+              hasSidebar ? " layout-content-constrained--sidebar" : ""
+            } site-layout__missing-translation`}
+          >
+            {/* DsAlert, not the altinn-components Alert: that one always renders
+                a heading element, and an empty heading both trips the
+                :empty safety net below and swallows the info icon, which
+                .ds-alert hangs off the first-child heading. Headingless is the
+                shape Designsystemet documents for a one-line notice. */}
+            <DsAlert data-color="info">{missingTranslationText}</DsAlert>
+          </div>
+        )}
         {shouldConstrainWidth ? (
           <div
             className={`layout-content-constrained${

--- a/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.types.ts
+++ b/astro-infoportal/src/Components/Layout/SiteLayout/SiteLayout.types.ts
@@ -7,4 +7,6 @@ export interface SiteLayoutProps {
   child?: { componentName: string; [key: string]: any };
   skipLinkText?: string;
   consentBanner?: ConsentBannerViewModel | null;
+  /** Set only when the page fell back to NB content (see buildMissingTranslationText). */
+  missingTranslationText?: string | null;
 }

--- a/astro-infoportal/src/Constants/globalData.test.ts
+++ b/astro-infoportal/src/Constants/globalData.test.ts
@@ -1,5 +1,7 @@
+import en from "@i18n/locales/en.json";
+import nn from "@i18n/locales/nn.json";
 import { describe, expect, it } from "vitest";
-import { buildConsentBanner } from "./globalData";
+import { buildConsentBanner, buildMissingTranslationText } from "./globalData";
 
 const full = {
   properties: {
@@ -61,5 +63,22 @@ describe("buildConsentBanner", () => {
     const vm = buildConsentBanner(noLinks);
     expect(vm?.changeLinkUrl).toBeUndefined();
     expect(vm?.necessaryLinkUrl).toBeUndefined();
+  });
+});
+
+describe("buildMissingTranslationText", () => {
+  it("returns null when the page is available in the requested language", () => {
+    expect(buildMissingTranslationText("nb", "nb")).toBeNull();
+    expect(buildMissingTranslationText("nn", "nn")).toBeNull();
+    expect(buildMissingTranslationText("en", "en")).toBeNull();
+  });
+
+  it("explains the fallback in the language the reader asked for", () => {
+    expect(buildMissingTranslationText("en", "nb")).toBe(
+      en["common.missingTranslation"],
+    );
+    expect(buildMissingTranslationText("nn", "nb")).toBe(
+      nn["common.missingTranslation"],
+    );
   });
 });

--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -77,6 +77,24 @@ export function buildConsentBanner(
   };
 }
 
+// Old-portal behaviour, restored: a page with no variant in the requested
+// language renders its NB content (see `contentLocale` in [...slug].astro), and
+// the reader is told so in the language they asked for rather than being left to
+// wonder why the page turned Norwegian. Returns null on NB and on any page that
+// really is translated — the notice must never appear when nothing fell back.
+//
+// This is page-level, matching the old portal. Individual fields that fall back
+// on an otherwise-translated page (e.g. an untranslated driftsmelding on the
+// localised front page, issue #672) are deliberately not covered: the page is
+// translated, so a whole-page notice would misrepresent it.
+export function buildMissingTranslationText(
+  locale: Locale,
+  contentLocale: Locale,
+): string | null {
+  if (locale === contentLocale) return null;
+  return t("common.missingTranslation", locale);
+}
+
 export function getGlobalData(
   locale: Locale = "nb",
   searchPageUrl = "/sok/",
@@ -177,6 +195,7 @@ export function getGlobalData(
     },
     skipLinkText: t("common.skipToContent", locale),
     consentBanner,
+    missingTranslationText: buildMissingTranslationText(locale, contentLocale),
     locale,
     contentLocale,
   };

--- a/astro-infoportal/src/i18n/locales/en.json
+++ b/astro-infoportal/src/i18n/locales/en.json
@@ -1,5 +1,6 @@
 {
   "common.skipToContent": "Jump to the main content",
+  "common.missingTranslation": "Unfortunately, this content is not available in English and is therefore displayed in Norwegian.",
   "common.loading": "Loading...",
   "common.in": "in",
   "common.nextStep": "Next step",

--- a/astro-infoportal/src/i18n/locales/nb.json
+++ b/astro-infoportal/src/i18n/locales/nb.json
@@ -1,5 +1,6 @@
 {
   "common.skipToContent": "Hopp til hovedinnhold",
+  "common.missingTranslation": "Dette innholdet er dessverre ikke tilgjengelig på det valgte språket og vises derfor på bokmål.",
   "common.loading": "Laster...",
   "common.in": "i",
   "common.nextStep": "Gå videre",

--- a/astro-infoportal/src/i18n/locales/nn.json
+++ b/astro-infoportal/src/i18n/locales/nn.json
@@ -1,5 +1,6 @@
 {
   "common.skipToContent": "Hopp til hovudinnhaldet",
+  "common.missingTranslation": "Dette innhaldet er diverre ikkje tilgjengeleg på nynorsk og blir difor vist på bokmål.",
   "common.loading": "Lastar...",
   "common.in": "i",
   "common.nextStep": "Gå videre",

--- a/astro-infoportal/src/transformers/JSONTransformer.ts
+++ b/astro-infoportal/src/transformers/JSONTransformer.ts
@@ -51,6 +51,10 @@ export class JSONTransformer implements IJSONTransformer {
         globalData?.properties?.consentBanner ??
         globalData?.consentBanner ??
         null,
+      missingTranslationText:
+        globalData?.properties?.missingTranslationText ??
+        globalData?.missingTranslationText ??
+        null,
       componentName: "SiteLayout",
       child: null,
     };

--- a/astro-infoportal/src/transformers/StartPageTransformer.ts
+++ b/astro-infoportal/src/transformers/StartPageTransformer.ts
@@ -1,5 +1,6 @@
 import {
   fetchUmbracoContent,
+  fetchUmbracoContentById,
   resolveBlockReferences,
 } from "@api/umbraco/client";
 import { type Locale, t } from "@i18n/index";
@@ -7,6 +8,7 @@ import {
   type ProviderInfo,
   ProviderResolver,
 } from "@services/Providers/ProviderResolver";
+import { loadAlertMessages, resolveAlertRefsWithNbFallback } from "./alertArea";
 import type { IJSONTransformer } from "./IJSONTransformer";
 import { transformOperationalMessageArticle } from "./OperationalMessageArticlePageTransformer";
 
@@ -27,21 +29,20 @@ export class StartPageTransformer implements IJSONTransformer {
     const p = cmsPageData.properties ?? {};
 
     // --- Operational messages from AlertArea ---
-    const alertRefs: any[] = p.alertArea ?? [];
+    // NB decides which driftsmeldinger the front page shows; each one is then
+    // loaded by id so a translated message renders localised and an untranslated
+    // one still reaches /nn/ and /en/ in bokmål (issue #672, see ./alertArea).
+    const alertRefs = await resolveAlertRefsWithNbFallback(
+      cmsPageData.id,
+      p.alertArea,
+      contentLocale,
+      (id) => fetchUmbracoContentById(id, "nb", isPreview),
+    );
     const alertMessages = (
-      await Promise.all(
-        alertRefs.map(async (ref: any) => {
-          const route = ref.route?.path;
-          if (!route) return null;
-          try {
-            const full = await fetchUmbracoContent(route, contentLocale, undefined, isPreview);
-            return transformOperationalMessageArticle(full);
-          } catch {
-            return null;
-          }
-        }),
+      await loadAlertMessages(alertRefs, (id) =>
+        fetchUmbracoContentById(id, contentLocale, isPreview),
       )
-    ).filter(Boolean);
+    ).map(transformOperationalMessageArticle);
     const criticalOperationalMessages = alertMessages.filter(
       (message: any) => message.colorVariant === "danger",
     );

--- a/astro-infoportal/src/transformers/alertArea.test.ts
+++ b/astro-infoportal/src/transformers/alertArea.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  alertAreaRefs,
+  loadAlertMessages,
+  mergeAlertRefs,
+  resolveAlertRefsWithNbFallback,
+} from "./alertArea";
+
+const ref = (id: string) => ({
+  contentType: "operationalMessageArticlePage",
+  id,
+  route: { path: `/om-altinn/driftsmeldinger/${id}/` },
+});
+
+describe("alertAreaRefs", () => {
+  it("normalises missing and non-array values to an empty list", () => {
+    expect(alertAreaRefs(null)).toEqual([]);
+    expect(alertAreaRefs(undefined)).toEqual([]);
+    expect(alertAreaRefs({})).toEqual([]);
+  });
+
+  it("passes an array through", () => {
+    const refs = [ref("a")];
+    expect(alertAreaRefs(refs)).toBe(refs);
+  });
+});
+
+describe("mergeAlertRefs", () => {
+  it("keeps NB's set and order", () => {
+    const merged = mergeAlertRefs([ref("a"), ref("b")], [ref("b")]);
+    expect(merged.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("appends references only the localised list carries", () => {
+    const merged = mergeAlertRefs([ref("a")], [ref("b")]);
+    expect(merged.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("returns NB's list when the localised list is empty", () => {
+    const merged = mergeAlertRefs([ref("a"), ref("b")], []);
+    expect(merged.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("drops duplicates and references without an id", () => {
+    const merged = mergeAlertRefs(
+      [ref("a"), ref("a"), { route: { path: "/x/" } }],
+      [ref("a"), null],
+    );
+    expect(merged.map((r) => r.id)).toEqual(["a"]);
+  });
+});
+
+describe("resolveAlertRefsWithNbFallback", () => {
+  const fetchNb = (alertArea: unknown) =>
+    vi.fn().mockResolvedValue({ properties: { alertArea } });
+
+  it("does not fall back when the content locale is already nb", async () => {
+    const fetch = fetchNb([ref("a")]);
+    const result = await resolveAlertRefsWithNbFallback(
+      "start-id",
+      [ref("b")],
+      "nb",
+      fetch,
+    );
+
+    expect(result.map((r) => r.id)).toEqual(["b"]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("uses NB's list when the localised alertArea is empty", async () => {
+    const fetch = fetchNb([ref("a"), ref("b")]);
+    const result = await resolveAlertRefsWithNbFallback(
+      "start-id",
+      [],
+      "en",
+      fetch,
+    );
+
+    expect(fetch).toHaveBeenCalledWith("start-id");
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("restores the messages the Delivery API filtered out of the localised list", async () => {
+    const fetch = fetchNb([ref("a"), ref("b")]);
+    const result = await resolveAlertRefsWithNbFallback(
+      "start-id",
+      [ref("b")],
+      "nn",
+      fetch,
+    );
+
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("keeps a locale-only reference that NB does not list", async () => {
+    const fetch = fetchNb([ref("a")]);
+    const result = await resolveAlertRefsWithNbFallback(
+      "start-id",
+      [ref("c")],
+      "en",
+      fetch,
+    );
+
+    expect(result.map((r) => r.id)).toEqual(["a", "c"]);
+  });
+
+  it("keeps the localised list when there is no node id to look up", async () => {
+    const fetch = fetchNb([ref("a")]);
+    const result = await resolveAlertRefsWithNbFallback(
+      undefined,
+      [ref("c")],
+      "en",
+      fetch,
+    );
+
+    expect(result.map((r) => r.id)).toEqual(["c"]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the localised list when the NB lookup fails or has no alertArea", async () => {
+    const failing = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(
+      resolveAlertRefsWithNbFallback("start-id", [ref("c")], "en", failing),
+    ).resolves.toEqual([ref("c")]);
+
+    const empty = vi.fn().mockResolvedValue({ properties: {} });
+    await expect(
+      resolveAlertRefsWithNbFallback("start-id", [ref("c")], "en", empty),
+    ).resolves.toEqual([ref("c")]);
+  });
+});
+
+describe("loadAlertMessages", () => {
+  it("loads every reference by id, preserving order", async () => {
+    const fetchById = vi.fn(async (id: string) => ({ name: id.toUpperCase() }));
+    const result = await loadAlertMessages([ref("a"), ref("b")], fetchById);
+
+    expect(fetchById.mock.calls.map(([id]) => id)).toEqual(["a", "b"]);
+    expect(result).toEqual([{ name: "A" }, { name: "B" }]);
+  });
+
+  it("drops references that cannot be loaded instead of failing the page", async () => {
+    const fetchById = vi.fn(async (id: string) => {
+      if (id === "a") throw new Error("boom");
+      if (id === "b") return null;
+      return { name: id };
+    });
+
+    const result = await loadAlertMessages(
+      [ref("a"), ref("b"), ref("c"), { route: { path: "/x/" } }],
+      fetchById,
+    );
+
+    expect(result).toEqual([{ name: "c" }]);
+  });
+});

--- a/astro-infoportal/src/transformers/alertArea.ts
+++ b/astro-infoportal/src/transformers/alertArea.ts
@@ -1,0 +1,97 @@
+// Front-page driftsmeldinger — the `alertArea` picker on startPage.
+//
+// Umbraco's Delivery API omits picked references whose target has no published
+// variant in the requested culture, so /nn/ and /en/ receive a truncated — often
+// completely empty — alertArea even though the messages exist on NB. Editors
+// expect an untranslated driftsmelding to still reach the localised front pages,
+// rendered in bokmål, exactly as the old portal did (issue #672).
+//
+// The whole-page NB fallback in client.ts never helps here: the start page
+// itself exists in every locale, so it never fires. Two field-level fallbacks
+// are needed instead:
+//   1. the reference list — NB's is the authoritative set of messages to show;
+//   2. each message's content — resolved by id, so a translated variant wins and
+//      NB is the fallback. A route-based fetch cannot express that: the NB route
+//      /om-altinn/driftsmeldinger/… has no counterpart under /nn/, so it would
+//      404 into NB and discard an existing nynorsk translation.
+
+function refId(ref: any): string | undefined {
+  return typeof ref?.id === "string" && ref.id ? ref.id : undefined;
+}
+
+/** Normalises the raw `alertArea` property value to an array of references. */
+export function alertAreaRefs(alertArea: unknown): any[] {
+  return Array.isArray(alertArea) ? alertArea : [];
+}
+
+/**
+ * NB's list decides which driftsmeldinger the front page shows, and in which
+ * order. References only the localised list carries are appended rather than
+ * dropped — the property may be culture-variant, so a message an editor added
+ * for one locale alone must survive. References without an id are unusable.
+ */
+export function mergeAlertRefs(nbRefs: any[], localizedRefs: any[]): any[] {
+  const merged: any[] = [];
+  const seen = new Set<string>();
+  for (const ref of [...nbRefs, ...localizedRefs]) {
+    const id = refId(ref);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    merged.push(ref);
+  }
+  return merged;
+}
+
+/**
+ * Field-level NB fallback for the reference list. On NB — or without a node id
+ * to look up — the localised list is already authoritative and no extra request
+ * is made. If the NB lookup fails, the localised list is used as-is: a partial
+ * front page beats a broken one.
+ */
+export async function resolveAlertRefsWithNbFallback(
+  contentId: string | undefined,
+  localizedAlertArea: unknown,
+  contentLocale: string | undefined,
+  fetchNbContentById: (id: string) => Promise<any>,
+): Promise<any[]> {
+  const localizedRefs = alertAreaRefs(localizedAlertArea);
+  if (!contentId || !contentLocale || contentLocale === "nb") {
+    return localizedRefs;
+  }
+
+  let nb: any = null;
+  try {
+    nb = await fetchNbContentById(contentId);
+  } catch {
+    return localizedRefs;
+  }
+  return mergeAlertRefs(
+    alertAreaRefs(nb?.properties?.alertArea),
+    localizedRefs,
+  );
+}
+
+/**
+ * Loads each referenced driftsmelding in the requested culture, preserving the
+ * reference order. `fetchById` is expected to fall back to NB when the message
+ * has no variant in that culture (what fetchUmbracoContentById does), so a
+ * translated message renders localised and an untranslated one renders in
+ * bokmål. Messages that fail to load are dropped instead of failing the page.
+ */
+export async function loadAlertMessages(
+  refs: any[],
+  fetchById: (id: string) => Promise<any>,
+): Promise<any[]> {
+  const loaded = await Promise.all(
+    refs.map(async (ref) => {
+      const id = refId(ref);
+      if (!id) return null;
+      try {
+        return await fetchById(id);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return loaded.filter(Boolean);
+}


### PR DESCRIPTION
Issue:
- https://github.com/Altinn/info.altinn.no/issues/672
<img width="1406" height="918" alt="Screenshot 2026-08-14 at 12 41 52" src="https://github.com/user-attachments/assets/ab0226ba-b009-4d8b-a433-bf51578e7c98" />


- https://github.com/Altinn/info.altinn.no/issues/648
http://localhost:4321/en/skjemaoversikt/arbeids-og-velferdsetaten-nav/avtale-om-tilskudd-til-sommerjobb/
<img width="1511" height="726" alt="Screenshot 2026-08-14 at 12 39 31" src="https://github.com/user-attachments/assets/4b2b4baa-4b5f-4a57-b747-0c0643e50697" />

