### PR TITLE
fix: hide missing-translation banner on nynorsk pages

### DIFF
--- a/astro-infoportal/src/Constants/globalData.test.ts
+++ b/astro-infoportal/src/Constants/globalData.test.ts
@@ -73,12 +73,16 @@ describe("buildMissingTranslationText", () => {
     expect(buildMissingTranslationText("en", "en")).toBeNull();
   });
 
-  it("explains the fallback in the language the reader asked for", () => {
+  it("explains the fallback on an english page", () => {
     expect(buildMissingTranslationText("en", "nb")).toBe(
       en["common.missingTranslation"],
     );
-    expect(buildMissingTranslationText("nn", "nb")).toBe(
-      nn["common.missingTranslation"],
-    );
+  });
+
+  // Issue #648: nynorsk readers read bokmål, so the notice stays off there even
+  // though nn/common.missingTranslation is still translated and ready.
+  it("stays silent on a nynorsk page that fell back to bokmål", () => {
+    expect(buildMissingTranslationText("nn", "nb")).toBeNull();
+    expect(nn["common.missingTranslation"]).not.toBe("");
   });
 });

--- a/astro-infoportal/src/Constants/globalData.ts
+++ b/astro-infoportal/src/Constants/globalData.ts
@@ -79,9 +79,15 @@ export function buildConsentBanner(
 
 // Old-portal behaviour, restored: a page with no variant in the requested
 // language renders its NB content (see `contentLocale` in [...slug].astro), and
-// the reader is told so in the language they asked for rather than being left to
-// wonder why the page turned Norwegian. Returns null on NB and on any page that
-// really is translated — the notice must never appear when nothing fell back.
+// the reader is told so rather than being left to wonder why the page turned
+// Norwegian. Returns null on any page that really is translated — the notice
+// must never appear when nothing fell back.
+//
+// English only, by editorial decision (issue #648): nynorsk readers read bokmål,
+// so the notice is noise there, and språklova requires many of these pages to
+// exist in both målformer — a notice sitting on one for years reads as an
+// excuse rather than help. The nn translation is kept in the locale files so the
+// decision can be reversed without re-translating.
 //
 // This is page-level, matching the old portal. Individual fields that fall back
 // on an otherwise-translated page (e.g. an untranslated driftsmelding on the
@@ -91,7 +97,7 @@ export function buildMissingTranslationText(
   locale: Locale,
   contentLocale: Locale,
 ): string | null {
-  if (locale === contentLocale) return null;
+  if (locale !== "en" || locale === contentLocale) return null;
   return t("common.missingTranslation", locale);
 }
 


### PR DESCRIPTION
Issue: https://github.com/Altinn/info.altinn.no/issues/648
