### PR TITLE
fix: unblock flux ACR login on self-hosted runners

### DIFF
--- a/.github/workflows/publish-syncroot-main.yaml
+++ b/.github/workflows/publish-syncroot-main.yaml
@@ -39,6 +39,16 @@ jobs:
     name: Publish syncroot artifact
     if: github.ref == 'refs/heads/main'
     runs-on: self-hosted
+    # The self-hosted runners are Azure Container App Jobs, which inject a
+    # managed identity endpoint. flux --provider=azure uses DefaultAzureCredential,
+    # which then tries ManagedIdentityCredential, gets HTTP 400 (the job has a
+    # user-assigned identity and flux passes no client id), and aborts the whole
+    # credential chain before reaching the az login session from azure/login.
+    # Clearing these makes that step fall through to the CLI credential, which is
+    # what happens on GitHub-hosted runners.
+    env:
+      IDENTITY_ENDPOINT: ""
+      MSI_ENDPOINT: ""
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Fixes the ACR login failure that **Publish Syncroot artifacts** hit after moving to self-hosted runners in #695.

```
✗ error during login with provider: ... DefaultAzureCredential: failed to acquire a token
    ManagedIdentityCredential authentication failed.
    RESPONSE 400: Unable to load the proper Managed Identity
```

## Why it happened

`flux --provider=azure` uses the Azure SDK's `DefaultAzureCredential`, which walks a fixed chain and **stops at the first hard failure**.

| Runner | What happens |
|---|---|
| GitHub-hosted | No managed identity endpoint → `ManagedIdentityCredential` reports *unavailable* → chain continues → **`AzureCLICredential` picks up the `azure/login` session** ✅ |
| Self-hosted (Container App Job) | Azure injects a managed identity endpoint → `ManagedIdentityCredential` is attempted → job has a **user-assigned** identity and flux passes no client id → **HTTP 400** → SDK treats it as a hard failure and **aborts the chain before `AzureCLICredential`** ❌ |

So `azure/login` succeeds, and its session is then never consulted.

Worth noting the runner's user-assigned identity has no role assignments either, so it could not push to `altinncr` even if flux had selected it correctly.

## The fix

Clearing the two endpoint variables for this job makes `ManagedIdentityCredential` report itself unavailable again, restoring exactly the code path GitHub-hosted runners take:

```yaml
env:
  IDENTITY_ENDPOINT: ""
  MSI_ENDPOINT: ""
```

## Verification

Reproduced both chains against flux 2.6.4 inside the `gh-runner:v0.10.0` image, using a mock endpoint returning the same 400:

```
with endpoint present (self-hosted):
    ManagedIdentityCredential authentication failed. RESPONSE 400   <- chain stops, matches CI log
with endpoint cleared (this PR):
    ManagedIdentityCredential: managed identity timed out
    AzureCLICredential: ERROR: Please run 'az login'                 <- chain reaches the CLI credential
```

The `az login` error in the second case is expected locally — there's no Azure session in my container. On the runner `azure/login` has already established one, which is the whole point.

## Scope

This is a workaround in one repo. The durable fix belongs in `Altinn/altinn-platform`'s `flux/build-push-image`, so flux authenticates explicitly instead of by discovery — proposed separately, since this will hit **any** team that moves a flux workflow onto these runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
