### PR TITLE
chore: run Publish Syncroot artifacts on self-hosted runners

### DIFF
--- a/.github/workflows/publish-syncroot-main.yaml
+++ b/.github/workflows/publish-syncroot-main.yaml
@@ -38,7 +38,7 @@ jobs:
   publish-syncroot:
     name: Publish syncroot artifact
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Runs **Publish Syncroot artifacts** on the self-hosted runners, so deploys stop queueing behind GitHub-hosted ones.

Refs #642, Altinn/altinn-platform#3838

## Why this was blocked until now

The workflow calls `yq` in three steps, and `yq` wasn't in the runner image. Added in Altinn/altinn-platform#3893 and rolled out in Altinn/altinn-platform#3895 — the runners now run `gh-runner:v0.10.0`, so this is ready to merge.

## Testing

Ran the workflow's own steps inside the released `v0.10.0` image, as the non-root `runner` user:

- Both input paths work — `at22` + AzureSQL (all three yq steps) and `prod` + Sqlite (the two database steps correctly skipped)
- yq output is byte-identical to older yq versions, so nothing changes versus GitHub-hosted runners
- flux 2.6.4 installs, and `push` → `tag` → `pull` completes a full artifact roundtrip with the updated image tag intact

Not covered locally: Azure OIDC login and egress from the runner VNet to `altinncr.azurecr.io`. Worth dispatching against **at22** first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
