### PR TITLE
fix: correct subcategory headings, order and counts on category page

### DIFF
--- a/astro-infoportal/src/api/umbraco/client.ts
+++ b/astro-infoportal/src/api/umbraco/client.ts
@@ -275,6 +275,36 @@ export async function fetchUmbracoContentList(
   return items;
 }
 
+/**
+ * Count the content items matching `filters` without transferring them.
+ *
+ * `fields=` drops the property payload, and `take=1` is deliberate: the
+ * Delivery API reports `total: 0` when `take=0`, so one item has to be
+ * requested for the count to be meaningful.
+ */
+export async function fetchUmbracoContentCount(
+  filters: string[],
+  culture?: string,
+  isPreview?: boolean,
+): Promise<number> {
+  const params = new URLSearchParams({ take: "1", fields: "" });
+  for (const filter of filters) {
+    params.append("filter", filter);
+  }
+  const url = deliveryUrl("/umbraco/delivery/api/v2/content", params.toString());
+
+  const response = await fetch(url, { headers: getHeaders(culture, isPreview) });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to count content in Umbraco: ${response.statusText} ${url}`,
+    );
+  }
+
+  const data = await response.json();
+  return data.total ?? 0;
+}
+
 export async function fetchUmbracoContentListPage(
   filters: string[],
   take = 100,

--- a/astro-infoportal/src/i18n/locales/en.json
+++ b/astro-infoportal/src/i18n/locales/en.json
@@ -195,6 +195,8 @@
   "schemaOverview.allServices": "All services",
   "schemaOverview.allProviders": "All providers",
   "schemaOverview.recommendedSchemas": "Relevant forms and services",
+  "category.schemaCount.one": "{0} service",
+  "category.schemaCount.other": "{0} services",
 
   "subsidy.youHaveChosen": "You have chosen",
   "subsidy.choose": "Choose",

--- a/astro-infoportal/src/i18n/locales/nb.json
+++ b/astro-infoportal/src/i18n/locales/nb.json
@@ -195,6 +195,8 @@
   "schemaOverview.allServices": "Alle tjenester",
   "schemaOverview.allProviders": "Alle etater",
   "schemaOverview.recommendedSchemas": "Aktuelle skjemaer og tjenester",
+  "category.schemaCount.one": "{0} tjeneste",
+  "category.schemaCount.other": "{0} tjenester",
 
   "subsidy.youHaveChosen": "Du har valgt",
   "subsidy.choose": "Velg",

--- a/astro-infoportal/src/i18n/locales/nn.json
+++ b/astro-infoportal/src/i18n/locales/nn.json
@@ -195,6 +195,8 @@
   "schemaOverview.allServices": "Alle tenester",
   "schemaOverview.allProviders": "Alle etatar",
   "schemaOverview.recommendedSchemas": "Aktuelle skjema og tenester",
+  "category.schemaCount.one": "{0} teneste",
+  "category.schemaCount.other": "{0} tenester",
 
   "subsidy.youHaveChosen": "Du har valt",
   "subsidy.choose": "Vel",

--- a/astro-infoportal/src/transformers/CategoryPageTransformer.test.ts
+++ b/astro-infoportal/src/transformers/CategoryPageTransformer.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchUmbracoAncestors = vi.fn();
+const fetchUmbracoChildren = vi.fn();
+const fetchUmbracoContentCount = vi.fn();
+
+vi.mock("../api/umbraco/client", () => ({
+  fetchUmbracoAncestors: (...args: any[]) => fetchUmbracoAncestors(...args),
+  fetchUmbracoChildren: (...args: any[]) => fetchUmbracoChildren(...args),
+  fetchUmbracoContentCount: (...args: any[]) =>
+    fetchUmbracoContentCount(...args),
+}));
+
+const { CategoryPageTransformer } = await import("./CategoryPageTransformer");
+
+// The EN variants of these nodes keep the bokmål "Starte, endre, avvikle - "
+// prefix, which is exactly what issue #371 reports leaking into the headings.
+const subCategory = (name: string, slug: string, id: string) => ({
+  contentType: "subCategoryPage",
+  id,
+  name,
+  route: { path: `/en/forms-overview/kategori/start-change-wind-up/${slug}/` },
+});
+
+const enChildren = [
+  subCategory(
+    "Starte, endre, avvikle - Start business",
+    "start-business",
+    "sub-1",
+  ),
+  subCategory(
+    "Starte, endre, avvikle - Change business",
+    "change-business",
+    "sub-2",
+  ),
+  subCategory(
+    "Starte, endre, avvikle - Liquidation and bankruptcy",
+    "liquidation-and-bankruptcy",
+    "sub-3",
+  ),
+];
+
+const counts: Record<string, number> = {
+  "sub-1": 11,
+  "sub-2": 12,
+  "sub-3": 11,
+};
+
+const cmsPageData = {
+  id: "cat-1",
+  name: "Start, change, liquidate",
+  route: { path: "/en/forms-overview/kategori/start-change-wind-up/" },
+  properties: {},
+};
+
+async function transform(children = enChildren, locale = "en") {
+  fetchUmbracoChildren.mockImplementation(async (path: string) =>
+    path === cmsPageData.route.path ? children : [],
+  );
+  const result = await new CategoryPageTransformer().Transform(cmsPageData, {
+    locale,
+    contentLocale: locale,
+  });
+  return result;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchUmbracoAncestors.mockResolvedValue([]);
+  fetchUmbracoContentCount.mockImplementation(async (filters: string[]) => {
+    const id = filters
+      .find((f) => f.startsWith("subCategory:"))
+      ?.slice("subCategory:".length);
+    return counts[id ?? ""] ?? 0;
+  });
+});
+
+describe("CategoryPageTransformer subcategories", () => {
+  it("strips the bokmål category prefix on a locale whose page name differs", async () => {
+    const { subCategories } = await transform();
+
+    expect(subCategories.map((s: any) => s.heading)).toEqual([
+      "Start business",
+      "Change business",
+      "Liquidation and bankruptcy",
+    ]);
+  });
+
+  it("keeps the order the editors arranged in Umbraco", async () => {
+    const { subCategories } = await transform();
+
+    // Alphabetical would be Change / Liquidation / Start — the old prod page
+    // listed them in editor order, so no re-sorting here.
+    expect(subCategories[0].heading).toBe("Start business");
+    expect(subCategories[2].heading).toBe("Liquidation and bankruptcy");
+  });
+
+  it("keeps only the first ' - ' as the prefix separator", async () => {
+    const { subCategories } = await transform([
+      subCategory(
+        "Permits and qualifications - E - Water supply and sewerage",
+        "water-supply",
+        "sub-1",
+      ),
+      subCategory("Language and Library services", "language-library", "sub-2"),
+    ]);
+
+    expect(subCategories.map((s: any) => s.heading)).toEqual([
+      "E - Water supply and sewerage",
+      "Language and Library services",
+    ]);
+  });
+});
+
+describe("CategoryPageTransformer schema counts", () => {
+  it("counts schemas in bokmål regardless of the page locale", async () => {
+    await transform();
+
+    for (const call of fetchUmbracoContentCount.mock.calls) {
+      expect(call[1]).toBe("nb");
+      expect(call[0]).toContain("contentType:schemaPage");
+    }
+  });
+
+  it("renders the count in the page locale", async () => {
+    expect(
+      (await transform(enChildren, "en")).subCategories[0].schemaCountText,
+    ).toBe("11 services");
+    expect(
+      (await transform(enChildren, "nb")).subCategories[1].schemaCountText,
+    ).toBe("12 tjenester");
+    expect(
+      (await transform(enChildren, "nn")).subCategories[2].schemaCountText,
+    ).toBe("11 tenester");
+  });
+
+  it("uses the singular form for a lone schema", async () => {
+    fetchUmbracoContentCount.mockResolvedValue(1);
+
+    expect(
+      (await transform(enChildren, "en")).subCategories[0].schemaCountText,
+    ).toBe("1 service");
+    expect(
+      (await transform(enChildren, "nb")).subCategories[0].schemaCountText,
+    ).toBe("1 tjeneste");
+    expect(
+      (await transform(enChildren, "nn")).subCategories[0].schemaCountText,
+    ).toBe("1 teneste");
+  });
+
+  it("omits the badge when the count is zero or unavailable", async () => {
+    fetchUmbracoContentCount.mockResolvedValueOnce(0);
+    fetchUmbracoContentCount.mockRejectedValueOnce(
+      new Error("Umbraco is down"),
+    );
+
+    const { subCategories } = await transform();
+
+    expect(subCategories[0].schemaCountText).toBeUndefined();
+    expect(subCategories[1].schemaCountText).toBeUndefined();
+    expect(subCategories[2].schemaCountText).toBe("11 services");
+  });
+});
+
+describe("CategoryPageTransformer sidebar", () => {
+  it("translates the 'all services' title", async () => {
+    expect(
+      (await transform(enChildren, "en")).pageSidebarViewModel.titleItem.label,
+    ).toBe("All services");
+    expect(
+      (await transform(enChildren, "nb")).pageSidebarViewModel.titleItem.label,
+    ).toBe("Alle tjenester");
+  });
+});

--- a/astro-infoportal/src/transformers/CategoryPageTransformer.ts
+++ b/astro-infoportal/src/transformers/CategoryPageTransformer.ts
@@ -1,71 +1,86 @@
-import type { IJSONTransformer } from "./IJSONTransformer";
-import { fetchUmbracoAncestors, fetchUmbracoChildren } from "../api/umbraco/client";
+import { type Locale, t } from "@i18n/index";
+import {
+  fetchUmbracoAncestors,
+  fetchUmbracoChildren,
+  fetchUmbracoContentCount,
+} from "../api/umbraco/client";
 import { BreadcrumbsTransformer } from "./BreadcrumbsTransformer";
+import { stripCategoryPrefix } from "./categoryPrefix";
+import type { IJSONTransformer } from "./IJSONTransformer";
 
-/** Normalize URL slugs: strip trailing slashes and collapse multiple dashes to single. */
-function normalizeUrl(url: string): string {
-  return url.replace(/\/+$/, "").replace(/-{2,}/g, "-");
+/**
+ * Number of schemas filed under a subcategory.
+ *
+ * Counted in bokmål on purpose: SubCategoryPageTransformer lists the
+ * subcategory's schemas from the NB tree in every locale, so an NN/EN count
+ * would advertise fewer services than the page it links to actually shows.
+ */
+async function fetchSchemaCount(subCategoryId: string): Promise<number> {
+  try {
+    return await fetchUmbracoContentCount(
+      ["contentType:schemaPage", `subCategory:${subCategoryId}`],
+      "nb",
+    );
+  } catch {
+    // Count is decoration — render the subcategory without a badge instead
+    // of failing the whole page.
+    return 0;
+  }
 }
 
-/** Fetch schema count text per subcategory URL from the production overview page. */
-async function fetchSchemaCountsByUrl(): Promise<Record<string, string>> {
-  const map: Record<string, string> = {};
-  try {
-    const res = await fetch("https://info.altinn.no/skjemaoversikt/");
-    const html = await res.text();
-    const m = html.match(/"schemaCategories":(\[.*?\])\s*,\s*"providerCollections"/s);
-    if (!m) return map;
-    const categories = JSON.parse(m[1]) as {
-      subCategories?: { url?: string; schemaCountText?: string }[];
-    }[];
-    for (const cat of categories) {
-      for (const sub of cat.subCategories ?? []) {
-        if (sub.url && sub.schemaCountText) {
-          map[normalizeUrl(sub.url)] = sub.schemaCountText;
-        }
-      }
-    }
-  } catch {
-    // If production fetch fails, counts will be empty
-  }
-  return map;
+/** "11 tjenester" / "1 service" — empty subcategories get no badge at all. */
+function schemaCountText(count: number, locale: Locale): string | undefined {
+  if (!count) return undefined;
+  const key =
+    count === 1 ? "category.schemaCount.one" : "category.schemaCount.other";
+  return t(key, locale).replace("{0}", String(count));
 }
 
 export class CategoryPageTransformer implements IJSONTransformer {
   public async Transform(cmsPageData: any, globalData?: any): Promise<any> {
     const props = cmsPageData.properties ?? {};
-    const locale = globalData?.locale ?? "nb";
-    const contentLocale = globalData?.contentLocale ?? locale;
+    const locale: Locale = globalData?.locale ?? "nb";
+    const contentLocale: Locale = globalData?.contentLocale ?? locale;
 
-    const ancestors = await fetchUmbracoAncestors(cmsPageData.id, contentLocale);
+    const ancestors = await fetchUmbracoAncestors(
+      cmsPageData.id,
+      contentLocale,
+    );
     const breadcrumb = BreadcrumbsTransformer.Transform(ancestors, cmsPageData);
 
-    // Subcategories: direct children of this category page
-    const children = await fetchUmbracoChildren(cmsPageData.route.path, 100, contentLocale);
-    const categoryPrefix = `${cmsPageData.name} - `;
-    const schemaCounts = await fetchSchemaCountsByUrl();
-    const subCategories = children
-      .filter((c: any) => c.contentType === "subCategoryPage")
-      .map((c: any) => {
-        const url = c.route?.path;
-        const normalizedUrl = url ? normalizeUrl(url) : undefined;
-        return {
-          heading: c.name.startsWith(categoryPrefix) ? c.name.slice(categoryPrefix.length) : c.name,
-          url,
-          schemaCountText: normalizedUrl ? schemaCounts[normalizedUrl] : undefined,
-        };
-      })
-      .sort((a: any, b: any) => a.heading.localeCompare(b.heading, "nb"));
+    // Subcategories: direct children of this category page, kept in the order
+    // the editors arranged them in Umbraco.
+    const children = await fetchUmbracoChildren(
+      cmsPageData.route.path,
+      100,
+      contentLocale,
+    );
+    const subCategories = await Promise.all(
+      children
+        .filter((c: any) => c.contentType === "subCategoryPage")
+        .map(async (c: any) => {
+          const count = await fetchSchemaCount(c.id);
+          return {
+            heading: stripCategoryPrefix(c.name),
+            url: c.route?.path,
+            schemaCountText: schemaCountText(count, locale),
+          };
+        }),
+    );
 
     // Sidebar: all sibling categories
     const segments = cmsPageData.route.path.split("/").filter(Boolean);
     segments.pop(); // remove current category slug → "skjemaoversikt/kategori"
     const parentPath = segments.join("/");
-    const allCategories = await fetchUmbracoChildren(parentPath, 100, contentLocale);
+    const allCategories = await fetchUmbracoChildren(
+      parentPath,
+      100,
+      contentLocale,
+    );
 
     const pageSidebarViewModel = {
       titleItem: {
-        label: "Alle tjenester",
+        label: t("schemaOverview.allServices", locale),
         url: "/skjemaoversikt",
         icon: "MenuGridIcon",
       },


### PR DESCRIPTION
Issue: https://github.com/Altinn/info.altinn.no/issues/371

## Årsak

Underkategorier lagres i Umbraco med navnet «\<Kategori\> - \<Underkategori\>», og EN-/NN-variantene beholder det norske prefikset («Starte, endre, avvikle - Change business»). `CategoryPageTransformer` bygde prefikset som skulle fjernes ut fra sidens eget oversatte navn («Start, change, liquidate - »), noe som bare treffer på bokmål. Derfor ble prefikset vist ordrett på alle kategorier på engelsk og nynorsk.

To andre avvik i samme fil, også synlige i skjermbildet i issuet:

- Underkategoriene ble sortert alfabetisk, mens listen skal følge rekkefølgen redaktørene har satt i Umbraco.
- Antallsmerket («11 tjenester») ble hentet ved å skrape HTML fra `https://info.altinn.no/skjemaoversikt/` ved hvert kall. Den adressen serverer nå den nye Astro-løsningen selv, så regex-treffet uteble og merket forsvant i alle språk — også i produksjon.

## Løsning

- Bruker `stripCategoryPrefix()`, som allerede finnes og brukes av `SubCategoryPageTransformer`. Den deler på første « - » i stedet for å matche mot sidens navn, og beholder dermed NACE-bokstaven («E - Vannforsyning …»).
- Fjernet den alfabetiske sorteringen, slik at redaktørenes rekkefølge beholdes.
- Erstattet HTML-skrapingen med et reelt oppslag i Umbraco: ny `fetchUmbracoContentCount()` med filtrene `contentType:schemaPage` og `subCategory:{id}`. Antallet telles bevisst i bokmål, fordi underkategorisiden lister bokmålsskjemaene uansett språk — et engelsk antall ville vist færre tjenester enn siden det lenkes til faktisk inneholder.
- Nye tekstnøkler `category.schemaCount.one`/`.other` for nb, nn og en, med riktig entallsform («1 tjeneste», ikke «1 tjenester»).
- Overskriften «Alle tjenester» i sidemenyen hentes nå via `t()` i stedet for å være hardkodet på bokmål.

## Verifisert

Gjengitt mot at22 i alle tre språk. Resultatet er identisk med det gamle produksjonsbildet i issuet: `Start business | 11 services`, `Change business | 12 services`, `Liquidation and bankruptcy | 11 services`. 86 tester passerer, inkludert 7 nye i `CategoryPageTransformer.test.ts`.