### PR TITLE
fix: render shared blocks referenced from Faglig brukerstøtte

### DIFF
--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -155,6 +155,41 @@ export async function fetchUmbracoContentById(id: string, culture?: string, isPr
  * `route.path` first, then fall back to `id` (necessary when the ref points to content
  * under a different startItem — path resolution fails there).
  */
+/**
+ * Resolves a single Content Picker reference to its full content item, by id.
+ *
+ * Unlike `resolveBlockReferences` this prefers the id over `route.path`, which
+ * matters for references that cross into another culture: a shared block's path
+ * is localised (`…/miljoedirektoratet/` in nb, `…/environment-agency/` in en)
+ * and the reference always carries the path of the culture the *referencing*
+ * page was fetched in. A path fetch in any other culture 404s and silently
+ * falls back to nb, so an English page would show Norwegian content. The id is
+ * culture-independent. Returns null when the reference cannot be resolved
+ * (unpublished or deleted) so callers can drop it.
+ */
+export async function resolveContentReference(
+  ref: any,
+  culture?: string,
+  isPreview?: boolean,
+): Promise<any | null> {
+  if (ref?.properties && Object.keys(ref.properties).length > 0) {
+    return ref;
+  }
+  if (ref?.id) {
+    const byId = await fetchUmbracoContentById(ref.id, culture, isPreview);
+    if (byId) return byId;
+  }
+  const route = ref?.route?.path;
+  if (route) {
+    try {
+      return await fetchUmbracoContent(route, culture, undefined, isPreview);
+    } catch {
+      // Unpublished, deleted, or not reachable in this culture.
+    }
+  }
+  return null;
+}
+
 export async function resolveBlockReferences(
   refs: any[] | { items?: any[] } | undefined | null,
   locale?: string,

--- a/astro-infoportal/src/transformers/ProviderPageTransformer.ts
+++ b/astro-infoportal/src/transformers/ProviderPageTransformer.ts
@@ -5,11 +5,13 @@ import {
   fetchUmbracoChildren,
   fetchUmbracoContentById,
   resolveBlockReferences,
+  resolveContentReference,
 } from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
 import {
   buildProviderContactInfo,
+  expandSharedBlocks,
   resolvePromoAreaWithNbFallback,
 } from "./promoAreaContact";
 
@@ -98,7 +100,12 @@ export class ProviderPageTransformer implements IJSONTransformer {
       contentLocale,
       (id) => fetchUmbracoContentById(id, "nb", isPreview),
     );
-    const contactInfo = buildProviderContactInfo(promoAreaData, {
+    // A "Delt blokk" entry only references a shared block; resolve it before
+    // mapping so it renders like an inline contact block (issue #690).
+    const promoAreaBlocks = await expandSharedBlocks(promoAreaData, (ref) =>
+      resolveContentReference(ref, contentLocale, isPreview),
+    );
+    const contactInfo = buildProviderContactInfo(promoAreaBlocks, {
       name: cmsPageData.name,
       imageUrl: providerIcon.imageUrl,
     });

--- a/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaAttachmentPageTransformer.ts
@@ -7,12 +7,14 @@ import {
   fetchUmbracoAncestors,
   fetchUmbracoContentById,
   resolveBlockReferences,
+  resolveContentReference,
 } from "../api/umbraco/client";
 import { BlockTransformer } from "./BlockTransformer";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
 import type { IJSONTransformer } from "./IJSONTransformer";
 import {
   buildPromoAreaContentArea,
+  expandSharedBlocks,
   resolvePromoAreaWithNbFallback,
 } from "./promoAreaContact";
 
@@ -67,8 +69,13 @@ export class SchemaAttachmentPageTransformer implements IJSONTransformer {
       contentLocale,
       (id) => fetchUmbracoContentById(id, "nb", isPreview),
     );
+    // A "Delt blokk" entry only references a shared block; resolve it before
+    // mapping so it renders like an inline contact block (issue #690).
+    const promoAreaBlocks = await expandSharedBlocks(promoAreaData, (ref) =>
+      resolveContentReference(ref, contentLocale, isPreview),
+    );
     const promoArea = buildPromoAreaContentArea(
-      promoAreaData,
+      promoAreaBlocks,
       (content) => BlockTransformer.TransformBlocks([content]).items[0],
     );
 

--- a/astro-infoportal/src/transformers/SchemaPageTransformer.ts
+++ b/astro-infoportal/src/transformers/SchemaPageTransformer.ts
@@ -7,6 +7,7 @@ import {
   fetchUmbracoContent,
   fetchUmbracoContentById,
   resolveBlockReferences,
+  resolveContentReference,
 } from "../api/umbraco/client";
 import { buildMunicipalitySearch } from "../api/umbraco/municipalitySearch";
 import { BlockTransformer } from "./BlockTransformer";
@@ -15,6 +16,7 @@ import { stripCategoryPrefix } from "./categoryPrefix";
 import type { IJSONTransformer } from "./IJSONTransformer";
 import {
   buildPromoAreaContentArea,
+  expandSharedBlocks,
   resolvePromoAreaWithNbFallback,
 } from "./promoAreaContact";
 
@@ -49,6 +51,7 @@ export class SchemaPageTransformer implements IJSONTransformer {
     const props = cmsPageData.properties ?? {};
     const locale: Locale = globalData?.locale || "nb";
     const contentLocale: Locale = globalData?.contentLocale || locale;
+    const isPreview = globalData?.isPreview;
     const resolver = await ProviderResolver.create();
 
     const ancestors = await fetchUmbracoAncestors(cmsPageData.id, contentLocale);
@@ -121,10 +124,16 @@ export class SchemaPageTransformer implements IJSONTransformer {
       cmsPageData.id,
       props.promoArea,
       contentLocale,
-      (id) => fetchUmbracoContentById(id, "nb"),
+      (id) => fetchUmbracoContentById(id, "nb", isPreview),
+    );
+    // Editors may reference a shared block ("Delt blokk") instead of authoring
+    // the contact details inline; those arrive as an unrenderable `blockPicker`
+    // wrapper and must be resolved first (issue #690).
+    const promoAreaBlocks = await expandSharedBlocks(promoAreaData, (ref) =>
+      resolveContentReference(ref, contentLocale, isPreview),
     );
     const promoArea = buildPromoAreaContentArea(
-      promoAreaData,
+      promoAreaBlocks,
       (content) => BlockTransformer.TransformBlocks([content]).items[0],
     );
 

--- a/astro-infoportal/src/transformers/promoAreaContact.test.ts
+++ b/astro-infoportal/src/transformers/promoAreaContact.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildPromoAreaContentArea,
   buildProviderContactInfo,
+  expandSharedBlocks,
   isContactBlock,
   mapContactBlock,
   promoAreaIsEmpty,
@@ -17,11 +18,29 @@ const freetextBlock = (properties: Record<string, unknown>) => ({
 const otherBlock = (properties: Record<string, unknown>) => ({
   content: { contentType: "linkButtonBlock", properties },
 });
+// "Delt blokk": a blockPicker wrapper holding unexpanded Content Picker refs.
+const sharedBlockPicker = (...refs: { id: string; path?: string }[]) => ({
+  content: {
+    contentType: "blockPicker",
+    properties: {
+      blockPicker: refs.map((ref) => ({
+        contentType: "providerContactInformationBlock",
+        id: ref.id,
+        route: { path: ref.path ?? `/delte-blokker/${ref.id}/` },
+        properties: {},
+      })),
+    },
+  },
+});
 
 describe("isContactBlock", () => {
   it("recognises both Faglig brukerstøtte block content types", () => {
     expect(isContactBlock("formElementContact")).toBe(true);
     expect(isContactBlock("formElementContactFreetext")).toBe(true);
+  });
+
+  it("recognises the shared-block content type used by Delt blokk", () => {
+    expect(isContactBlock("providerContactInformationBlock")).toBe(true);
   });
 
   it("rejects other content types and undefined", () => {
@@ -227,5 +246,91 @@ describe("resolvePromoAreaWithNbFallback", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe("expandSharedBlocks", () => {
+  const resolved = (id: string, email: string) => ({
+    contentType: "providerContactInformationBlock",
+    id,
+    properties: { email, heading: "Godkjenningsmyndighet" },
+  });
+
+  it("replaces a Delt blokk wrapper with the resolved shared block", async () => {
+    const resolve = vi
+      .fn()
+      .mockResolvedValue(resolved("block-1", "post@miljodir.no"));
+
+    const result = await expandSharedBlocks(
+      { items: [sharedBlockPicker({ id: "block-1" })] },
+      resolve,
+    );
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(result.items).toEqual([
+      { content: resolved("block-1", "post@miljodir.no") },
+    ]);
+  });
+
+  it("expands every reference held by one wrapper, in order", async () => {
+    const resolve = vi
+      .fn()
+      .mockImplementation(async (ref: any) =>
+        resolved(ref.id, `${ref.id}@x.no`),
+      );
+
+    const result = await expandSharedBlocks(
+      { items: [sharedBlockPicker({ id: "a" }, { id: "b" })] },
+      resolve,
+    );
+
+    expect(result.items.map((i: any) => i.content.id)).toEqual(["a", "b"]);
+  });
+
+  it("drops references that cannot be resolved instead of rendering an empty block", async () => {
+    const resolve = vi.fn().mockResolvedValue(null);
+
+    const result = await expandSharedBlocks(
+      { items: [sharedBlockPicker({ id: "gone" })] },
+      resolve,
+    );
+
+    expect(result.items).toEqual([]);
+  });
+
+  it("leaves inline blocks untouched and resolves nothing for them", async () => {
+    const resolve = vi.fn();
+    const inline = freetextBlock({ email: "post@toll.no" });
+
+    const result = await expandSharedBlocks({ items: [inline] }, resolve);
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(result.items).toEqual([inline]);
+  });
+
+  it("returns an empty promoArea unchanged", async () => {
+    const resolve = vi.fn();
+    expect(await expandSharedBlocks(null, resolve)).toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("feeds buildPromoAreaContentArea a renderable contact block (issue #690)", async () => {
+    const expanded = await expandSharedBlocks(
+      { items: [sharedBlockPicker({ id: "block-1" })] },
+      async () => resolved("block-1", "post@miljodir.no"),
+    );
+
+    const result = buildPromoAreaContentArea(expanded, () => undefined);
+
+    expect(result).toEqual({
+      componentName: "ContentArea",
+      items: [
+        expect.objectContaining({
+          componentName: "ProviderContactInformationBlock",
+          email: "post@miljodir.no",
+          pageName: "Godkjenningsmyndighet",
+        }),
+      ],
+    });
   });
 });

--- a/astro-infoportal/src/transformers/promoAreaContact.ts
+++ b/astro-infoportal/src/transformers/promoAreaContact.ts
@@ -12,7 +12,19 @@
 const CONTACT_BLOCK_TYPES = new Set([
   "formElementContactFreetext",
   "formElementContact",
+  // Shared blocks (editor label "Delt blokk") live under the `delte-blokker`
+  // root and are published as their own content type. The property shape is
+  // identical to formElementContactFreetext, so mapContactBlock handles both.
+  "providerContactInformationBlock",
 ]);
+
+/**
+ * Content type of the "Delt blokk" wrapper element, and the alias of the
+ * Content Picker property it holds. The wrapper carries no renderable content
+ * of its own — only references to shared blocks under the `delte-blokker` root.
+ */
+const SHARED_BLOCK_WRAPPER_TYPE = "blockPicker";
+const SHARED_BLOCK_PICKER_ALIAS = "blockPicker";
 
 export function isContactBlock(contentType: string | undefined): boolean {
   return !!contentType && CONTACT_BLOCK_TYPES.has(contentType);
@@ -65,6 +77,46 @@ function promoAreaItems(promoArea: any): any[] {
     : Array.isArray(promoArea?.items)
       ? promoArea.items
       : [];
+}
+
+/**
+ * Expands "Delt blokk" wrappers into the shared blocks they point at (issue #690).
+ *
+ * The Delivery API returns the wrapper as
+ * `{ contentType: "blockPicker", properties: { blockPicker: [ref, …] } }`,
+ * where each ref carries only `id`/`route` and an empty `properties` object.
+ * Nothing downstream knows the `blockPicker` alias, so an unexpanded wrapper
+ * renders as nothing at all. Resolve each ref and splice the resolved content
+ * in as if the editor had authored it inline; refs that cannot be resolved
+ * (unpublished or deleted) are dropped rather than rendered empty.
+ *
+ * Blocks that are not wrappers pass through untouched, so this is a no-op —
+ * and costs no requests — for promoAreas authored entirely inline.
+ */
+export async function expandSharedBlocks(
+  promoArea: any,
+  resolveSharedBlock: (ref: any) => Promise<any>,
+): Promise<any> {
+  const items = promoAreaItems(promoArea);
+  if (!items.some(isSharedBlockWrapper)) return promoArea;
+
+  const expanded = await Promise.all(
+    items.map(async (wrapper) => {
+      if (!isSharedBlockWrapper(wrapper)) return [wrapper];
+      const content = wrapper?.content ?? wrapper;
+      const refs = content?.properties?.[SHARED_BLOCK_PICKER_ALIAS];
+      if (!Array.isArray(refs)) return [];
+      const resolved = await Promise.all(refs.map(resolveSharedBlock));
+      return resolved.filter(Boolean).map((block) => ({ content: block }));
+    }),
+  );
+
+  return { ...(promoArea ?? {}), items: expanded.flat() };
+}
+
+function isSharedBlockWrapper(wrapper: any): boolean {
+  const content = wrapper?.content ?? wrapper;
+  return content?.contentType === SHARED_BLOCK_WRAPPER_TYPE;
 }
 
 /**


### PR DESCRIPTION
Issue: https://github.com/Altinn/info.altinn.no/issues/690

## Årsak

`Faglig brukerstøtte` (`promoArea`) kan inneholde en **"Delt blokk"** — en referanse til
en delt blokk under `delte-blokker`-roten. Delivery API-et returnerer denne wrapperen
uekspandert som `{ contentType: "blockPicker", properties: { blockPicker: [ref] } }`,
der den refererte noden fortsatt har tomme `properties`.

Ingenting på frontenden kjenner til aliaset `blockPicker`, så fallbacken i
`BlockTransformer` sendte ut `componentName: "BlockPicker"` — en komponent som ikke
finnes i komponentregisteret — og blokken forsvant uten feilmelding. Den samme wrapperen
inne i `accordianList` fungerer allerede, fordi `BlockListPropertyConverter` løser den
opp på serversiden; den converteren er bevisst avgrenset til `accordianList`.

Omfang på AT22: **365 referanser til delte blokker fordelt på 212 skjemasider**, alle
mot `providerContactInformationBlock`. Ingen andre sidetyper eller felter er berørt.

## Løsning

- `expandSharedBlocks()` løser opp hver `blockPicker`-referanse og setter innholdet inn
  som om redaktøren hadde lagt det inn direkte. Referanser som ikke lar seg løse opp
  (upublisert eller slettet) droppes i stedet for å rendres tomme; et `promoArea` uten
  wrappere gjør ingenting og koster ingen ekstra kall.
- `providerContactInformationBlock` er lagt til i settet med kontaktblokker — feltene er
  identiske med `formElementContactFreetext`, så `mapContactBlock` håndterer den uendret.
- `resolveContentReference()` slår opp på **id**, ikke på sti. Stien til en delt blokk er
  lokalisert (`…/miljoedirektoratet/` vs. `…/environment-agency/`), så dagens
  sti-først-logikk i `resolveBlockReferences` ville gitt 404 på engelsk og stille falt
  tilbake til bokmål — engelske sider ville vist norsk kontaktinformasjon.
- Koblet inn i `SchemaPageTransformer`, `SchemaAttachmentPageTransformer` og
  `ProviderPageTransformer`, som alle bruker dette feltet.

## Merknad ved deploy

De 212 berørte sidene ligger i cachen i `cache-infoportal`, og må purges (eller utløpe)
etter release før redaktørene ser endringen.

